### PR TITLE
Support `ResponseSpec.limit_to_content_type`

### DIFF
--- a/dmr/metadata.py
+++ b/dmr/metadata.py
@@ -1,13 +1,8 @@
 import dataclasses
 from abc import abstractmethod
-from collections.abc import Mapping
+from collections.abc import Mapping, Set
 from http import HTTPStatus
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    TypeAlias,
-    final,
-)
+from typing import TYPE_CHECKING, Any, TypeAlias, final
 
 if TYPE_CHECKING:
     from dmr.components import ComponentParser
@@ -36,7 +31,7 @@ class ResponseSpec:
     """
     Represents a single API response specification.
 
-    Args:
+    Attributes:
         return_type: Shows *return_type* in the documentation
             as returned model schema.
             We validate *return_type* to match the returned response content
@@ -51,6 +46,9 @@ class ResponseSpec:
             When passed, we validate that all given required cookies are present
             in the final response.
         description: Text comment about what this response represents.
+        limit_to_content_types: This response can only happen
+            only for given content types. By default, when equals to ``None``,
+            all responses can happen for all content types.
 
     We use this structure to validate responses and render them in OpenAPI.
     """
@@ -67,6 +65,10 @@ class ResponseSpec:
         default=None,
     )
     description: str | None = dataclasses.field(
+        kw_only=True,
+        default=None,
+    )
+    limit_to_content_types: Set[str] | None = dataclasses.field(
         kw_only=True,
         default=None,
     )

--- a/dmr/validation/response.py
+++ b/dmr/validation/response.py
@@ -172,6 +172,17 @@ class ResponseValidator:
             ResponseSchemaError: When validation fails.
 
         """
+        if (
+            schema.limit_to_content_types
+            and content_type not in schema.limit_to_content_types
+        ):
+            hint = list(schema.limit_to_content_types)
+            raise ResponseSchemaError(
+                f'Response {schema.status_code} is not allowed '
+                f'for {content_type!r}, '
+                f'only for {hint!r}',
+            )
+
         content_types = get_conditional_types(schema.return_type)
         if content_types:
             model = content_types.get(content_type, EmptyObj)

--- a/docs/examples/negotiation/limit_to_content_types.py
+++ b/docs/examples/negotiation/limit_to_content_types.py
@@ -1,0 +1,48 @@
+from http import HTTPStatus
+
+import pydantic
+
+from dmr import APIError, Controller, Query, ResponseSpec
+from dmr.negotiation import ContentType
+from dmr.plugins.msgspec import MsgspecJsonParser, MsgspecJsonRenderer
+from dmr.plugins.pydantic import PydanticSerializer
+from examples.negotiation.negotiation import XmlParser, XmlRenderer
+
+
+class _QueryModel(pydantic.BaseModel):
+    show_error: bool = False
+
+
+class ExampleController(Controller[PydanticSerializer], Query[_QueryModel]):
+    parsers = (MsgspecJsonParser(), XmlParser())
+    renderers = (MsgspecJsonRenderer(), XmlRenderer())
+    responses = (
+        ResponseSpec(
+            list[str],
+            status_code=HTTPStatus.CONFLICT,
+            limit_to_content_types={ContentType.json},
+        ),
+        ResponseSpec(
+            dict[str, str],
+            status_code=HTTPStatus.PAYMENT_REQUIRED,
+            limit_to_content_types={ContentType.xml},
+        ),
+    )
+
+    def get(self) -> str:
+        if self.request.accepts(ContentType.json):
+            if self.parsed_query.show_error:
+                # This is explicitly wrong:
+                # `PAYMENT_REQUIRED` cannot happen with `json`,
+                # response validation will catch this:
+                raise APIError([], status_code=HTTPStatus.PAYMENT_REQUIRED)
+            raise APIError(['wrong', 'items'], status_code=HTTPStatus.CONFLICT)
+        raise APIError(
+            {'wrong': 'items'},
+            status_code=HTTPStatus.PAYMENT_REQUIRED,
+        )
+
+
+# run: {"controller": "ExampleController", "method": "get", "url": "/api/example/", "headers": {"Accept": "application/json"}, "fail-with-body": false}  # noqa: E501, ERA001
+# run: {"controller": "ExampleController", "method": "get", "url": "/api/example/", "headers": {"Accept": "application/xml"}, "fail-with-body": false}  # noqa: E501, ERA001
+# run: {"controller": "ExampleController", "method": "get", "url": "/api/example/", "headers": {"Accept": "application/json"}, "query": "?show_error=1", "curl_args": ["-D", "-"], "fail-with-body": false}  # noqa: E501, ERA001

--- a/docs/pages/negotiation.rst
+++ b/docs/pages/negotiation.rst
@@ -226,6 +226,21 @@ Note that you would also have to customize
 accordingly.
 
 
+Limiting response specs to content types
+----------------------------------------
+
+Sometimes some responses can only be returned for some content types.
+We need a way to describe it: both for our validation and OpenAPI spec.
+
+To do so, we utilize :attr:`~dmr.metadata.ResponseSpec.limit_to_content_types`
+attribute:
+
+.. literalinclude:: /examples/negotiation/limit_to_content_types.py
+   :caption: views.py
+   :language: python
+   :linenos:
+
+
 Negotiation API
 ---------------
 

--- a/tests/test_unit/test_negotiation/test_limit_to_content_types.py
+++ b/tests/test_unit/test_negotiation/test_limit_to_content_types.py
@@ -1,0 +1,111 @@
+import json
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import Any, final
+
+import pydantic
+from django.http import HttpResponse
+from inline_snapshot import snapshot
+from typing_extensions import override
+
+from dmr import APIError, Controller, Query, ResponseSpec
+from dmr.negotiation import ContentType
+from dmr.parsers import JsonParser
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.renderers import JsonRenderer, Renderer
+from dmr.test import DMRRequestFactory
+
+
+class _FakeJson5Renderer(Renderer):
+    content_type = 'application/json5'
+
+    @override
+    def render(
+        self,
+        to_serialize: Any,
+        serializer_hook: Callable[[Any], Any],
+    ) -> bytes:
+        return JsonRenderer().render(
+            to_serialize,
+            serializer_hook=serializer_hook,
+        )
+
+    @property
+    @override
+    def validation_parser(self) -> JsonParser:
+        return JsonParser()
+
+
+@final
+class _QueryModel(pydantic.BaseModel):
+    conflict: bool = False
+
+
+@final
+class _LimitedContentController(
+    Query[_QueryModel],
+    Controller[PydanticSerializer],
+):
+    renderers = (JsonRenderer(), _FakeJson5Renderer())
+
+    responses = (
+        ResponseSpec(
+            int,
+            status_code=HTTPStatus.CONFLICT,
+            limit_to_content_types={ContentType.json},
+        ),
+        ResponseSpec(
+            int,
+            status_code=HTTPStatus.PAYMENT_REQUIRED,
+            limit_to_content_types={'application/json5'},
+        ),
+    )
+
+    def get(self) -> str:
+        if self.parsed_query.conflict:
+            raise APIError(1, status_code=HTTPStatus.CONFLICT)
+        raise APIError(2, status_code=HTTPStatus.PAYMENT_REQUIRED)
+
+
+def test_correctly_limited(dmr_rf: DMRRequestFactory) -> None:
+    """Ensures that correct content type works."""
+    request = dmr_rf.get(
+        '/whatever/?conflict=1',
+        headers={
+            'Accept': str(ContentType.json),
+        },
+    )
+
+    response = _LimitedContentController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.CONFLICT, response.content
+    assert response.headers == {'Content-Type': 'application/json'}
+    assert json.loads(response.content) == snapshot(1)
+
+
+def test_wrong_limited(dmr_rf: DMRRequestFactory) -> None:
+    """Ensures that wrong content type raises."""
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={
+            'Accept': 'application/json5',
+        },
+    )
+
+    response = _LimitedContentController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.headers == {'Content-Type': 'application/json5'}
+    assert json.loads(response.content) == snapshot({
+        'detail': [
+            {
+                'msg': (
+                    'Response 402 is not allowed for '
+                    "'application/json', only for ['application/json5']"
+                ),
+                'type': 'value_error',
+            },
+        ],
+    })

--- a/tests/test_unit/test_negotiation/test_tricky_headers.py
+++ b/tests/test_unit/test_negotiation/test_tricky_headers.py
@@ -7,10 +7,7 @@ from django.http import HttpResponse
 from faker import Faker
 from inline_snapshot import snapshot
 
-from dmr import (
-    Body,
-    Controller,
-)
+from dmr import Body, Controller
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.test import DMRRequestFactory
 


### PR DESCRIPTION
Closes https://github.com/wemake-services/django-modern-rest/issues/533