### PR TITLE
Try to compile `parse_headers`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ package: ## Check package dependencies with pip
 
 .PHONY: benchmarks-type-check
 benchmarks-type-check: ## Run type check on benches
-	uv run mypy -p benchmarks.tests
+	cd benchmarks && uv run mypy tests/
 
 .PHONY: benchmarks
 benchmarks: mypyc ## Run feature benches

--- a/benchmarks/tests/test_compiled/conftest.py
+++ b/benchmarks/tests/test_compiled/conftest.py
@@ -1,0 +1,39 @@
+import sys
+from collections.abc import Callable, Iterator, Set
+from contextlib import AbstractContextManager, contextmanager
+from types import ModuleType
+from typing import Final, TypeAlias
+
+import pytest
+
+CleanModules: TypeAlias = Callable[
+    [],
+    AbstractContextManager[dict[str, ModuleType]],
+]
+
+_COMPILED_MODULES: Final = frozenset((
+    'dmr.envs',
+    'dmr.compiled',
+    'dmr._compiled',
+))
+
+
+@pytest.fixture
+def clean_modules() -> CleanModules:
+    """Fixture to clean required modules."""
+
+    @contextmanager
+    def factory(
+        names: Set[str] = _COMPILED_MODULES,
+    ) -> Iterator[dict[str, ModuleType]]:
+        orig_modules = {}
+        prefixes = tuple(f'{name}.' for name in names)
+        for modname in list(sys.modules):
+            if modname in names or modname.startswith(prefixes):
+                orig_modules[modname] = sys.modules.pop(modname)
+
+        yield orig_modules
+
+        sys.modules.update(orig_modules)
+
+    return factory

--- a/benchmarks/tests/test_compiled/test_negotiation.py
+++ b/benchmarks/tests/test_compiled/test_negotiation.py
@@ -1,42 +1,13 @@
-import sys
-from collections.abc import Callable, Iterator, Set
-from contextlib import AbstractContextManager, contextmanager
-from types import ModuleType
-from typing import Final, TypeAlias
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
 
 import pytest
 from django.http import HttpRequest
 from pytest_codspeed import BenchmarkFixture
 
-_CleanModules: TypeAlias = Callable[
-    [set[str]],
-    AbstractContextManager[dict[str, ModuleType]],
-]
-
-_COMPILED_MODULES: Final = frozenset((
-    'dmr.envs',
-    'dmr.compiled',
-    'dmr._compiled',
-))
-
-
-@pytest.fixture
-def clean_modules() -> _CleanModules:
-    """Fixture to clean required modules."""
-
-    @contextmanager
-    def factory(names: Set[str]) -> Iterator[dict[str, ModuleType]]:
-        orig_modules = {}
-        prefixes = tuple(f'{name}.' for name in names)
-        for modname in list(sys.modules):
-            if modname in names or modname.startswith(prefixes):
-                orig_modules[modname] = sys.modules.pop(modname)
-
-        yield orig_modules
-
-        sys.modules.update(orig_modules)
-
-    return factory
+if TYPE_CHECKING:
+    from conftest import CleanModules
 
 
 _ACCEPTED_TYPE_CASES: Final = (
@@ -64,13 +35,13 @@ _ACCEPTED_TYPE_CASES: Final = (
 def test_negotiation_compiled(
     benchmark: BenchmarkFixture,
     monkeypatch: pytest.MonkeyPatch,
-    clean_modules: _CleanModules,
+    clean_modules: CleanModules,
 ) -> None:
     """Test compiled version of the negotiation protocol."""
 
     monkeypatch.setenv('DMR_USE_COMPILED', '1')
 
-    with clean_modules(_COMPILED_MODULES):
+    with clean_modules():
         from dmr._compiled import negotiation  # noqa: PLC0415, PLC2701
 
         assert negotiation.__file__.endswith('.so')
@@ -88,13 +59,13 @@ def test_negotiation_compiled(
 def test_negotiation_raw(
     benchmark: BenchmarkFixture,
     monkeypatch: pytest.MonkeyPatch,
-    clean_modules: _CleanModules,
+    clean_modules: CleanModules,
 ) -> None:
     """Test raw version of the negotiation protocol."""
 
     monkeypatch.setenv('DMR_USE_COMPILED', '0')
 
-    with clean_modules(_COMPILED_MODULES):
+    with clean_modules():
         from dmr.compiled import accepted_type  # noqa: PLC0415
 
         assert '_pure' in accepted_type.__module__

--- a/dmr/_compiled/README.md
+++ b/dmr/_compiled/README.md
@@ -10,6 +10,7 @@ But, we still provide a fallback to regular Python code:
 2. Some runtimes run Python code faster than compiled
 3. Some people might prefer to monkeypatch something in regular Python code
 
+
 ## What we compile
 
 We only compile code that makes sense to be compiled.
@@ -24,3 +25,8 @@ Criteria:
    otherwise - compilation will not have much effect
 5. Does not have complex typing
 6. Have no external dependencies
+
+
+## How
+
+Run `make mypyc` to run the compilation.

--- a/dmr/compiled.py
+++ b/dmr/compiled.py
@@ -1,3 +1,10 @@
+"""
+Re-exports compiled parts.
+
+Uses smart exporting: define ``USE_COMPILED=0`` env var
+to disable compiled parts.
+"""
+
 from typing import TYPE_CHECKING
 
 from dmr.envs import USE_COMPILED

--- a/dmr/components.py
+++ b/dmr/components.py
@@ -528,7 +528,7 @@ class HeadersComponent(ComponentParser):
             '__dmr_split_commas__',
             None,
         )
-        if split_commas is None:
+        if not split_commas:
             return controller.request.headers
         return parse_headers(
             controller.request.headers,

--- a/dmr/internal/django.py
+++ b/dmr/internal/django.py
@@ -53,19 +53,16 @@ _UTF8_REQUIRED_MSG: Final = _(
 
 
 def parse_headers(
-    headers: 'CaseInsensitiveMapping[str]',
-    *,
+    headers: CaseInsensitiveMapping[str],
     split_commas: frozenset[str],
-) -> 'CaseInsensitiveMapping[Any]':
+) -> CaseInsensitiveMapping[str | list[str]]:
     """
     Split headers specified in *split_commas* on ``','`` char.
 
     Make sure that all headers in *split_commas* have lower-case names.
+    Do not pass empty *split_commas* parameter.
     """
-    if not split_commas:
-        return headers
-
-    parsed_headers: dict[str, Any] = {}
+    parsed_headers: dict[str, str | list[str]] = {}
     for header_key, header_value in headers.items():
         if header_key.lower() in split_commas:
             parsed_headers[header_key] = header_value.split(',')


### PR DESCRIPTION
It does not really make sense:
<img width="788" height="533" alt="Снимок экрана 2026-04-05 в 00 58 32" src="https://github.com/user-attachments/assets/b208e76c-9eef-4c15-94b9-442a69020532" />


Bench:

```python
from __future__ import annotations

from typing import TYPE_CHECKING, Final

import pytest
from django.utils.datastructures import CaseInsensitiveMapping
from pytest_codspeed import BenchmarkFixture

if TYPE_CHECKING:
    from conftest import CleanModules


_CASES: Final = [
    (
        CaseInsensitiveMapping({'a': '1,2,3,4'}),
        frozenset(('a',)),
        CaseInsensitiveMapping({'a': ['1', '2', '3', '4']}),
    ),
    (
        CaseInsensitiveMapping({'a': '1,2,3,4', 'b': '', 'c': 'text'}),
        frozenset(),
        CaseInsensitiveMapping({'a': '1,2,3,4', 'b': '', 'c': 'text'}),
    ),
    (
        CaseInsensitiveMapping({'a': '1,2,3,4'}),
        frozenset(('b', 'c')),
        CaseInsensitiveMapping({'a': '1,2,3,4'}),
    ),
    (
        CaseInsensitiveMapping({
            'a': '1,2,3,4',
            'b': '',
            'c': 'text',
            'd': ',',
        }),
        frozenset(('a', 'b', 'c', 'd')),
        CaseInsensitiveMapping({
            'a': ['1', '2', '3', '4'],
            'b': [''],
            'c': ['text'],
            'd': ['', ''],
        }),
    ),
    (
        CaseInsensitiveMapping({}),
        frozenset(('a', 'b', 'c')),
        CaseInsensitiveMapping({}),
    ),
    (
        CaseInsensitiveMapping({'a': '1,2,3,4', 'b': '5, 6, 7'}),
        frozenset(('a', 'b', 'c')),
        CaseInsensitiveMapping({
            'a': ['1', '2', '3', '4'],
            'b': ['5', ' 6', ' 7'],
        }),
    ),
]


def test_parse_headers_compiled(
    benchmark: BenchmarkFixture,
    monkeypatch: pytest.MonkeyPatch,
    clean_modules: CleanModules,
) -> None:
    """Test compiled version of the parse_headers."""

    monkeypatch.setenv('DMR_USE_COMPILED', '1')

    with clean_modules():
        from dmr._compiled import components_parsing  # noqa: PLC0415, PLC2701

        assert components_parsing.__file__.endswith('.so')

        from dmr.compiled import parse_headers  # noqa: PLC0415

        assert '_pure' not in parse_headers.__module__

        @benchmark
        def factory() -> None:
            for headers, split_commas, expected in _CASES:
                assert parse_headers(headers, split_commas) == expected


def test_parse_headers_raw(
    benchmark: BenchmarkFixture,
    monkeypatch: pytest.MonkeyPatch,
    clean_modules: CleanModules,
) -> None:
    """Test raw version of the parse_headers function."""

    monkeypatch.setenv('DMR_USE_COMPILED', '0')

    with clean_modules():
        from dmr.compiled import parse_headers  # noqa: PLC0415

        assert '_pure' in parse_headers.__module__

        @benchmark
        def factory() -> None:
            for headers, split_commas, expected in _CASES:
                assert parse_headers(headers, split_commas) == expected

```