### PR TITLE
Add package inclusion for 'dmr' in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
 ]
 
 packages = [
+  { include = "dmr" },
   { include = "dmr_pytest.py" }
 ]
 


### PR DESCRIPTION
In the pull request https://github.com/wemake-services/django-modern-rest/pull/331 I made a mistake that makes django-modern-rest impossible to import. It's time to fix it.

## Checking that there is a bug
```shell
python3 -m venv .venv
. .venv/bin/activate
pip install pytest django-modern-rest[msgspec]@git+https://github.com/wemake-services/django-modern-rest@master
python -c 'import dmr_pytest'
python -c 'import dmr'
```
<img width="794" height="210" alt="image" src="https://github.com/user-attachments/assets/428c3e7c-b665-41f1-b352-cc54ed77750e" />

## Checking that the bug has been fixed
```shell
deactivate && rm -rf .* *
python3 -m venv .venv
. .venv/bin/activate
pip install pytest django-modern-rest[msgspec]@git+https://github.com/gimntut/django-modern-rest@fix-include
python -c 'import dmr_pytest'
python -c 'import dmr'
```
<img width="829" height="189" alt="image" src="https://github.com/user-attachments/assets/28b3b659-0a5f-49a7-a0f2-767e98098e4d" />
