### PR TITLE
docs: properly quote shell args in example output

### DIFF
--- a/docs/tools/sphinx_ext/run_examples.py
+++ b/docs/tools/sphinx_ext/run_examples.py
@@ -18,6 +18,7 @@ import os
 import platform
 import re
 import socket
+import shlex
 import subprocess  # noqa: S404
 import sys
 import time
@@ -526,7 +527,7 @@ def _process_single_example(
             )
         return ''
 
-    clean_args_string = ' '.join(clean_args)
+    clean_args_string = shlex.join(clean_args)
     return '\n'.join((f'$ {clean_args_string}', *stdout))
 
 

--- a/docs/tools/sphinx_ext/run_examples.py
+++ b/docs/tools/sphinx_ext/run_examples.py
@@ -17,8 +17,8 @@ import multiprocessing
 import os
 import platform
 import re
-import socket
 import shlex
+import socket
 import subprocess  # noqa: S404
 import sys
 import time


### PR DESCRIPTION
I looked over the project and its endpoints and noticed that a lot of the curl commands in the docs are missing quotes. 

If you've got spaces, ampersands, or these brackets { } < >, you've gotta put quotes around it for the shell. 

Just a quick fix for all the curl requests in the docs.

Before the fix:
```
$ curl http://127.0.0.1:8000/api/math/ -d {"left": 1, "right": 0} -H Content-Type: application/json
```

After the fix:
```
$ curl http://127.0.0.1:8000/api/math/ -d '{"left": 1, "right": 0}' -H 'Content-Type: application/json
```