### PR TITLE
Fix make comment indent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unit:
 
 .PHONY: smoke
 smoke:
-	# Checks that it is possible to import the base package without django.setup
+# Checks that it is possible to import the base package without django.setup
 	poetry run python -c 'from django_modern_rest import Controller'
 
 .PHONY: example


### PR DESCRIPTION
# I have made things!

Existing Makefile breaks on Windows (maybe on other platforms too).

As per [Makefile documentation](https://www.gnu.org/software/make/manual/html_node/Makefile-Contents.html):

> Comments within a recipe are passed to the shell, just as with any other recipe text. The shell decides how to interpret it: whether or not this is a comment is up to the shell.

On Windows 10, GNU Make 4.4.1 for Windows32 `smoke` recipe fails with:

```
> make smoke
# Checks that it is possible to import the base package without django.setup
process_begin: CreateProcess(NULL, # Checks that it is possible to import the base package without django.setup, ...) failed.
make (e=2): �� ������� ����� ��������� ����.
make: *** [Makefile:30: smoke] Error 2
```

Comment has been unindented to prevent that.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
