### PR TITLE
fix: improve JWT claim validation and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We follow [Semantic Versions](https://semver.org/).
 ### Bugfixes
 
 - Fixed OpenAPI schema for custom HTTP Basic auth headers, #672
+- Fixed JWT claim validation and error handling in `JWToken.decode`, #675
 
 
 ## Version 0.2.0 (2026-03-15)

--- a/dmr/security/jwt/token.py
+++ b/dmr/security/jwt/token.py
@@ -246,14 +246,10 @@ class JWToken:
             raise NotAuthenticatedError from None
 
         # Convert types to match our definition:
-        payload['exp'] = dt.datetime.fromtimestamp(
-            payload['exp'],
-            tz=dt.UTC,
-        )
-        payload['iat'] = dt.datetime.fromtimestamp(
-            payload['iat'],
-            tz=dt.UTC,
-        )
+        payload['exp'] = cls._decode_datetime_claim(payload, 'exp')
+        payload['iat'] = cls._decode_datetime_claim(payload, 'iat')
+        cls._require_claim(payload, 'sub')
+
         extra_fields = payload.keys() - {field.name for field in fields(cls)}
         extras = payload.setdefault('extras', {})
         for key in extra_fields:
@@ -294,6 +290,32 @@ class JWToken:
             'require': list(require_claims) if require_claims else [],
         }
         return options
+
+    @classmethod
+    def _require_claim(
+        cls,
+        payload: dict[str, Any],
+        claim: str,
+    ) -> Any:
+        try:
+            return payload[claim]
+        except KeyError as error:
+            raise NotAuthenticatedError from error
+
+    @classmethod
+    def _decode_datetime_claim(
+        cls,
+        payload: dict[str, Any],
+        claim: str,
+    ) -> dt.datetime:
+        claim_value = cls._require_claim(payload, claim)
+        try:
+            return dt.datetime.fromtimestamp(
+                claim_value,
+                tz=dt.UTC,
+            )
+        except (TypeError, ValueError, OSError):
+            raise NotAuthenticatedError from None
 
 
 def _normalize_datetime(datetime: dt.datetime) -> dt.datetime:

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -6,7 +6,7 @@
 import dataclasses
 import datetime as dt
 import secrets
-from typing import Any
+from typing import Any, TypedDict
 
 import jwt
 import pytest
@@ -14,6 +14,12 @@ from faker import Faker
 
 from dmr.exceptions import InternalServerError, NotAuthenticatedError
 from dmr.security.jwt import JWToken
+
+
+class _DecodeKwargs(TypedDict, total=False):
+    verify_exp: bool
+    verify_iat: bool
+    verify_sub: bool
 
 
 @pytest.mark.parametrize('algorithm', ['HS256', 'HS384', 'HS512'])
@@ -258,3 +264,75 @@ def test_verify_nbf_can_be_disabled_independently() -> None:
     )
 
     assert token.extras['nbf'] == int(not_before.timestamp())
+
+
+@pytest.mark.parametrize(
+    ('raw_token', 'decode_kwargs'),
+    [
+        (
+            {
+                'sub': 'foo',
+                'iat': dt.datetime.now(dt.UTC),
+            },
+            {
+                'verify_exp': False,
+            },
+        ),
+        (
+            {
+                'sub': 'foo',
+                'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+            },
+            {
+                'verify_iat': False,
+            },
+        ),
+        (
+            {
+                'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+                'iat': dt.datetime.now(dt.UTC),
+            },
+            {
+                'verify_sub': False,
+            },
+        ),
+    ],
+)
+def test_missing_required_claims_raise_auth_error(
+    *,
+    raw_token: dict[str, Any],
+    decode_kwargs: _DecodeKwargs,
+) -> None:
+    """Ensure missing required claims still fail as auth errors."""
+    secret = secrets.token_hex()
+    encoded = jwt.encode(raw_token, key=secret, algorithm='HS256')
+
+    with pytest.raises(NotAuthenticatedError):
+        JWToken.decode(
+            encoded,
+            secret=secret,
+            algorithm='HS256',
+            **decode_kwargs,
+        )
+
+
+def test_invalid_datetime_claim_raises_auth_error() -> None:
+    """Ensure malformed datetime claims fail as auth errors."""
+    secret = secrets.token_hex()
+    encoded = jwt.encode(
+        {
+            'sub': 'foo',
+            'exp': 'not-a-timestamp',
+            'iat': dt.datetime.now(dt.UTC),
+        },
+        key=secret,
+        algorithm='HS256',
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        JWToken.decode(
+            encoded,
+            secret=secret,
+            algorithm='HS256',
+            verify_exp=False,
+        )

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -267,45 +267,39 @@ def test_verify_nbf_can_be_disabled_independently() -> None:
 
 
 @pytest.mark.parametrize(
-    ('raw_token', 'decode_kwargs'),
+    ('raw_token_data', 'decode_kwargs'),
     [
         (
             {
                 'sub': 'foo',
                 'iat': dt.datetime.now(dt.UTC),
             },
-            {
-                'verify_exp': False,
-            },
+            _DecodeKwargs(verify_exp=False),
         ),
         (
             {
                 'sub': 'foo',
                 'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
             },
-            {
-                'verify_iat': False,
-            },
+            _DecodeKwargs(verify_iat=False),
         ),
         (
             {
                 'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
                 'iat': dt.datetime.now(dt.UTC),
             },
-            {
-                'verify_sub': False,
-            },
+            _DecodeKwargs(verify_sub=False),
         ),
     ],
 )
 def test_missing_required_claims_raise_auth_error(
     *,
-    raw_token: dict[str, Any],
+    raw_token_data: dict[str, Any],
     decode_kwargs: _DecodeKwargs,
 ) -> None:
     """Ensure missing required claims still fail as auth errors."""
     secret = secrets.token_hex()
-    encoded = jwt.encode(raw_token, key=secret, algorithm='HS256')
+    encoded = jwt.encode(raw_token_data, key=secret, algorithm='HS256')
 
     with pytest.raises(NotAuthenticatedError):
         JWToken.decode(


### PR DESCRIPTION
# I have made things!

Ensure JWToken.decode() returns NotAuthenticatedError instead of leaking KeyError or TypeError when required claims are missing or malformed and claim verification is disabled.

Changes:
- validate required sub, exp, and iat claims explicitly during decode
- convert malformed datetime claims into auth failures
- add regression tests for missing exp, iat, sub, and invalid datetime claim values

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
