### PR TITLE
Support `attrs`, add `django-mantle` notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
       run: |
         poetry config virtualenvs.in-project true
         poetry run pip install -U pip
-        poetry install --extras=msgspec --extras=jwt
+        poetry install --extras=msgspec --extras=attrs --extras=jwt
 
     - name: Run checks
       run: |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@
 - [x] Fully typed and checked with `mypy`, `pyright`, and `pyrefly` in strict modes
 - [x] Strict schema validation of both requests and responses
 - [x] Supports `django>=5.2`
-- [x] Supports `pydantic2`, but not bound to it
-- [x] Supports `msgspec`, but not bound to it
+- [x] Supports `pydantic2`, `msgspec`, `attrs`, `dataclasses`, `TypedDict`, but not bound to any of the these libraries
 - [x] Supports async Django without any `sync_to_async` calls inside
 - [x] Supports `openapi` 3.1+ schema generation out of the box
 - [x] Supports all your existing `django` primitives and packages, no custom runtimes
@@ -76,6 +75,7 @@ There are several included extras:
 - `'django-modern-rest[msgspec]'` provides `msgspec` support
   and the fastest json parsing, recommended to be **always** included
 - `'django-modern-rest[pydantic]'` provides `pydantic` support
+- `'django-modern-rest[attrs]'` provides `attrs` support
 - `'django-modern-rest[jwt]'` provides [`pyjwt`](https://github.com/jpadilla/pyjwt) auth support
 - `'django-modern-rest[openapi]'` provides `OpenAPI` [schema validation](https://github.com/python-openapi/openapi-spec-validator)
   and generates better OpenAPI examples with [`polyfactory`](https://github.com/litestar-org/polyfactory)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,6 +86,7 @@ intersphinx_mapping = {
         'https://typing-extensions.readthedocs.io/en/stable/',
         None,
     ),
+    'attrs': ('https://www.attrs.org/en/stable/', None),
 }
 
 # Napoleon:

--- a/docs/examples/auth/django_session/django_session.py
+++ b/docs/examples/auth/django_session/django_session.py
@@ -25,3 +25,7 @@ class SessionSyncController(
     @override
     def make_api_response(self) -> DjangoSessionResponse:
         return {'user_id': str(self.request.user.pk)}
+
+
+# run: {"controller": "SessionSyncController", "method": "post", "url": "/api/auth/", "body" :{"username": "test_user", "password": "password"}, "curl_args": ["-D", "-"], "populate_db": true}  # noqa: ERA001, E501
+# openapi: {"controller": "SessionSyncController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/examples/auth/jwt/jwt_complex_tokens.py
+++ b/docs/examples/auth/jwt/jwt_complex_tokens.py
@@ -61,3 +61,7 @@ class ObtainAccessAndRefreshSyncController(
                 'refresh': refresh,
             },
         }
+
+
+# run: {"controller": "ObtainAccessAndRefreshSyncController", "method": "post", "url": "/api/auth/", "body": {"email": "test_user", "password": "password"}, "populate_db": true}  # noqa: ERA001, E501
+# openapi: {"controller": "ObtainAccessAndRefreshSyncController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/examples/auth/jwt/jwt_obtain_tokens.py
+++ b/docs/examples/auth/jwt/jwt_obtain_tokens.py
@@ -38,3 +38,7 @@ class ObtainAccessAndRefreshSyncController(
                 token_type='refresh',
             ),
         }
+
+
+# run: {"controller": "ObtainAccessAndRefreshSyncController", "method": "post", "url": "/api/auth/", "body": {"username": "test_user", "password": "password"}, "populate_db": true}  # noqa: ERA001, E501
+# openapi: {"controller": "ObtainAccessAndRefreshSyncController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/examples/getting_started/attrs_controller.py
+++ b/docs/examples/getting_started/attrs_controller.py
@@ -1,0 +1,32 @@
+import uuid
+
+import attrs
+
+from dmr import Body, Controller, Headers
+from dmr.plugins.msgspec import MsgspecSerializer
+
+
+@attrs.define
+class UserCreateModel:
+    email: str
+
+
+@attrs.define
+class UserModel(UserCreateModel):
+    uid: uuid.UUID
+
+
+@attrs.define
+class HeaderModel:
+    consumer: str = attrs.field(alias='X-API-Consumer')
+
+
+class UserController(
+    Controller[MsgspecSerializer],
+    Body[UserCreateModel],
+    Headers[HeaderModel],
+):
+    def post(self) -> UserModel:
+        """All added props have the correct runtime and static types."""
+        assert self.parsed_headers.consumer == 'my-api'
+        return UserModel(uid=uuid.uuid4(), email=self.parsed_body.email)

--- a/docs/examples/getting_started/dataclasses_controller.py
+++ b/docs/examples/getting_started/dataclasses_controller.py
@@ -1,0 +1,25 @@
+import dataclasses
+import uuid
+
+from dmr import Body, Controller
+from dmr.plugins.msgspec import MsgspecSerializer
+
+
+@dataclasses.dataclass
+class UserCreateModel:
+    email: str
+
+
+@dataclasses.dataclass
+class UserModel(UserCreateModel):
+    uid: uuid.UUID
+
+
+class UserController(
+    Controller[MsgspecSerializer],
+    # Dataclasses do not support field name aliases, so can't use Headers :(
+    Body[UserCreateModel],
+):
+    def post(self) -> UserModel:
+        """All added props have the correct runtime and static types."""
+        return UserModel(uid=uuid.uuid4(), email=self.parsed_body.email)

--- a/docs/examples/getting_started/typed_dict_controller.py
+++ b/docs/examples/getting_started/typed_dict_controller.py
@@ -1,0 +1,27 @@
+import uuid
+from typing import TypedDict
+
+from dmr import Body, Controller, Headers
+from dmr.plugins.msgspec import MsgspecSerializer
+
+
+class UserCreateModel(TypedDict):
+    email: str
+
+
+class UserModel(UserCreateModel):
+    uid: uuid.UUID
+
+
+HeaderModel = TypedDict('HeaderModel', {'X-API-Consumer': str})
+
+
+class UserController(
+    Controller[MsgspecSerializer],
+    Body[UserCreateModel],
+    Headers[HeaderModel],
+):
+    def post(self) -> UserModel:
+        """All added props have the correct runtime and static types."""
+        assert self.parsed_headers['X-API-Consumer'] == 'my-api'
+        return UserModel(uid=uuid.uuid4(), email=self.parsed_body['email'])

--- a/docs/examples/integrations/django_mantel.py
+++ b/docs/examples/integrations/django_mantel.py
@@ -1,0 +1,25 @@
+import attrs
+
+from dmr import Controller
+from dmr.plugins.msgspec import MsgspecSerializer
+
+
+@attrs.define
+class _UserModel:
+    username: str
+    email: str
+    is_active: bool
+
+
+class UsersController(Controller[MsgspecSerializer]):
+    def get(self) -> list[_UserModel]:
+        # We have to do import here due to how our docs build systems works,
+        # but in real apps they must be on the module level:
+        from django.contrib.auth.models import User  # noqa: PLC0415
+        from mantle import Query  # type: ignore[import-untyped]  # noqa: PLC0415
+
+        return Query(User.objects.all(), _UserModel).all()  # type: ignore[no-any-return]
+
+
+# run: {"controller": "UsersController", "method": "get", "url": "/api/users/", "populate_db": true}  # noqa: ERA001, E501
+# openapi: {"controller": "UsersController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/examples/integrations/django_mantel.py
+++ b/docs/examples/integrations/django_mantel.py
@@ -16,7 +16,9 @@ class UsersController(Controller[MsgspecSerializer]):
         # We have to do import here due to how our docs build systems works,
         # but in real apps they must be on the module level:
         from django.contrib.auth.models import User  # noqa: PLC0415
-        from mantle import Query  # type: ignore[import-untyped]  # noqa: PLC0415
+        from mantle import (  # type: ignore[import-untyped]  # noqa: PLC0415
+            Query,
+        )
 
         return Query(User.objects.all(), _UserModel).all()  # type: ignore[no-any-return]
 

--- a/docs/examples/integrations/pagination.py
+++ b/docs/examples/integrations/pagination.py
@@ -46,3 +46,4 @@ class UsersController(
 
 # run: {"controller": "UsersController", "method": "get", "url": "/api/users/"}  # noqa: ERA001, E501
 # run: {"controller": "UsersController", "method": "get", "url": "/api/users/", "query": "?page=2"}  # noqa: ERA001, E501
+# openapi: {"controller": "UsersController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -34,6 +34,7 @@ Works for:
 Extras for different serializers:
 
 - ``'django-modern-rest[pydantic]'`` for ``pydantic`` support
+- ``'django-modern-rest[attrs]'`` for ``attrs`` support
 - ``'django-modern-rest[msgspec]'`` for ``msgspec`` support
   and the fastest ``json`` parsing
 
@@ -104,29 +105,72 @@ Let's see the basics and learn how to use ``dmr`` in a single example:
 
     .. tab:: msgspec
 
+      We support :class:`msgspec.Struct`
+      via :class:`~dmr.plugins.msgspec.MsgspecSerializer`.
+
       .. literalinclude:: /examples/getting_started/msgspec_controller.py
         :caption: views.py
         :language: python
         :linenos:
-        :emphasize-lines: 6, 22
+        :emphasize-lines: 3, 6, 22
 
     .. tab:: pydantic
+
+      We support :class:`pydantic.BaseModel`
+      via :class:`~dmr.plugins.pydantic.PydanticSerializer`.
 
       .. literalinclude:: /examples/getting_started/pydantic_controller.py
         :caption: views.py
         :language: python
         :linenos:
-        :emphasize-lines: 6, 22
+        :emphasize-lines: 3, 6, 22
+
+    .. tab:: attrs
+
+      We support :func:`attrs.define`
+      via :class:`~dmr.plugins.msgspec.MsgspecSerializer`.
+
+      .. literalinclude:: /examples/getting_started/attrs_controller.py
+        :caption: views.py
+        :language: python
+        :linenos:
+        :emphasize-lines: 3, 6, 9, 14, 19, 25
+
+    .. tab:: dataclasses
+
+      We support :func:`dataclasses.dataclass` via both
+      :class:`~dmr.plugins.msgspec.MsgspecSerializer`
+      and :class:`~dmr.plugins.pydantic.PydanticSerializer`.
+
+      .. literalinclude:: /examples/getting_started/dataclasses_controller.py
+        :caption: views.py
+        :language: python
+        :linenos:
+        :emphasize-lines: 1, 5, 8, 13, 19
+
+    .. tab:: TypedDict
+
+      We support :class:`typing.TypedDict` via both
+      :class:`~dmr.plugins.msgspec.MsgspecSerializer`
+      and :class:`~dmr.plugins.pydantic.PydanticSerializer`.
+
+      .. literalinclude:: /examples/getting_started/typed_dict_controller.py
+        :caption: views.py
+        :language: python
+        :linenos:
+        :emphasize-lines: 2, 5, 8, 12, 16, 20
+
 
 In this example:
 
-1. We defined regular ``pydantic`` or ``msgspec`` models
+1. We defined regular ``pydantic``, ``msgspec``, or ``attrs`` models
    that we will use for our API
 2. We added two component parsers: one for request's
    :class:`~dmr.components.Body` and one
    for :class:`~dmr.components.Headers`
    which will parse them into the typed models
-   (:class:`pydantic.BaseModel` or :class:`msgspec.Struct` based) that we pass
+   (:class:`pydantic.BaseModel`, :class:`msgspec.Struct`,
+   or :func:`attrs.define` based) that we pass
    to these components as type parameters
 3. Next we created
    a :class:`~dmr.controller.Controller` class

--- a/docs/pages/integrations.rst
+++ b/docs/pages/integrations.rst
@@ -62,6 +62,19 @@ Now you have your REST API that returns fully typed model responses
 and can work with :class:`~django.db.models.query.QuerySet`
 and :class:`~django.db.models.Model` instances.
 
+django-mantle
+~~~~~~~~~~~~~
+
+If you want to automate this part and automatically
+convert ``QuerySet`` into typed models, you can use
+`django-mantle <https://noumenal.es/mantle/>`_
+which is built just for this purpose:
+
+.. literalinclude:: /examples/integrations/django_mantel.py
+  :caption: views.py
+  :language: python
+  :linenos:
+
 
 CSRF
 ----

--- a/docs/tools/sphinx_ext/run_examples.py
+++ b/docs/tools/sphinx_ext/run_examples.py
@@ -236,7 +236,7 @@ class _BaseBuilder:  # noqa: WPS214
         settings.configure(
             ROOT_URLCONF='url_conf',
             ALLOWED_HOSTS=['*'],
-            DEBUG=True,
+            DEBUG=False,
             SECRET_KEY='dummy-key-for-examples',  # noqa: S106
             INSTALLED_APPS=[
                 'django.contrib.auth',

--- a/docs/tools/sphinx_ext/run_examples.py
+++ b/docs/tools/sphinx_ext/run_examples.py
@@ -22,17 +22,19 @@ import subprocess  # noqa: S404
 import sys
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager, redirect_stderr
+from contextlib import contextmanager, redirect_stderr, suppress
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias, cast
 from urllib.parse import urlencode
 
+import django
 import httpx
 import uvicorn
 import xmltodict
 from django.conf import settings
 from django.core.handlers.asgi import ASGIHandler
+from django.db import IntegrityError
 from django.test import override_settings
 from django.urls import URLPattern, clear_url_caches, path
 from django.views import View
@@ -74,7 +76,7 @@ def _get_mp_context() -> Any:
         ) from error
 
 
-_MP_CONTEXT = _get_mp_context()
+_MP_CONTEXT: Final = _get_mp_context()
 
 _PATH_TO_TMP_EXAMPLES: Final = '_build/_tmp_example/'
 _RGX_RUN: Final = re.compile(r'# +?run:(.*)')
@@ -87,6 +89,8 @@ _OpenAPIRunArgs: TypeAlias = dict[str, Any]
 
 logger: Final = logging.getLogger(__name__)
 ignore_missing_output: Final = True
+
+db_populated = False
 
 
 class _StartupError(RuntimeError):
@@ -212,7 +216,7 @@ def _get_available_port() -> int:
             return cast(int, sock.getsockname()[1])
 
 
-class _BaseBuilder:
+class _BaseBuilder:  # noqa: WPS214
     def __init__(self, file_path: Path, config: _AppRunArgs) -> None:
         """Initialize application builder with file path and configuration."""
         self.file_path = file_path
@@ -221,7 +225,9 @@ class _BaseBuilder:
     def build_app(self) -> ASGIHandler:
         """Build and return configured ASGI application."""
         self._configure_settings()
-        return self._build_app()
+        app = self._build_app()
+        self._populate_db()
+        return app
 
     def _configure_settings(self) -> None:
         if settings.configured:
@@ -230,20 +236,55 @@ class _BaseBuilder:
         settings.configure(
             ROOT_URLCONF='url_conf',
             ALLOWED_HOSTS=['*'],
-            DEBUG=False,
+            DEBUG=True,
             SECRET_KEY='dummy-key-for-examples',  # noqa: S106
             INSTALLED_APPS=[
                 'django.contrib.auth',
+                'django.contrib.sessions',
                 'django.contrib.contenttypes',
                 'dmr',
                 'dmr.security.jwt.blocklist',
             ],
-            MIDDLEWARE=[],
+            MIDDLEWARE=[
+                'django.middleware.security.SecurityMiddleware',
+                'django.contrib.sessions.middleware.SessionMiddleware',
+                'django.middleware.common.CommonMiddleware',
+                'django.middleware.csrf.CsrfViewMiddleware',
+                'django.contrib.auth.middleware.AuthenticationMiddleware',
+            ],
             USE_TZ=True,
+            DATABASES={
+                'default': {
+                    'ENGINE': 'django.db.backends.sqlite3',
+                    'NAME': '_build/test.db',
+                },
+            },
+            LOGGING_CONFIG=None,
             # Needed for HTTP Basic auth example:
             HTTP_BASIC_USERNAME='admin',
             HTTP_BASIC_PASSWORD='pass',  # noqa: S106
         )
+        django.setup()
+
+    def _populate_db(self) -> None:
+        global db_populated  # noqa: PLW0603, WPS420
+        if not self.config.get('populate_db') or db_populated:
+            return
+
+        from django.core.management.commands import migrate  # noqa: PLC0415
+
+        migrate.Command().run_from_argv(['python', 'run_examples.py'])
+
+        from django.contrib.auth.models import User  # noqa: PLC0415
+
+        with suppress(IntegrityError):
+            User.objects.create_user(
+                'test_user',
+                email='test@example.com',
+                password='password',  # noqa: S106
+            )
+
+        db_populated = True
 
     def _build_app(self) -> ASGIHandler:
         file_path_without_ext = self.file_path.with_suffix('')

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,7 +86,7 @@ files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
 ]
-markers = {main = "extra == \"openapi\""}
+markers = {main = "extra == \"openapi\" or extra == \"attrs\""}
 
 [[package]]
 name = "babel"
@@ -102,6 +102,33 @@ files = [
 
 [package.extras]
 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+description = "Composable complex class support for attrs and dataclasses."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096"},
+    {file = "cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40"},
+]
+
+[package.dependencies]
+attrs = ">=25.4.0"
+typing-extensions = ">=4.14.0"
+
+[package.extras]
+bson = ["pymongo (>=4.4.0)"]
+cbor2 = ["cbor2 (>=5.4.6)"]
+msgpack = ["msgpack (>=1.0.5)"]
+msgspec = ["msgspec (>=0.19.0) ; implementation_name == \"cpython\""]
+orjson = ["orjson (>=3.11.3) ; implementation_name == \"cpython\""]
+pyyaml = ["pyyaml (>=6.0)"]
+tomlkit = ["tomlkit (>=0.11.8)"]
+tomllib = ["tomli (>=1.1.0) ; python_version < \"3.11\"", "tomli-w (>=1.1.0)"]
+ujson = ["ujson (>=5.10.0)"]
 
 [[package]]
 name = "certifi"
@@ -640,6 +667,37 @@ tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "django-mantle"
+version = "26.5"
+description = "Your type-safe wrapper around Django's liquid core."
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "django_mantle-26.5-py2.py3-none-any.whl", hash = "sha256:eea7e660b79e3e109920fb37b6d29242f8f7e0adc609a2f097c7e26f7c6a9776"},
+    {file = "django_mantle-26.5.tar.gz", hash = "sha256:c253b9292b3fc5a89f18e4d3c86a38d63f92405ccc6f75f4bffea388c776ed15"},
+]
+
+[package.extras]
+dev = ["django-stubs", "mypy"]
+docs = ["Sphinx"]
+
+[[package]]
+name = "django-readers"
+version = "2.5.1"
+description = "A lightweight function-oriented toolkit for better organisation of business logic and efficient selection and projection of data in Django projects."
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "django_readers-2.5.1-py3-none-any.whl", hash = "sha256:af0d043403458cf66c0313f9b594b24e87a8781057510de1c95f54b1051268d9"},
+    {file = "django_readers-2.5.1.tar.gz", hash = "sha256:b00529c73842b4af69d3e44f6c362dc4ce8122cbda9b85034216a1236c26a56a"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
 
 [[package]]
 name = "django-stubs"
@@ -1624,7 +1682,7 @@ description = "A fast serialization and validation library, with builtin support
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"msgspec\""
+markers = "extra == \"msgspec\" or extra == \"attrs\""
 files = [
     {file = "msgspec-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:23a6ec2a3b5038c233b04740a545856a068bc5cb8db184ff493a58e08c994fbf"},
     {file = "msgspec-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cde2c41ed3eaaef6146365cb0d69580078a19f974c6cb8165cc5dcd5734f573e"},
@@ -3376,6 +3434,7 @@ files = [
 test = ["pytest", "pytest-cov"]
 
 [extras]
+attrs = ["attrs", "msgspec"]
 jwt = ["pyjwt"]
 msgspec = ["msgspec"]
 openapi = ["openapi-spec-validator", "polyfactory"]
@@ -3384,4 +3443,4 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "0df4066965068d89d46575d3a8b821b9808b12329d1bc5260f985abc3c8309a9"
+content-hash = "4f0c574abbaf59ff0e9227272671ba7f3819bcf81c5e0740aa7a426cc5737700"

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,7 +50,7 @@ version = "3.11.1"
 description = "ASGI specs, helper code, and adapters"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"},
     {file = "asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce"},
@@ -81,7 +81,7 @@ version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -109,7 +109,7 @@ version = "26.1.0"
 description = "Composable complex class support for attrs and dataclasses."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["docs"]
 files = [
     {file = "cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096"},
     {file = "cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40"},
@@ -653,7 +653,7 @@ version = "5.2.12"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7"},
     {file = "django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb"},
@@ -674,7 +674,7 @@ version = "26.5"
 description = "Your type-safe wrapper around Django's liquid core."
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["docs"]
 files = [
     {file = "django_mantle-26.5-py2.py3-none-any.whl", hash = "sha256:eea7e660b79e3e109920fb37b6d29242f8f7e0adc609a2f097c7e26f7c6a9776"},
     {file = "django_mantle-26.5.tar.gz", hash = "sha256:c253b9292b3fc5a89f18e4d3c86a38d63f92405ccc6f75f4bffea388c776ed15"},
@@ -690,7 +690,7 @@ version = "2.5.1"
 description = "A lightweight function-oriented toolkit for better organisation of business logic and efficient selection and projection of data in Django projects."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["docs"]
 files = [
     {file = "django_readers-2.5.1-py3-none-any.whl", hash = "sha256:af0d043403458cf66c0313f9b594b24e87a8781057510de1c95f54b1051268d9"},
     {file = "django_readers-2.5.1.tar.gz", hash = "sha256:b00529c73842b4af69d3e44f6c362dc4ce8122cbda9b85034216a1236c26a56a"},
@@ -3192,7 +3192,7 @@ version = "0.5.5"
 description = "A non-validating SQL parser."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"},
     {file = "sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e"},
@@ -3315,7 +3315,6 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {docs = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -3339,12 +3338,12 @@ version = "2025.3"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
     {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
 ]
-markers = {main = "extra == \"openapi\" and platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "extra == \"openapi\" and platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\"", docs = "sys_platform == \"win32\""}
 
 [[package]]
 name = "urllib3"
@@ -3443,4 +3442,4 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "4f0c574abbaf59ff0e9227272671ba7f3819bcf81c5e0740aa7a426cc5737700"
+content-hash = "8e2e8b9068f8388a71464b1f69596c534990cbc100b9015b7e6a4a7290b89fcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,6 @@ polyfactory = "^3.2"
 
 httpx = "^0.28"
 xmltodict = "^1.0"
-django-mantle = "^26.5"
-cattrs = "^26.1"
-django-readers = "^2.5"
 
 [tool.poetry.group.docs]
 optional = true
@@ -127,6 +124,9 @@ httpx = "^0.28"
 
 # Needed for examples:
 xmltodict = "^1.0"
+django-mantle = "^26.5"
+cattrs = "^26.1"
+django-readers = "^2.5"
 
 
 [tool.poetry.plugins."pytest11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,14 +54,16 @@ typing_extensions = ">=4"
 django = ">=5.2,<6.1"
 
 msgspec = { version = ">=0.19", optional = true }
-pydantic = { version = "^2.12", optional = true, extras = ["email"] }
+pydantic = { version = ">=2.12", optional = true, extras = ["email"] }
 pyjwt = { version = ">=2.11", optional = true, extras = ["crypto"] }
-openapi-spec-validator = { version = "^0.8", optional = true }
-polyfactory = { version = "^3.2", optional = true }
+openapi-spec-validator = { version = ">=0.8", optional = true }
+polyfactory = { version = ">=3.2", optional = true }
+attrs = { version = ">=26.0", optional = true }
 
 [tool.poetry.extras]
 pydantic = ["pydantic"]
 msgspec = ["msgspec"]
+attrs = ["msgspec", "attrs"]
 jwt = ["pyjwt"]
 openapi = ["openapi-spec-validator", "polyfactory"]
 
@@ -96,6 +98,9 @@ polyfactory = "^3.2"
 
 httpx = "^0.28"
 xmltodict = "^1.0"
+django-mantle = "^26.5"
+cattrs = "^26.1"
+django-readers = "^2.5"
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_attrs.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_attrs.ambr
@@ -1,0 +1,186 @@
+# serializer version: 1
+# name: test_auth_and_cookies_schema
+  '''
+  {
+    "info": {
+      "title": "Django Modern Rest",
+      "version": "0.1.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {
+      "/api/cookies": {
+        "post": {
+          "operationId": "postUsercontrollerApiCookies",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_UserModel"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/_UserResponseModel"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Raised when request components cannot be parsed",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Raised when returned response does not match the response schema",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Raised when provided `Accept` header cannot be satisfied",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            }
+          },
+          "deprecated": false
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "_UserModel": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "first_name": {
+              "type": "string"
+            },
+            "last_name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "required": [
+            "email",
+            "first_name",
+            "last_name",
+            "age"
+          ],
+          "title": "_UserModel"
+        },
+        "_UserResponseModel": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "first_name": {
+              "type": "string"
+            },
+            "last_name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer"
+            },
+            "uid": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "status": {
+              "$ref": "#/components/schemas/_UserStatus"
+            }
+          },
+          "type": "object",
+          "required": [
+            "email",
+            "first_name",
+            "last_name",
+            "age",
+            "uid",
+            "status"
+          ],
+          "title": "_UserResponseModel"
+        },
+        "_UserStatus": {
+          "enum": [
+            0,
+            1
+          ],
+          "title": "_UserStatus"
+        },
+        "ErrorModel": {
+          "properties": {
+            "detail": {
+              "items": {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "required": [
+            "detail"
+          ],
+          "title": "ErrorModel",
+          "description": "Default error response schema.\n\nCan be customized.\nSee :ref:`customizing-error-messages` for more details."
+        },
+        "ErrorDetail": {
+          "properties": {
+            "loc": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "msg"
+          ],
+          "title": "ErrorDetail",
+          "description": "Base schema for error details description."
+        }
+      },
+      "securitySchemes": {}
+    }
+  }
+  '''
+# ---

--- a/tests/test_unit/test_plugins/test_msgspec/test_attrs.py
+++ b/tests/test_unit/test_plugins/test_msgspec/test_attrs.py
@@ -1,0 +1,170 @@
+import enum
+import json
+import uuid
+from http import HTTPStatus
+
+import pytest
+from dirty_equals import IsUUID
+from django.http import HttpResponse
+from django.urls import path
+from faker import Faker
+from inline_snapshot import snapshot
+from syrupy.assertion import SnapshotAssertion
+
+from dmr import Body, Controller
+from dmr.openapi import build_schema
+from dmr.routing import Router
+
+try:
+    import msgspec  # noqa: F401
+except ImportError:  # pragma: no cover
+    pytest.skip(reason='msgspec is not installed', allow_module_level=True)
+
+import attrs
+
+from dmr.plugins.msgspec import MsgspecSerializer
+from dmr.test import DMRRequestFactory
+
+
+@attrs.define
+class _UserModel:
+    email: str
+    first_name: str
+    last_name: str
+    age: int
+
+
+@enum.unique
+class _UserStatus(enum.IntEnum):
+    active = 0
+    inactive = 1
+
+
+@attrs.define
+class _UserResponseModel(_UserModel):
+    uid: uuid.UUID
+    status: _UserStatus
+
+
+class _UserController(
+    Controller[MsgspecSerializer],
+    Body[_UserModel],
+):
+    def post(self) -> _UserResponseModel:
+        return _UserResponseModel(
+            uid=uuid.uuid4(),
+            status=_UserStatus.active,
+            email=self.parsed_body.email,
+            first_name=self.parsed_body.first_name,
+            last_name=self.parsed_body.last_name,
+            age=self.parsed_body.age,
+        )
+
+
+def test_correct_serializer(
+    dmr_rf: DMRRequestFactory,
+    faker: Faker,
+) -> None:
+    """Ensures the correct parsing works."""
+    request_data = {
+        'email': faker.email(),
+        'first_name': faker.name(),
+        'last_name': faker.name(),
+        'age': faker.pyint(),
+    }
+    request = dmr_rf.post('/whatever/', data=request_data)
+    response = _UserController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.CREATED, response.content
+    assert json.loads(response.content) == {
+        'uid': IsUUID,
+        'status': _UserStatus.active.value,
+        **request_data,
+    }
+
+
+def test_missing_fields(
+    dmr_rf: DMRRequestFactory,
+    faker: Faker,
+) -> None:
+    """Ensures the missing fields raise."""
+    request = dmr_rf.post('/whatever/', data={})
+    response = _UserController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.content
+    assert json.loads(response.content) == snapshot({
+        'detail': [
+            {
+                'msg': (
+                    'Object missing required field `email` - at `$.parsed_body`'
+                ),
+                'type': 'value_error',
+            },
+        ],
+    })
+
+
+def test_wrong_types_serializer(
+    dmr_rf: DMRRequestFactory,
+    faker: Faker,
+) -> None:
+    """Ensures the wrong types raise."""
+    request_data = {
+        'email': faker.email(),
+        'first_name': faker.name(),
+        'last_name': faker.name(),
+        'age': 'wrong',
+    }
+    request = dmr_rf.post('/whatever/', data=request_data)
+    response = _UserController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.content
+    assert json.loads(response.content) == snapshot({
+        'detail': [
+            {
+                'msg': 'Expected `int`, got `str` - at `$.parsed_body.age`',
+                'type': 'value_error',
+            },
+        ],
+    })
+
+
+def test_auth_and_cookies_schema(snapshot: SnapshotAssertion) -> None:
+    """Ensure that schema is correct for authed and cookies controller."""
+    assert (
+        json.dumps(
+            build_schema(
+                Router(
+                    'api/',
+                    [path('/cookies', _UserController.as_view())],
+                ),
+            ).convert(),
+            indent=2,
+        )
+        == snapshot
+    )
+
+
+class _ResponseValidationController(Controller[MsgspecSerializer]):
+    def get(self) -> str:
+        return 1  # type: ignore[return-value]
+
+
+def test_wrong_response_validation(
+    dmr_rf: DMRRequestFactory,
+    faker: Faker,
+) -> None:
+    """Ensures the wrong types raise."""
+    request = dmr_rf.get('/whatever/')
+    response = _ResponseValidationController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, (
+        response.content
+    )
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Expected `str`, got `int`', 'type': 'value_error'}],
+    })

--- a/tests/test_unit/test_plugins/test_msgspec/test_serializers.py
+++ b/tests/test_unit/test_plugins/test_msgspec/test_serializers.py
@@ -1,3 +1,4 @@
+import json
 from http import HTTPStatus
 from typing import Any
 
@@ -14,14 +15,6 @@ except ImportError:  # pragma: no cover
 from dmr import Body, Controller
 from dmr.plugins.msgspec import MsgspecSerializer
 from dmr.test import DMRRequestFactory
-
-
-class _ForTestError(Exception):
-    """Testing as custom error from built-in exception."""
-
-
-class _ForTestMsgSpecError(msgspec.ValidationError):
-    """Testing as custom error from msgspec.ValidationError."""
 
 
 class _MsgSpecUserModel(msgspec.Struct):
@@ -49,6 +42,15 @@ def test_serializer_via_endpoint(
 
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.CREATED, response.content
+    assert json.loads(response.content) == {'email': email}
+
+
+class _ForTestError(Exception):
+    """Testing as custom error from built-in exception."""
+
+
+class _ForTestMsgSpecError(msgspec.ValidationError):
+    """Testing as custom error from msgspec.ValidationError."""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi, @carltongibson, long time no see 👋 

I integrated `django-mantle` into our documentation to show how to convert `QuerySet` into typed `attrs` object.

But, there are several problems as of right now, so I want to share my feedback here (sorry, I tried to do that on the project's main page, but I don't have an account there and have no idea what "codenberg" is).

So, what problems did I face?

1. `py.typed` file is missing from `django_mantle/src` folder, without it `mypy` does not recognize annotations from this module
2. `attrs`, `cattrs`, and `django-readers` are not listed as depedencies of `django-mantle`, forcing users to install 4 different projects is kinda hard, I guess :)

Other than that - the project looks really cool and I am looking for to trying it on some real project.

If you can mention `django-modern-rest` in `django-mantle` docs, it would be VERY cool. Because this integration looks very promising.

P.S. We are accepting [testimonials](https://github.com/wemake-services/django-modern-rest?tab=readme-ov-file#testimonials) for `django-modern-rest`, if you feel like it :)