### PR TITLE
fix: `path` benchmarks

### DIFF
--- a/benchmarks/features/url_resolver.py
+++ b/benchmarks/features/url_resolver.py
@@ -8,7 +8,7 @@ from django.urls import Resolver404, URLPattern, include
 from django.urls import path as django_path
 from django.urls.resolvers import RegexPattern, URLResolver
 
-from django_modern_rest import path as dmr_path
+from django_modern_rest.routing import path as dmr_path
 
 
 def _a_view(request: HttpRequest) -> HttpResponse:

--- a/docs/pages/routing.rst
+++ b/docs/pages/routing.rst
@@ -192,9 +192,9 @@ Performance Impact
 
 Benchmark results on MacBook Pro M4 Pro:
 
-- **Best case**: 8–9% faster (match found in first few URL patterns)
-- **Average case**: 8–9% faster (match found in middle of URL patterns list)
-- **Worst case**: 23–31% faster (404 Not Found, all patterns checked)
+- **Best case**: 9% faster (match found in first few URL patterns)
+- **Average case**: 13% faster (match found in middle of URL patterns list)
+- **Worst case**: 31% faster (404 Not Found, all patterns checked)
 
 The prefix-based optimization dramatically reduces regex operations:
 


### PR DESCRIPTION
After some cleanup, the router benchmarks were broken. There is also an error in the benchmark results for the average case.


Here are the actual results:

```
Benchmark 1: django-best
  Time (mean ± σ):      3.148 s ±  0.053 s    [User: 3.103 s, System: 0.031 s]
  Range (min … max):    3.098 s …  3.211 s    5 runs

Benchmark 2: dmr-best
  Time (mean ± σ):      2.857 s ±  0.005 s    [User: 2.827 s, System: 0.025 s]
  Range (min … max):    2.852 s …  2.864 s    5 runs

Benchmark 3: django-avg
  Time (mean ± σ):      5.269 s ±  0.052 s    [User: 5.219 s, System: 0.037 s]
  Range (min … max):    5.200 s …  5.336 s    5 runs

Benchmark 4: dmr-avg
  Time (mean ± σ):      4.663 s ±  0.049 s    [User: 4.619 s, System: 0.030 s]
  Range (min … max):    4.589 s …  4.711 s    5 runs

Benchmark 5: django-worst
  Time (mean ± σ):      7.549 s ±  0.153 s    [User: 7.496 s, System: 0.041 s]
  Range (min … max):    7.342 s …  7.745 s    5 runs

Benchmark 6: dmr-worst
  Time (mean ± σ):      5.751 s ±  0.048 s    [User: 5.719 s, System: 0.029 s]
  Range (min … max):    5.705 s …  5.804 s    5 runs
```