### PR TITLE
i18n: add Japanese (ja) translation

### DIFF
--- a/dmr/locale/ja/LC_MESSAGES/django.po
+++ b/dmr/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,97 @@
+# django-modern-rest.
+# Copyright (C) 2026, wemake.services
+# This file is distributed under the same license as the PACKAGE package.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-12 14:21+0300\n"
+"PO-Revision-Date: 2026-04-14 05:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: dmr/components.py:54
+#, python-brace-format
+msgid ""
+"Path {cls} with field_model={field_model} does not allow unnamed path "
+"parameters args={args}"
+msgstr ""
+"パス {cls}（field_model={field_model}）は名前のないパスパラメータ "
+"args={args} を許可しません"
+
+#: dmr/components.py:59
+#, python-brace-format
+msgid ""
+"Trying to parse files with {parser_name} that does not support "
+"SupportsFileParsing protocol"
+msgstr ""
+"SupportsFileParsingプロトコルをサポートしていない {parser_name} で "
+"ファイルの解析を試みています"
+
+#: dmr/controller.py:33
+#, python-brace-format
+msgid "Method {method} is not allowed, allowed: {allowed}"
+msgstr "メソッド {method} は許可されていません。許可されているメソッド: {allowed}"
+
+#: dmr/exceptions.py:10
+msgid "Not authenticated"
+msgstr "認証されていません"
+
+#: dmr/exceptions.py:11
+msgid "Too many requests"
+msgstr "リクエストが多すぎます"
+
+#: dmr/exceptions.py:49
+msgid "Internal server error"
+msgstr "内部サーバーエラー"
+
+#: dmr/internal/django.py:49
+msgid ""
+"HTTP requests with the 'application/x-www-form-urlencoded' content type must "
+"be UTF-8 encoded."
+msgstr ""
+"コンテンツタイプ 'application/x-www-form-urlencoded' のHTTPリクエストは "
+"UTF-8でエンコードする必要があります。"
+
+#: dmr/internal/negotiation.py:18
+#, python-brace-format
+msgid ""
+"Cannot serialize response body with accepted types {accepted_types}, "
+"supported={supported}"
+msgstr ""
+"受け入れタイプ {accepted_types} でレスポンスボディをシリアライズできません。"
+"サポートされているタイプ: {supported}"
+
+#: dmr/negotiation.py:20
+#, python-brace-format
+msgid ""
+"Cannot parse request body with content type {content_type}, "
+"expected={expected}"
+msgstr ""
+"コンテンツタイプ {content_type} でリクエストボディを解析できません。"
+"期待されるタイプ: {expected}"
+
+#: dmr/security/django_session/auth.py:22
+#, python-brace-format
+msgid "CSRF Failed: {reason}"
+msgstr "CSRF検証に失敗しました: {reason}"
+
+#: dmr/security/jwt/blocklist/models.py:44
+msgid "BlocklistedJWToken"
+msgstr "BlocklistedJWToken"
+
+#: dmr/security/jwt/blocklist/models.py:45
+msgid "BlocklistedJWTokens"
+msgstr "BlocklistedJWTokens"
+
+#: dmr/serializer.py:16
+#, python-brace-format
+msgid "Value {value} of type {type} is not supported for {target_type}"
+msgstr "型 {type} の値 {value} は {target_type} ではサポートされていません"


### PR DESCRIPTION
## Summary

Adds Japanese (`ja`) locale for `django-modern-rest`, translating all error messages and system strings.

This follows the existing pattern of other translations (ru_RU, pt_BR, kk_KZ, etc.) and covers all 13 translatable strings in the codebase.

## Changes

- Added `dmr/locale/ja/LC_MESSAGES/django.po` with complete Japanese translations

## Translations included

- Authentication errors (`Not authenticated`, `Too many requests`, `Internal server error`)
- HTTP method validation errors
- Content-type parsing errors
- CSRF failure messages
- Path parameter errors
- Response serialization errors
- Model verbose names

Closes #718