### PR TITLE
Add `set_cookies` function

### DIFF
--- a/dmr/cookies.py
+++ b/dmr/cookies.py
@@ -161,7 +161,7 @@ class NewCookie(_BaseCookie):
 
 def set_cookies(
     response: HttpResponseBase,
-    cookies: Mapping[str, NewCookie] | None = None,
+    cookies: Mapping[str, NewCookie] | None,
 ) -> None:
     """Set cookies for the HTTP response."""
     if cookies:

--- a/dmr/cookies.py
+++ b/dmr/cookies.py
@@ -28,8 +28,11 @@
 # SOFTWARE.
 
 import dataclasses
+from collections.abc import Mapping
 from http.cookies import Morsel, SimpleCookie
 from typing import Any, ClassVar, Literal, final
+
+from django.http import HttpResponseBase
 
 
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
@@ -154,3 +157,13 @@ class NewCookie(_BaseCookie):
     def as_dict(self) -> dict[str, Any]:
         """Converts to a dictionary ."""
         return dataclasses.asdict(self)
+
+
+def set_cookies(
+    response: HttpResponseBase,
+    cookies: Mapping[str, NewCookie] | None = None,
+) -> None:
+    """Set cookies for the HTTP response."""
+    if cookies:
+        for cookie_key, cookie in cookies.items():
+            response.set_cookie(cookie_key, **cookie.as_dict())

--- a/dmr/response.py
+++ b/dmr/response.py
@@ -9,7 +9,7 @@ from django.utils.encoding import iri_to_uri
 from django.utils.http import MAX_URL_REDIRECT_LENGTH
 from typing_extensions import TypeVar
 
-from dmr.cookies import NewCookie
+from dmr.cookies import NewCookie, set_cookies
 from dmr.settings import Settings, resolve_setting
 
 if TYPE_CHECKING:
@@ -253,9 +253,7 @@ def build_response(  # noqa: WPS210, WPS211
         status=status,
         headers=response_headers,
     )
-    if cookies:
-        for cookie_key, cookie in cookies.items():
-            response.set_cookie(cookie_key, **cookie.as_dict())
+    set_cookies(response, cookies)
     return response
 
 

--- a/dmr/streaming/controller.py
+++ b/dmr/streaming/controller.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseBase
 from typing_extensions import override
 
 from dmr.controller import Controller
-from dmr.cookies import NewCookie
+from dmr.cookies import NewCookie, set_cookies
 from dmr.endpoint import Endpoint
 from dmr.internal.types import call_init_subclass
 from dmr.negotiation import request_renderer
@@ -169,12 +169,7 @@ class StreamingController(Controller[_SerializerT_co]):
                 )
             ),
         )
-        # TODO: move to `set_cookies` function?
-        for cookie_key, cookie in (cookies or {}).items():
-            streaming_response.set_cookie(
-                cookie_key,
-                **cookie.as_dict(),
-            )
+        set_cookies(streaming_response, cookies)
         return streaming_response
 
     def ping_event(self) -> Any | None:

--- a/docs/pages/deep-dive/public-api.rst
+++ b/docs/pages/deep-dive/public-api.rst
@@ -54,6 +54,9 @@ Response, headers and cookies
 .. autoclass:: dmr.cookies.NewCookie
   :members:
 
+.. autofunction:: dmr.cookies.set_cookies
+  :members:
+
 
 Validation
 ----------

--- a/docs/pages/deep-dive/public-api.rst
+++ b/docs/pages/deep-dive/public-api.rst
@@ -55,7 +55,6 @@ Response, headers and cookies
   :members:
 
 .. autofunction:: dmr.cookies.set_cookies
-  :members:
 
 
 Validation


### PR DESCRIPTION
Closes #773

I added the public helper function `set_cookies` to `dmr.cookies` and documented it in `public-api.rst`.