### PR TITLE
fix: support custom HTTP authentication headers in security schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 We follow [Semantic Versions](https://semver.org/).
 
 
+## WIP
+
+### Bugfixes
+
+- Fixed OpenAPI schema for custom HTTP Basic auth headers, #672
+
+
 ## Version 0.2.0 (2026-03-15)
 
 ### Features
@@ -23,7 +30,6 @@ We follow [Semantic Versions](https://semver.org/).
 - Fixed a bug, when request to a missing page with wrong `Accept` header
   was raising an error. Now it returns 406 as it should, #656
 - Fixed fake examples generation, #638
-- Fixed OpenAPI schema for custom HTTP Basic auth headers, #672
 - Fixed OpenAPI schema for custom JWT auth parameters, #660
 - Fixed ``Body`` component was not able to properly parse lists
   with ``multipart/form-data`` parser, #644

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We follow [Semantic Versions](https://semver.org/).
 - Fixed a bug, when request to a missing page with wrong `Accept` header
   was raising an error. Now it returns 406 as it should, #656
 - Fixed fake examples generation, #638
+- Fixed OpenAPI schema for custom HTTP Basic auth headers, #672
 - Fixed OpenAPI schema for custom JWT auth parameters, #660
 - Fixed ``Body`` component was not able to properly parse lists
   with ``multipart/form-data`` parser, #644

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -30,13 +30,21 @@ class _HttpBasicAuth:
     @property
     def security_schemes(self) -> dict[str, SecurityScheme | Reference]:
         """Provides a security schema definition."""
+        if self._uses_standard_http_basic_auth():
+            return {
+                self.security_scheme_name: SecurityScheme(
+                    type='http',
+                    scheme='basic',
+                    description='Http Basic auth',
+                ),
+            }
+
         return {
-            # TODO: this does not change if `name!='Authentication'`,
-            # but it probably should.
             self.security_scheme_name: SecurityScheme(
-                type='http',
-                scheme='basic',
-                description='Http Basic auth',
+                type='apiKey',
+                name=self.header,
+                security_scheme_in='header',
+                description=self._get_custom_security_scheme_description(),
             ),
         }
 
@@ -66,6 +74,19 @@ class _HttpBasicAuth:
         except Exception:
             return None
         return unquote(username), unquote(password)
+
+    def _uses_standard_http_basic_auth(self) -> bool:
+        """Whether the auth contract matches OpenAPI HTTP basic auth."""
+        return self.header == 'Authorization'
+
+    def _get_custom_security_scheme_description(self) -> str:
+        """Describe non-standard basic auth header contracts."""
+        return (
+            'HTTP Basic auth via '
+            f'`{self.header}` header using '
+            '`<base64(username:password)>` or '
+            '`Basic <base64(username:password)>` format'
+        )
 
 
 class HttpBasicSyncAuth(_HttpBasicAuth, SyncAuth):

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -23,3 +23,25 @@ def test_schema(
         ),
     })
     assert instance.security_requirement == snapshot({'http_basic': []})
+
+
+@pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
+def test_custom_header_schema(
+    typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
+) -> None:
+    """Ensures that custom basic auth is documented with the real header."""
+    instance = typ(header='X-Api-Auth')
+
+    assert instance.security_schemes == snapshot({
+        'http_basic': SecurityScheme(
+            type='apiKey',
+            description=(
+                'HTTP Basic auth via `X-Api-Auth` header using '
+                '`<base64(username:password)>` or '
+                '`Basic <base64(username:password)>` format'
+            ),
+            name='X-Api-Auth',
+            security_scheme_in='header',
+        ),
+    })
+    assert instance.security_requirement == snapshot({'http_basic': []})


### PR DESCRIPTION
# I have made things!

This PR fixes OpenAPI docs for HttpBasicSyncAuth and HttpBasicAsyncAuth when a custom header is used.

Previously, the schema always advertised standard HTTP Basic auth (Authorization: Basic ...) even if auth was actually configured to read from a different header like X-Api-Auth. Now, standard Authorization continues to use the OpenAPI http/basic scheme, while custom headers are documented as a header-based apiKey scheme with a description that matches the real wire format. It also adds tests to cover the custom-header case.

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
