### PR TITLE
feat: enhance JWT authentication to support custom headers

### DIFF
--- a/dmr/security/jwt/auth.py
+++ b/dmr/security/jwt/auth.py
@@ -111,14 +111,22 @@ class _BaseJWTAuth:  # noqa: WPS214, WPS230
     @property
     def security_schemes(self) -> dict[str, SecurityScheme | Reference]:
         """Provides a security schema definition."""
+        if self._uses_standard_http_bearer_auth():
+            return {
+                self.security_scheme_name: SecurityScheme(
+                    type='http',
+                    scheme=self.auth_scheme,
+                    bearer_format='JWT',
+                    description='JWT token auth',
+                ),
+            }
+
         return {
-            # TODO: this does not change if `name!='Authentication'`,
-            # but it probably should.
             self.security_scheme_name: SecurityScheme(
-                type='http',
-                scheme=self.auth_scheme,
-                bearer_format='JWT',
-                description='JWT token auth',
+                type='apiKey',
+                name=self.auth_header,
+                security_scheme_in='header',
+                description=self._get_custom_security_scheme_description(),
             ),
         }
 
@@ -198,6 +206,21 @@ class _BaseJWTAuth:  # noqa: WPS214, WPS230
         """Set current user as authed for this request."""
         request.user = user
         request.jwt = token  # type: ignore[attr-defined]
+
+    def _uses_standard_http_bearer_auth(self) -> bool:
+        """Whether the auth contract matches OpenAPI HTTP bearer auth."""
+        return (
+            self.auth_header == 'Authorization'
+            and self.auth_scheme.casefold() == 'bearer'
+        )
+
+    def _get_custom_security_scheme_description(self) -> str:
+        """Describe non-standard JWT auth contracts for generated docs."""
+        return (
+            'JWT token auth via '
+            f'`{self.auth_header}` header using '
+            f'`{self.auth_scheme} <token>` format'
+        )
 
 
 class JWTSyncAuth(_BaseJWTAuth, SyncAuth):

--- a/tests/test_unit/test_security/test_jwt/test_jwt_schema.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_schema.py
@@ -21,3 +21,45 @@ def test_schema(
         ),
     })
     assert instance.security_requirement == snapshot({'jwt': []})
+
+
+@pytest.mark.parametrize('typ', [JWTSyncAuth, JWTAsyncAuth])
+def test_custom_header_schema(
+    typ: type[JWTSyncAuth] | type[JWTAsyncAuth],
+) -> None:
+    """Ensures that custom jwt auth is documented with the real header."""
+    instance = typ(auth_header='X-Api-Auth', auth_scheme='JWT')
+
+    assert instance.security_schemes == snapshot({
+        'jwt': SecurityScheme(
+            type='apiKey',
+            description=(
+                'JWT token auth via `X-Api-Auth` header '
+                'using `JWT <token>` format'
+            ),
+            name='X-Api-Auth',
+            security_scheme_in='header',
+        ),
+    })
+    assert instance.security_requirement == snapshot({'jwt': []})
+
+
+@pytest.mark.parametrize('typ', [JWTSyncAuth, JWTAsyncAuth])
+def test_custom_scheme_schema(
+    typ: type[JWTSyncAuth] | type[JWTAsyncAuth],
+) -> None:
+    """Ensures that non-bearer JWT auth is documented as a header contract."""
+    instance = typ(auth_scheme='JWT')
+
+    assert instance.security_schemes == snapshot({
+        'jwt': SecurityScheme(
+            type='apiKey',
+            description=(
+                'JWT token auth via `Authorization` header '
+                'using `JWT <token>` format'
+            ),
+            name='Authorization',
+            security_scheme_in='header',
+        ),
+    })
+    assert instance.security_requirement == snapshot({'jwt': []})


### PR DESCRIPTION
# I have made things!

This PR fixes JWT OpenAPI generation so the documented auth contract matches runtime behavior.

Previously, JWT auth always emitted a generic HTTP auth scheme in OpenAPI, even when JWTAsyncAuth / JWTSyncAuth were configured with a custom header or custom scheme. That meant generated docs and clients did not reflect the real request format.

With this change:

- Default `Authorization: Bearer <token>` auth is still documented as an HTTP bearer scheme
- Custom JWT configs like `X-Api-Auth: JWT <token>` are now documented as a header-based apiKey scheme with the real header name
## Checklist

<!-- Please check everything that applies: -->

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
