### PR TITLE
Add "Ask DeepWiki" badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![codecov](https://codecov.io/gh/wemake-services/django-modern-rest/branch/master/graph/badge.svg)](https://codecov.io/gh/wemake-services/django-modern-rest)
 [![Python Version](https://img.shields.io/pypi/pyversions/django-modern-rest.svg)](https://pypi.org/project/django-modern-rest/)
 [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
+[![Ask DeepWiki](https://img.shields.io/badge/Ask_DeepWiki-blue)](https://deepwiki.com/wemake-services/django-modern-rest)
 </div>
 
 ## Features


### PR DESCRIPTION
Added a badge for DeepWiki to the README.

Important remarks:
* DeepWiki generates documentation for the main branch
* documentation on DeepWiki can be up to 7 days behind.