### PR TITLE
test: add integration tests for custom cookie name

### DIFF
--- a/tests/test_integration/test_django_session_auth/test_django_sessions_custom_cookie_name.py
+++ b/tests/test_integration/test_django_session_auth/test_django_sessions_custom_cookie_name.py
@@ -1,0 +1,134 @@
+import json
+import pytest
+
+from faker import Faker
+from http import HTTPStatus
+from http.cookies import CookieError
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import reverse
+from inline_snapshot import snapshot
+
+from dmr.test import DMRClient
+
+
+@pytest.fixture
+def password(faker: Faker) -> str:
+    """Create a password for a user."""
+    return faker.password()
+
+
+@pytest.fixture
+def user(faker: Faker, password: str) -> User:
+    """Create fake user for tests."""
+    return User.objects.create_user(
+        faker.unique.user_name(),
+        faker.unique.email(),
+        password,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'check_url',
+    [
+        reverse('api:django_session_auth:django_session_sync'),
+        reverse('api:django_session_auth:django_session_async'),
+    ],
+)
+def test_django_sessions_default_cookie_name(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    *,
+    check_url: str,
+) -> None:
+    response = dmr_client.post(
+        check_url,
+        data={'username': user.username, 'password': password},
+        content_type='application/json',
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.cookies[settings.SESSION_COOKIE_NAME]
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "cookie_name",
+    [
+        "sessionid",
+        
+        "dmr_sessions",
+        "django_sessionid",
+        "CustomSessionCookieName",
+        "auth-token-id",
+        "s",                               
+        "session_manager_id_for_production_env_0123456789",
+    ],
+)
+@pytest.mark.parametrize(
+    'check_url',
+    [
+        reverse('api:django_session_auth:django_session_sync'),
+        reverse('api:django_session_auth:django_session_async'),
+    ],
+)
+def test_django_sessions_custom_cookie_name(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    cookie_name: str,
+    check_url: str,
+):
+    default_cookie_name = settings.SESSION_COOKIE_NAME
+    with override_settings(SESSION_COOKIE_NAME=cookie_name):
+        response = dmr_client.post(
+            check_url,
+            data={'username': user.username, 'password': password},
+            content_type='application/json',
+        )
+        assert response.status_code == HTTPStatus.OK, response.content
+        assert response.headers['Content-Type'] == 'application/json'
+        assert response.cookies[cookie_name]
+        if cookie_name != default_cookie_name:
+            assert default_cookie_name not in response.cookies
+    
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "invalid_cookie_name",
+    [
+        "session cookie",    
+        "session;id",       
+        "session=id",       
+        "session,id",       
+        "",                 
+        "   ",              
+    ],
+)
+@pytest.mark.parametrize(
+    'check_url',
+    [
+        reverse('api:django_session_auth:django_session_sync'),
+        reverse('api:django_session_auth:django_session_async'),
+    ],
+)
+def test_django_sessions_wrong_cookie_name(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    invalid_cookie_name: str,
+    check_url: str,
+):
+    with override_settings(SESSION_COOKIE_NAME=invalid_cookie_name):
+        with pytest.raises(CookieError, match=f"Illegal key {repr(invalid_cookie_name)}"):
+            dmr_client.post(
+                check_url,
+                data={'username': user.username, 'password': password},
+                content_type='application/json',
+            )
+

--- a/tests/test_integration/test_django_session_auth/test_django_sessions_custom_cookie_name.py
+++ b/tests/test_integration/test_django_session_auth/test_django_sessions_custom_cookie_name.py
@@ -1,15 +1,12 @@
-import json
-import pytest
-
-from faker import Faker
 from http import HTTPStatus
 from http.cookies import CookieError
 
+import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import override_settings
 from django.urls import reverse
-from inline_snapshot import snapshot
+from faker import Faker
 
 from dmr.test import DMRClient
 
@@ -55,18 +52,18 @@ def test_django_sessions_default_cookie_name(
     assert response.headers['Content-Type'] == 'application/json'
     assert response.cookies[settings.SESSION_COOKIE_NAME]
 
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "cookie_name",
+    'cookie_name',
     [
-        "sessionid",
-        
-        "dmr_sessions",
-        "django_sessionid",
-        "CustomSessionCookieName",
-        "auth-token-id",
-        "s",                               
-        "session_manager_id_for_production_env_0123456789",
+        'sessionid',
+        'dmr_sessions',
+        'django_sessionid',
+        'CustomSessionCookieName',
+        'auth-token-id',
+        's',
+        'session_manager_id_for_production_env_0123456789',
     ],
 )
 @pytest.mark.parametrize(
@@ -95,19 +92,18 @@ def test_django_sessions_custom_cookie_name(
         assert response.cookies[cookie_name]
         if cookie_name != default_cookie_name:
             assert default_cookie_name not in response.cookies
-    
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "invalid_cookie_name",
+    'invalid_cookie_name',
     [
-        "session cookie",    
-        "session;id",       
-        "session=id",       
-        "session,id",       
-        "",                 
-        "   ",              
+        'session cookie',
+        'session;id',
+        'session=id',
+        'session,id',
+        '',
+        '   ',
     ],
 )
 @pytest.mark.parametrize(
@@ -125,10 +121,11 @@ def test_django_sessions_wrong_cookie_name(
     check_url: str,
 ):
     with override_settings(SESSION_COOKIE_NAME=invalid_cookie_name):
-        with pytest.raises(CookieError, match=f"Illegal key {repr(invalid_cookie_name)}"):
+        with pytest.raises(
+            CookieError, match=f'Illegal key {invalid_cookie_name!r}'
+        ):
             dmr_client.post(
                 check_url,
                 data={'username': user.username, 'password': password},
                 content_type='application/json',
             )
-

--- a/tests/test_integration/test_django_session_auth/test_django_sessions_custom_cookie_name.py
+++ b/tests/test_integration/test_django_session_auth/test_django_sessions_custom_cookie_name.py
@@ -1,15 +1,13 @@
 import json
-import pytest
-
-from faker import Faker
 from http import HTTPStatus
 from http.cookies import CookieError
 
+import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import override_settings
 from django.urls import reverse
-from inline_snapshot import snapshot
+from faker import Faker
 
 from dmr.test import DMRClient
 
@@ -45,9 +43,10 @@ def test_django_sessions_default_cookie_name(
     *,
     check_url: str,
 ) -> None:
+    """Ensure that the default session cookie name is used correctly."""
     response = dmr_client.post(
         check_url,
-        data={'username': user.username, 'password': password},
+        data=json.dumps({'username': user.username, 'password': password}),
         content_type='application/json',
     )
 
@@ -55,18 +54,19 @@ def test_django_sessions_default_cookie_name(
     assert response.headers['Content-Type'] == 'application/json'
     assert response.cookies[settings.SESSION_COOKIE_NAME]
 
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "cookie_name",
+    'cookie_name',
     [
-        "sessionid",
-        
-        "dmr_sessions",
-        "django_sessionid",
-        "CustomSessionCookieName",
-        "auth-token-id",
-        "s",                               
-        "session_manager_id_for_production_env_0123456789",
+        'sessionid',
+        'dmr_sessions',
+        'django_sessionid',
+        'CustomSessionCookieName',
+        'auth-token-id',
+        's',
+        'session_manager_id_for_production_env_0123456789',
+        'session.id!#',
     ],
 )
 @pytest.mark.parametrize(
@@ -82,12 +82,13 @@ def test_django_sessions_custom_cookie_name(
     password: str,
     cookie_name: str,
     check_url: str,
-):
+) -> None:
+    """Ensure that custom session cookie names are respected by the API."""
     default_cookie_name = settings.SESSION_COOKIE_NAME
     with override_settings(SESSION_COOKIE_NAME=cookie_name):
         response = dmr_client.post(
             check_url,
-            data={'username': user.username, 'password': password},
+            data=json.dumps({'username': user.username, 'password': password}),
             content_type='application/json',
         )
         assert response.status_code == HTTPStatus.OK, response.content
@@ -95,19 +96,18 @@ def test_django_sessions_custom_cookie_name(
         assert response.cookies[cookie_name]
         if cookie_name != default_cookie_name:
             assert default_cookie_name not in response.cookies
-    
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "invalid_cookie_name",
+    'invalid_cookie_name',
     [
-        "session cookie",    
-        "session;id",       
-        "session=id",       
-        "session,id",       
-        "",                 
-        "   ",              
+        'session cookie',
+        'session;id',
+        'session=id',
+        'session,id',
+        '',
+        '   ',
     ],
 )
 @pytest.mark.parametrize(
@@ -123,12 +123,17 @@ def test_django_sessions_wrong_cookie_name(
     password: str,
     invalid_cookie_name: str,
     check_url: str,
-):
-    with override_settings(SESSION_COOKIE_NAME=invalid_cookie_name):
-        with pytest.raises(CookieError, match=f"Illegal key {repr(invalid_cookie_name)}"):
-            dmr_client.post(
-                check_url,
-                data={'username': user.username, 'password': password},
-                content_type='application/json',
-            )
-
+) -> None:
+    """Ensure that RFC-invalid cookie names raise a CookieError."""
+    with (
+        override_settings(SESSION_COOKIE_NAME=invalid_cookie_name),
+        pytest.raises(
+            CookieError,
+            match=f'Illegal key {invalid_cookie_name!r}',
+        ),
+    ):
+        dmr_client.post(
+            check_url,
+            data=json.dumps({'username': user.username, 'password': password}),
+            content_type='application/json',
+        )


### PR DESCRIPTION
Hello! I've implemented the first check from issue #911 to improve django-sessions support.

This PR adds a comprehensive suite of integration tests to verify that both synchronous and asynchronous session views correctly respect the SESSION_COOKIE_NAME setting.

All tests are passing locally across the full parameter matrix for both sync and async endpoints.




## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)



## Related issues
- Refs #911 


Looking forward to your feedback! Cheers.

