### PR TITLE
Add better tests for `MultiValueDict` parsing

### DIFF
--- a/tests/test_unit/test_internal/test_django/test_multivalue.py
+++ b/tests/test_unit/test_internal/test_django/test_multivalue.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import pytest
+from django.utils.datastructures import MultiValueDict
+
+from dmr.internal.django import convert_multi_value_dict
+
+
+@pytest.mark.parametrize(
+    ('to_parse', 'force_list', 'cast_null', 'split_commas', 'expected'),
+    [
+        (
+            MultiValueDict(),
+            frozenset(),
+            frozenset(),
+            None,
+            {},
+        ),
+        (
+            MultiValueDict(),
+            frozenset(),
+            frozenset(),
+            frozenset(),
+            {},
+        ),
+        (
+            MultiValueDict(),
+            frozenset(('name',)),
+            frozenset(('name',)),
+            frozenset(('name',)),
+            {},
+        ),
+        (
+            MultiValueDict({'name': ['a', 'b'], 'empty': []}),
+            frozenset(),
+            frozenset(),
+            frozenset(),
+            {'name': 'b', 'empty': []},
+        ),
+        (
+            MultiValueDict({'name': ['a', 'b'], 'other': [], 'single': [1]}),  # type: ignore[arg-type]
+            frozenset(('name',)),
+            frozenset(),
+            frozenset(),
+            {'name': ['a', 'b'], 'other': [], 'single': 1},
+        ),
+        (
+            MultiValueDict({'name': ['a', 'b'], 'other': [], 'single': [1]}),  # type: ignore[arg-type]
+            frozenset(('name', 'other', 'single')),
+            frozenset(),
+            frozenset(),
+            {'name': ['a', 'b'], 'other': [], 'single': [1]},
+        ),
+        (
+            MultiValueDict({'name': ['null'], 'other': ['null']}),
+            frozenset(),
+            frozenset(('name',)),
+            frozenset(),
+            {'name': None, 'other': 'null'},
+        ),
+        (
+            MultiValueDict({'name': ['a', 'b', 'null']}),
+            frozenset(('name', 'other')),
+            frozenset(('name', 'other')),
+            frozenset(),
+            {'name': ['a', 'b', None]},
+        ),
+        (
+            MultiValueDict({'name': ['1,2,3,4,5'], 'other': ['6,7']}),
+            frozenset(),
+            frozenset(),
+            frozenset(('name',)),
+            {'name': ['1', '2', '3', '4', '5'], 'other': '6,7'},
+        ),
+        (
+            MultiValueDict({'name': ['1,2,3,4,5'], 'other': ['6,7']}),
+            frozenset(),
+            frozenset(('name',)),
+            frozenset(('name', 'missing')),
+            {'name': ['1', '2', '3', '4', '5'], 'other': '6,7'},
+        ),
+        (
+            MultiValueDict({'name': ['1,2,3,4,5'], 'other': ['6,7']}),
+            frozenset(('name',)),
+            frozenset(),
+            frozenset(('name',)),
+            {'name': ['1,2,3,4,5'], 'other': '6,7'},
+        ),
+    ],
+)
+def test_convert_multi_value_dict(
+    *,
+    to_parse: 'MultiValueDict[str, Any]',
+    force_list: frozenset[str],
+    cast_null: frozenset[str],
+    split_commas: frozenset[str] | None,
+    expected: dict[str, Any],
+) -> None:
+    """Test multivalue dict works correctly."""
+    assert (
+        convert_multi_value_dict(
+            to_parse,
+            force_list=force_list,
+            cast_null=cast_null,
+            split_commas=split_commas,
+        )
+        == expected
+    )


### PR DESCRIPTION
I tried to compile this feature, but it was not good:

<img width="788" height="533" alt="Снимок экрана 2026-04-05 в 13 02 40" src="https://github.com/user-attachments/assets/9ad19314-5a5a-4f57-bbb4-0a89f24aa935" />


```python
from __future__ import annotations

from typing import TYPE_CHECKING, Final

import pytest
from django.utils.datastructures import MultiValueDict
from pytest_codspeed import BenchmarkFixture

if TYPE_CHECKING:
    from conftest import CleanModules


_CASES: Final = [
    (
        MultiValueDict(),
        frozenset(),
        frozenset(),
        None,
        {},
    ),
    (
        MultiValueDict(),
        frozenset(),
        frozenset(),
        frozenset(),
        {},
    ),
    (
        MultiValueDict({'name': ['a', 'b'], 'empty': []}),
        frozenset(),
        frozenset(),
        frozenset(),
        {'name': 'b', 'empty': []},
    ),
    (
        MultiValueDict({'name': ['a', 'b'], 'other': [], 'single': [1]}),
        frozenset(('name',)),
        frozenset(),
        frozenset(),
        {'name': ['a', 'b'], 'other': [], 'single': 1},
    ),
    (
        MultiValueDict({'name': ['a', 'b'], 'other': [], 'single': [1]}),
        frozenset(('name', 'other', 'single')),
        frozenset(),
        frozenset(),
        {'name': ['a', 'b'], 'other': [], 'single': [1]},
    ),
    (
        MultiValueDict({'name': ['null'], 'other': ['null']}),
        frozenset(),
        frozenset(('name',)),
        frozenset(),
        {'name': None, 'other': 'null'},
    ),
    (
        MultiValueDict({'name': ['a', 'b', 'null']}),
        frozenset(('name',)),
        frozenset(('name',)),
        frozenset(),
        {'name': ['a', 'b', None]},
    ),
    (
        MultiValueDict({'name': ['1,2,3,4,5'], 'other': ['6,7']}),
        frozenset(),
        frozenset(),
        frozenset(('name',)),
        {'name': ['1', '2', '3', '4', '5'], 'other': '6,7'},
    ),
    (
        MultiValueDict({'name': ['1,2,3,4,5'], 'other': ['6,7']}),
        frozenset(('name',)),
        frozenset(),
        frozenset(('name',)),
        {'name': ['1,2,3,4,5'], 'other': '6,7'},
    ),
]

_REPEAT: Final = 1_000_000


def test_multivalue_compiled(
    benchmark: BenchmarkFixture,
    monkeypatch: pytest.MonkeyPatch,
    clean_modules: CleanModules,
) -> None:
    """Test compiled version of the multivalue dict."""

    monkeypatch.setenv('DMR_USE_COMPILED', '1')

    with clean_modules():
        from dmr._compiled import multivalue  # noqa: PLC0415, PLC2701

        assert multivalue.__file__.endswith('.so')

        from dmr.compiled import convert_multi_value_dict  # noqa: PLC0415

        assert '_pure' not in convert_multi_value_dict.__module__

        @benchmark
        def factory() -> None:
            for _repeat in range(_REPEAT):
                for (
                    to_parse,
                    force_list,
                    cast_null,
                    split_commas,
                    expected,
                ) in _CASES:
                    assert (
                        convert_multi_value_dict(
                            to_parse,
                            force_list,
                            cast_null,
                            split_commas,
                        )
                        == expected
                    )


def test_multivalue_raw(
    benchmark: BenchmarkFixture,
    monkeypatch: pytest.MonkeyPatch,
    clean_modules: CleanModules,
) -> None:
    """Test raw version of the multivalue dict."""

    monkeypatch.setenv('DMR_USE_COMPILED', '0')

    with clean_modules():
        from dmr.compiled import convert_multi_value_dict  # noqa: PLC0415

        assert '_pure' in convert_multi_value_dict.__module__

        @benchmark
        def factory() -> None:
            for _repeat in range(_REPEAT):
                for (
                    to_parse,
                    force_list,
                    cast_null,
                    split_commas,
                    expected,
                ) in _CASES:
                    assert (
                        convert_multi_value_dict(
                            to_parse,
                            force_list,
                            cast_null,
                            split_commas,
                        )
                        == expected
                    )

```