### PR TITLE
chore: force free gil behavior

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14', '3.14t']
+        include:
+          - python-version: '3.14t'
+            force_free_gil: true
 
     steps:
     - uses: actions/checkout@v6
@@ -46,6 +49,8 @@ jobs:
         poetry install --all-extras --all-groups
 
     - name: Run checks
+      env:
+        PYTHON_GIL: ${{ matrix.force_free_gil && '0' || '1' }}
       run: make test
 
     # Upload coverage to codecov: https://codecov.io/


### PR DESCRIPTION
# I have made things!

This PR forces the Free GIL behavior for the versions that supports it, in the current CI setup is only `3.14t`. When the Python runtime identifies a dependency not marked explicit as _free gil supported_ it fallback to the default and use GIL, setting the `PYTHON_GIL=0` forces to use the Free GIL version even not having all dependencies with that mark.

I think would be great to have this forced by default so we can see future problems and fix them (or at least try to fix/open an issue), also this could be related to desired thread safe behavior for this framework.

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

Refs #55 
