### PR TITLE
Update docs: remove bot refs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,6 +161,8 @@ Here are our amazing people who made this project possible.
     .. contributors:: wemake-services/django-modern-rest
         :avatars:
         :contributions:
+        :names:
+        :exclude: dependabot[bot],pre-commit-ci[bot],Copilot
 
 
 .. toctree::


### PR DESCRIPTION
# I have made things!

* Well, those are amaizing tools\helpers or whatever, but not people :rofl: 

* Also switched to displaying names if available, better and more humanistic than usernames imo

------------------

<img width="887" height="896" alt="image" src="https://github.com/user-attachments/assets/459dd1da-61c1-424c-81fd-02d2289a47bb" />


