### PR TITLE
Updated poetry activation introduction in contributing.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ To install them you would need to run `install` command:
 poetry install
 ```
 
-To activate your `virtualenv` run `poetry env activate` or `source .venv/bin/activate`.
+To activate your `virtualenv` run `eval "$(poetry env activate)"` or `source .venv/bin/activate`.
 
 ## One magic command
 


### PR DESCRIPTION
While setting up `django-modern-rest`, I noticed a different Poetry environment usage (see the screenshot below).
<img width="842" height="185" alt="Screenshot 2025-10-18 at 12 09 02" src="https://github.com/user-attachments/assets/d5384e99-c4c7-4e14-ae17-ac915f8cf26f" />

To clarify the setup process, I updated the `CONTRIBUTING.md` file.