### PR TITLE
Add schemathesis docs

### DIFF
--- a/docs/examples/testing/polyfactory_usage.py
+++ b/docs/examples/testing/polyfactory_usage.py
@@ -1,11 +1,4 @@
-import sys
-
-import pytest
-
-if sys.version_info >= (3, 14):
-    pytest.skip(reason='Module is not supported yet', allow_module_level=True)
-
-import json  # type: ignore[unreachable, unused-ignore]
+import json
 from http import HTTPStatus
 
 from dirty_equals import IsUUID

--- a/docs/pages/testing.rst
+++ b/docs/pages/testing.rst
@@ -77,3 +77,99 @@ Let's reuse the models for data generation in tests!
 
 Which will make your tests simple, fast,
 and will help you find unexpected corner cases.
+
+
+Property-based API testing
+--------------------------
+
+There's a great tool called
+`schemathesis <https://github.com/schemathesis/schemathesis>`_
+that can be used to test your API to match your OpenAPI spec.
+
+Official docs: https://schemathesis.readthedocs.io
+
+``schemathesis`` is not bundled together with the ``django-modern-rest``.
+You have to install it with:
+
+.. tabs::
+
+    .. tab:: :iconify:`material-icon-theme:uv` uv
+
+        .. code-block:: bash
+
+            uv add --group dev schemathesis
+
+    .. tab:: :iconify:`devicon:poetry` poetry
+
+        .. code-block:: bash
+
+            poetry add --group dev schemathesis
+
+    .. tab:: :iconify:`devicon:pypi` pip
+
+        .. code-block:: bash
+
+            pip install schemathesis
+
+
+Now, let's see how you can generate thounds of tests for your API
+with just several lines of python code:
+
+.. literalinclude:: /../tests/test_integration/test_openapi/test_schema.py
+  :caption: test_schema.py
+  :language: python
+  :linenos:
+
+What will happen here?
+
+1. ``schemathesis`` with load OpenAPI schema definition
+   from the ``reverse('openapi')`` URL
+2. Then we will create a top level ``schema`` object from the ``api_schema``
+   pytest fixture. It is needed to create a property-based test case
+3. Lastly, we create a generated test case with the help of
+
+You can also provide settings, like
+the number of generated tests, enabled rules, auth, etc:
+
+.. literalinclude:: /../schemathesis.toml
+  :caption: schemathesis.toml
+  :language: toml
+  :linenos:
+
+When running the test case with
+
+.. code-block:: bash
+
+    pytest tests/test_integration/test_openapi/test_schema.py
+
+it will cover all your API. In simple cases it might be enough of tests.
+Yes, you heard right: in simple cases just using ``schemathesis``
+can remove the need in writting any other integration tests.
+
+.. important::
+
+  Using ``schemathesis`` with ``django-modern-rest`` is very easy,
+  because we offer state-of-the-art OpenAPI schema generation.
+  It will be really hard to satisfy ``schemathesis`` with a different framework.
+
+
+Validating responses
+~~~~~~~~~~~~~~~~~~~~
+
+``schemathesis`` can also be used in regular
+tests to validate the response schema.
+See https://schemathesis.readthedocs.io/en/stable/guides/schema-conformance/
+
+Example:
+
+.. code-block:: python
+
+    from dmr.test import DMRClient
+
+    def test_with_conditional_logic(dmr_client: DMRClient) -> None:
+        response = dmr_client.post(
+           '/users',
+           data={'name': 'Alice'},
+       )
+
+       assert schema['/users']['POST'].is_valid_response(response.json())

--- a/docs/pages/testing.rst
+++ b/docs/pages/testing.rst
@@ -144,7 +144,7 @@ When running the test case with
 
 it will cover all your API. In simple cases it might be enough of tests.
 Yes, you heard right: in simple cases just using ``schemathesis``
-can remove the need in writting any other integration tests.
+can remove the need in writing any other integration tests.
 
 .. important::
 


### PR DESCRIPTION
Friendly ping to @Stranger6667

Our work on OpenAPI spec is done. We generate a spec so detailed that it passes `schemathesis` by default. There are several problems with `xml`-test parser that we use, but it will also be fixed soon.

If you want to add something / change - please feel free :)
We are also accepting [testimonials](https://github.com/wemake-services/django-modern-rest?tab=readme-ov-file#testimonials), just saying 🌚️️