### PR TITLE
Add pagination example

### DIFF
--- a/django_modern_rest/pagination.py
+++ b/django_modern_rest/pagination.py
@@ -8,19 +8,22 @@ _ModelT = TypeVar('_ModelT')
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
 class Page(Generic[_ModelT]):
     """
-    Default page model.
+    Default page model for serialization.
 
     Can be used when using pagination with ``django_modern_rest``.
     """
 
     number: int
+    # Does not support `_SupportsPagination` type,
+    # explicit type cast to `list` or `tuple` is required,
+    # because it is hard to serialize complex `_SupportsPagination` protocol.
     object_list: Sequence[_ModelT]
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
 class Paginated(Generic[_ModelT]):
     """
-    Helper type to help serializer the default ``Paginator`` object.
+    Helper type to serialize the default ``Paginator`` object.
 
     Django already ships a pagination system, we don't want to replicate it.
     So, we only provide metadata.

--- a/django_modern_rest/pagination.py
+++ b/django_modern_rest/pagination.py
@@ -1,0 +1,32 @@
+import dataclasses
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+_ModelT = TypeVar('_ModelT')
+
+
+@dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
+class Page(Generic[_ModelT]):
+    """
+    Default page model.
+
+    Can be used when using pagination with ``django_modern_rest``.
+    """
+
+    number: int
+    object_list: Sequence[_ModelT]
+
+
+@dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
+class Paginated(Generic[_ModelT]):
+    """
+    Helper type to help serializer the default ``Paginator`` object.
+
+    Django already ships a pagination system, we don't want to replicate it.
+    So, we only provide metadata.
+    See :class:`django.core.paginator.Paginator` for the exact API.
+    """
+
+    count: int
+    num_pages: int
+    page: Page[_ModelT]

--- a/django_test_app/server/apps/django_session_auth/urls.py
+++ b/django_test_app/server/apps/django_session_auth/urls.py
@@ -24,9 +24,4 @@ router = Router([
         views.UserAsyncController.as_view(),
         name='user_session_async',
     ),
-    path(
-        'users-paginated/',
-        views.PaginatedUsersController.as_view(),
-        name='users_paginated',
-    ),
 ])

--- a/django_test_app/server/apps/django_session_auth/urls.py
+++ b/django_test_app/server/apps/django_session_auth/urls.py
@@ -24,4 +24,9 @@ router = Router([
         views.UserAsyncController.as_view(),
         name='user_session_async',
     ),
+    path(
+        'users-paginated/',
+        views.PaginatedUsersController.as_view(),
+        name='users_paginated',
+    ),
 ])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,7 @@ nitpick_ignore = [
         'django_modern_rest.security.django_session.views._RequestModelT',
     ),
     (PY_CLASS, 'django_modern_rest.security.django_session.views._ResponseT'),
+    (PY_CLASS, 'django_modern_rest.pagination._ModelT'),
     (PY_CLASS, 'django_modern_rest.controller._SerializerT_co'),
     ('py:obj', 'django_modern_rest.controller._SerializerT_co'),
     # Unsolvable imports:

--- a/docs/examples/integrations/pagination.py
+++ b/docs/examples/integrations/pagination.py
@@ -1,0 +1,48 @@
+from typing import Final, NotRequired, TypedDict, final
+
+import pydantic
+from django.core.paginator import Paginator
+
+from django_modern_rest import Controller, Query
+from django_modern_rest.pagination import Page, Paginated
+from django_modern_rest.plugins.pydantic import PydanticSerializer
+
+
+class _User(pydantic.BaseModel):
+    email: str
+
+
+class _PageQuery(TypedDict):
+    page_size: NotRequired[int]
+    page: NotRequired[int]
+
+
+_USERS: Final = (
+    _User(email='one@example.com'),
+    _User(email='two@example.com'),
+    _User(email='three@example.com'),
+)
+
+
+@final
+class UsersController(
+    Controller[PydanticSerializer],
+    Query[_PageQuery],
+):
+    def get(self) -> Paginated[_User]:
+        page = self.parsed_query.get('page', 1)
+        page_size = self.parsed_query.get('page_size', 2)
+
+        paginator = Paginator(_USERS, page_size)
+        return Paginated(
+            count=paginator.count,
+            num_pages=paginator.num_pages,
+            page=Page(
+                number=page,
+                object_list=list(paginator.page(page).object_list),
+            ),
+        )
+
+
+# run: {"controller": "UsersController", "method": "get", "url": "/api/users/"}  # noqa: ERA001, E501
+# run: {"controller": "UsersController", "method": "get", "url": "/api/users/", "query": "?page=2"}  # noqa: ERA001, E501

--- a/docs/pages/integrations.rst
+++ b/docs/pages/integrations.rst
@@ -105,7 +105,26 @@ how ``django-stubs`` is used.
 Pagination
 ----------
 
-TODO
+We don't ship our own pagination.
+We (as our main design goal suggests) provide support
+for any existing pagination plugin for Django.
+Including builtin :class:`django.core.paginator.Paginator`.
+
+To do so, we only provide metadata for the default pagination:
+
+.. literalinclude:: /examples/integrations/pagination.py
+  :caption: views.py
+  :language: python
+  :linenos:
+
+If you are using a different pagination system, you can define
+your own metadata / models and use them with our framework.
+
+.. autoclass:: django_modern_rest.pagination.Paginated
+  :members:
+
+.. autoclass:: django_modern_rest.pagination.Page
+  :members:
 
 
 django-filters

--- a/docs/tools/sphinx_ext/run_examples.py
+++ b/docs/tools/sphinx_ext/run_examples.py
@@ -291,16 +291,17 @@ def _build_curl_request(
     port: int,
     url_path: str,
 ) -> tuple[_CurlArgs, _CurlCleanArgs]:
+    query = run_args.pop('query', '')
     args = [
         'curl',
         '-v',
         '-s',
-        f'http://127.0.0.1:{port}{url_path}',
+        f'http://127.0.0.1:{port}{url_path}{query}',
     ]
     if run_args.pop('fail-with-body', True):
         args.append('--fail-with-body')
 
-    clean_args = ['curl', f'http://127.0.0.1:8000{url_path}']
+    clean_args = ['curl', f'http://127.0.0.1:8000{url_path}{query}']
 
     _add_curl_flags(args, clean_args, run_args)
     _add_method(args, clean_args, run_args)


### PR DESCRIPTION
CC @milssky schema generation for dataclasses does not work, it raises:

```
  File "/Users/sobolev/Desktop/django-modern-rest/django_test_app/server/urls.py", line 77, in <module>
    path('docs/', build_spec(router)),
                  ~~~~~~~~~~^^^^^^^^
  File "/Users/sobolev/Desktop/django-modern-rest/django_test_app/server/apps/openapi/urls.py", line 17, in build_spec
    return openapi_spec(
        router=router,
    ...<6 lines>...
        config=get_openapi_config(),
    )
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/spec.py", line 42, in openapi_spec
    schema = _build_schema(config or _default_config(), router)
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/spec.py", line 74, in _build_schema
    schema = OpenApiBuilder(context).build(router)
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/core/builder.py", line 30, in build
    path_item = self.context.generators.path_item.generate(controller)
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/generators/path_item.py", line 42, in generate
    operation = self.context.generators.operation.generate(
        endpoint,
        mapping.path,
    )
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/generators/operation.py", line 36, in generate
    responses = self.context.generators.response.generate(
        metadata.responses,
        metadata.parsers,
    )
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/generators/response.py", line 32, in generate
    schema=self.context.generators.schema.generate(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        response_spec.return_type,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/generators/schema.py", line 86, in generate
    return self._generate_reference(annotation)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/generators/schema.py", line 89, in _generate_reference
    field_definitions = find_extractor(
                        ~~~~~~~~~~~~~~^
        source_type,
        ^^^^^^^^^^^^
    ).extract_fields(source_type)
    ^
  File "/Users/sobolev/Desktop/django-modern-rest/django_modern_rest/openapi/extractors/finder.py", line 11, in find_extractor
    raise ValueError(f'Field extractor for {source_type} not found')
ValueError: Field extractor for django_modern_rest.pagination.Paginated[server.apps.django_session_auth.views._User] not found
```

Please take a look :)

Closes #313 