### PR TITLE
docs: add copy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There are several included extras:
 
 ## Example
 
-The [shortest example](https://github.com/wemake-services/django-modern-rest/blob/master/docs/examples/getting_started/pydantic_controller.py):
+The shortest example [(click here to copy the whole file)](https://github.com/wemake-services/django-modern-rest/blob/master/docs/examples/getting_started/pydantic_controller.py):
 
 ```python
 >>> import uuid


### PR DESCRIPTION
 Follow-up to #716. Instead of removing doctest-style formatting, add an explicit "click here to copy the whole file" link as suggested by @sobolevn 