### PR TITLE
more compiled stuff

### DIFF
--- a/benchmarks/tests/test_compiled/test_security.py
+++ b/benchmarks/tests/test_compiled/test_security.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from base64 import b64encode
+from typing import TYPE_CHECKING, Final
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+
+if TYPE_CHECKING:
+    from conftest import CleanModules
+
+
+_CASES: Final = (
+    # basic cases
+    ('admin', 'pass', 'Basic ', 'Basic YWRtaW46cGFzcw=='),
+    ('user', '1234', 'Basic ', 'Basic dXNlcjoxMjM0'),
+    # no prefix
+    ('admin', 'pass', '', 'YWRtaW46cGFzcw=='),
+    # custom prefix
+    ('admin', 'pass', 'Bearer ', 'Bearer YWRtaW46cGFzcw=='),
+    # empty username / password
+    ('', '', 'Basic ', 'Basic Og=='),  # ":"
+    ('user', '', 'Basic ', 'Basic dXNlcjo='),  # "user:"
+    ('', 'pass', 'Basic ', 'Basic OnBhc3M='),  # ":pass"
+    # special characters
+    ('user', 'p@ss:word', 'Basic ', 'Basic dXNlcjpwQHNzOndvcmQ='),
+    ('üser', 'päss', 'Basic ', 'Basic w7xzZXI6cMOkc3M='),
+    # whitespace
+    (' user ', ' pass ', 'Basic ', 'Basic IHVzZXIgOiBwYXNzIA=='),
+    # long values
+    *tuple(
+        (
+            'a' * n,
+            'b' * n,
+            'Basic ',
+            'Basic ' + b64encode(f'{"a" * n}:{"b" * n}'.encode()).decode(),
+        )
+        for n in range(10, 101, 10)
+    ),
+)
+
+
+def test_basic_auth_compiled(
+    benchmark: BenchmarkFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_modules: CleanModules,
+) -> None:
+    """Test compiled version of the basic_auth."""
+
+    monkeypatch.setenv('DMR_USE_COMPILED', '1')
+
+    with clean_modules():
+        from dmr._compiled import security  # noqa: PLC0415, PLC2701
+
+        assert security.__file__.endswith('.so')
+
+        from dmr.compiled import basic_auth  # noqa: PLC0415
+
+        assert '_pure' not in basic_auth.__module__
+
+        @benchmark
+        def factory() -> None:
+            for username, password, prefix, expected in _CASES:
+                assert basic_auth(username, password, prefix=prefix) == expected
+
+
+def test_basic_auth_raw(
+    benchmark: BenchmarkFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_modules: CleanModules,
+) -> None:
+    """Test raw version of the basic_auth."""
+
+    monkeypatch.setenv('DMR_USE_COMPILED', '0')
+
+    with clean_modules():
+        from dmr.compiled import basic_auth  # noqa: PLC0415
+
+        assert '_pure' in basic_auth.__module__
+
+        @benchmark
+        def factory() -> None:
+            for username, password, prefix, expected in _CASES:
+                assert basic_auth(username, password, prefix=prefix) == expected

--- a/dmr/_compiled/routing.py
+++ b/dmr/_compiled/routing.py
@@ -1,0 +1,43 @@
+import re
+from typing import Any, Protocol, TypeAlias
+
+_CapturedArgs: TypeAlias = tuple[Any, ...]
+_CapturedKwargs: TypeAlias = dict[str, int | str]
+_RouteMatch: TypeAlias = tuple[str, _CapturedArgs, _CapturedKwargs]
+
+
+class _HasSearch(Protocol):
+    @staticmethod
+    def search(inp: str) -> re.Match[str] | None: ...
+
+
+class _RoutePattern(Protocol):
+    _is_static: bool
+    _is_endpoint: bool
+    _prefix: str
+    converters: dict[str, Any]
+    regex: _HasSearch
+
+
+def match_impl(  # noqa: C901
+    self: _RoutePattern,
+    path: str,
+) -> _RouteMatch | None:
+    if self._is_static:
+        if self._is_endpoint and path == self._prefix:
+            return '', (), {}
+        if not self._is_endpoint and path.startswith(self._prefix):
+            return path[len(self._prefix) :], (), {}
+    elif path.startswith(self._prefix):
+        match = self.regex.search(path)
+        if match:
+            # RoutePattern doesn't allow non-named groups so args are ignored.
+            kwargs = match.groupdict()
+            for key, value in kwargs.items():
+                converter = self.converters[key]
+                try:
+                    kwargs[key] = converter.to_python(value)
+                except ValueError:
+                    return None
+            return path[match.end() :], (), kwargs
+    return None

--- a/dmr/_compiled/security.py
+++ b/dmr/_compiled/security.py
@@ -1,0 +1,20 @@
+try:
+    from librt.base64 import b64encode
+except ImportError:
+    from base64 import b64encode
+
+
+def basic_auth(username: str, password: str, *, prefix: str = 'Basic ') -> str:
+    """
+    Return a header value for basic auth for a given *username* and *password*.
+
+    .. code:: python
+
+      >>> basic_auth('admin', 'pass')
+      'Basic YWRtaW46cGFzcw=='
+
+      >>> basic_auth('admin', 'pass', prefix='')
+      'YWRtaW46cGFzcw=='
+
+    """
+    return prefix + b64encode((username + ':' + password).encode()).decode()

--- a/dmr/compiled.py
+++ b/dmr/compiled.py
@@ -11,9 +11,13 @@ from dmr.envs import USE_COMPILED
 
 if TYPE_CHECKING:
     from dmr._compiled.negotiation import accepted_type as accepted_type
+    from dmr._compiled.routing import match_impl as match_impl
+    from dmr._compiled.security import basic_auth as basic_auth
 
 if USE_COMPILED:
     from dmr._compiled.negotiation import accepted_type  # noqa: WPS474
+    from dmr._compiled.routing import match_impl  # noqa: WPS474
+    from dmr._compiled.security import basic_auth  # noqa: WPS474
 else:
     import sys
     import types
@@ -42,7 +46,11 @@ else:
         return mod
 
     # Add new objects here:
-    _mod = _import_pure('negotiation')
-    accepted_type = _mod.accepted_type
+    _negotiation_mod = _import_pure('negotiation')
+    accepted_type = _negotiation_mod.accepted_type
+    _security_mod = _import_pure('security')
+    basic_auth = _security_mod.basic_auth
+    _routing_mod = _import_pure('routing')
+    match_impl = _routing_mod.match_impl
 
-    del sys, types, _import_pure, _mod  # noqa: WPS420
+    del sys, types, _import_pure, _negotiation_mod, _security_mod, _routing_mod  # noqa: WPS420

--- a/dmr/routing.py
+++ b/dmr/routing.py
@@ -9,6 +9,7 @@ from django.utils.encoding import force_str
 from django.views import defaults
 from typing_extensions import override
 
+from dmr.compiled import match_impl
 from dmr.errors import ErrorType, format_error
 from dmr.exceptions import InternalServerError, NotAcceptableError
 from dmr.openapi.collector import controller_mapping_collector
@@ -249,14 +250,7 @@ class _PrefixRoutePattern(RoutePattern):
         self,
         path: str,
     ) -> _RouteMatch | None:
-        if self._is_static:
-            if self._is_endpoint and path == self._prefix:
-                return '', (), {}
-            if not self._is_endpoint and path.startswith(self._prefix):
-                return path[len(self._prefix) :], (), {}
-        elif path.startswith(self._prefix):
-            return super().match(path)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-        return None
+        return match_impl(self, path)
 
 
 # NOTE: keep in sync with `django-stubs`!


### PR DESCRIPTION
played with `security/http.py:basic_auth`: absolutely no difference, even when bundled with `librt`'s faster b64 implementation
the same for `routing.py`, no luck
at least on cpython 3.14

```
                                 Benchmark Results                                 
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃                      Benchmark ┃ Time (best) ┃ Rel. StdDev ┃ Run time ┃   Iters ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ test_negotiation_django_native │     40.58µs │       27.1% │    3.00s │  13,270 │
│      test_negotiation_compiled │       955ns │       22.6% │    3.00s │  92,194 │
│           test_negotiation_raw │      2.01µs │       39.4% │    2.97s │  61,740 │
│           test_router_path_dmr │      37.5ms │        5.0% │    2.81s │      71 │
│        test_router_path_native │      43.2ms │       13.2% │    3.01s │      67 │
│            test_basic_auth_raw │        44ns │       21.4% │    3.00s │ 431,568 │
│       test_basic_auth_compiled │        42ns │        8.3% │    2.93s │ 446,851 │
└────────────────────────────────┴─────────────┴─────────────┴──────────┴─────────┘
```