### PR TITLE
Breaking: rename `APIRedirectError` to `RedirectTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ of requirements for an API to count as public.
 
 ### Features
 
+- *Breaking*: Renamed `APIRedirectError` to `RedirectTo`
 - Added `validate_negotiation` metadata flag, so we can explicitly validate,
   that returned response followed the negotiation process, #711
 

--- a/dmr/__init__.py
+++ b/dmr/__init__.py
@@ -13,4 +13,4 @@ from dmr.headers import HeaderSpec as HeaderSpec
 from dmr.headers import NewHeader as NewHeader
 from dmr.metadata import ResponseSpec as ResponseSpec
 from dmr.response import APIError as APIError
-from dmr.response import APIRedirectError as APIRedirectError
+from dmr.response import RedirectTo as RedirectTo

--- a/dmr/endpoint.py
+++ b/dmr/endpoint.py
@@ -41,7 +41,7 @@ from dmr.openapi.objects import (
 )
 from dmr.parsers import Parser
 from dmr.renderers import Renderer
-from dmr.response import APIError, APIRedirectError
+from dmr.response import APIError, RedirectTo
 from dmr.security.base import AsyncAuth, SyncAuth
 from dmr.serializer import BaseSerializer
 from dmr.settings import HttpSpec, Settings, resolve_setting
@@ -360,7 +360,7 @@ class Endpoint:  # noqa: WPS214
 
                 # Return response:
                 func_result = await func(controller, **context)
-            except (APIError, APIRedirectError) as exc:
+            except (APIError, RedirectTo) as exc:
                 func_result = controller.to_error(
                     exc.raw_data,
                     status_code=exc.status_code,
@@ -396,7 +396,7 @@ class Endpoint:  # noqa: WPS214
 
                 # Return response:
                 func_result = func(controller, **context)
-            except (APIError, APIRedirectError) as exc:
+            except (APIError, RedirectTo) as exc:
                 func_result = controller.to_error(
                     exc.raw_data,
                     status_code=exc.status_code,

--- a/dmr/response.py
+++ b/dmr/response.py
@@ -80,7 +80,7 @@ class APIError(Exception, Generic[_ItemT]):
         if HTTPStatus.MULTIPLE_CHOICES <= status_code < HTTPStatus.BAD_REQUEST:
             raise DisallowedRedirect(
                 'APIError should not be used with redirects, '
-                'use APIRedirectError instead '
+                'use `RedirectTo` instead '
                 f'with status code {status_code!s}',
             )
 
@@ -91,9 +91,12 @@ class APIError(Exception, Generic[_ItemT]):
         self.cookies = cookies
 
 
-class APIRedirectError(Exception):
+class RedirectTo(Exception):  # noqa: N818
     """
-    Special class to fast return redirects from API.
+    Special class to redirect from ``@modify`` styled endpoints.
+
+    It is modeled as an exception, because you can't return ``HttpResponse``
+    subclasses from :func:`~dmr.endpoint.modify` endpoints.
 
     We model this class closely
     to match :class:`django.http.HttpResponseRedirect`.
@@ -104,7 +107,7 @@ class APIRedirectError(Exception):
 
         >>> from http import HTTPStatus
         >>> from dmr import (
-        ...     APIRedirectError,
+        ...     RedirectTo,
         ...     Controller,
         ...     ResponseSpec,
         ...     modify,
@@ -125,7 +128,7 @@ class APIRedirectError(Exception):
         ...     )
         ...     def get(self) -> str:
         ...         # This API endpoint is deprecated, use new one:
-        ...         raise APIRedirectError(
+        ...         raise RedirectTo(
         ...             '/api/new/users/',
         ...             status_code=HTTPStatus.FOUND,
         ...         )
@@ -162,7 +165,7 @@ class APIRedirectError(Exception):
             or status_code < HTTPStatus.MULTIPLE_CHOICES
         ):
             raise DisallowedRedirect(
-                'APIRedirectError might be used only with 3xx statuses, '
+                'RedirectTo might be used only with 3xx statuses, '
                 f'given: {status_code!s}',
             )
         super().__init__()

--- a/docs/examples/auth/django_session/using_django_session.py
+++ b/docs/examples/auth/django_session/using_django_session.py
@@ -14,3 +14,6 @@ class APIController(Controller[PydanticSerializer]):
         # Let's test that `User` has the correct type:
         assert self.request.user.username
         return 'authed'
+
+
+# openapi: {"controller": "APIController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001

--- a/docs/examples/auth/http_basic/views.py
+++ b/docs/examples/auth/http_basic/views.py
@@ -9,9 +9,7 @@ class _RequestModel(TypedDict):
     bill: str
 
 
-class BillController(
-    Controller[PydanticSerializer],
-):
+class BillController(Controller[PydanticSerializer]):
     auth = (HttpBasicAsync(),)
 
     async def post(self, parsed_body: Body[_RequestModel]) -> str:
@@ -20,3 +18,4 @@ class BillController(
 
 # run: {"controller": "BillController", "method": "post", "body": {"bill": "parking"}, "url": "/api/username/", "curl_args": ["-D", "-"], "assert-error-text": "Not authenticated", "fail-with-body": false}  # noqa: ERA001, E501
 # run: {"controller": "BillController", "method": "post", "body": {"bill": "parking"}, "url": "/api/username/", "headers": {"Authorization": "Basic YWRtaW46cGFzcw=="}}  # noqa: ERA001, E501
+# openapi: {"controller": "BillController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/examples/auth/jwt/blocklist_tokens.py
+++ b/docs/examples/auth/jwt/blocklist_tokens.py
@@ -1,15 +1,10 @@
 from django.contrib.auth.models import User
-from django.http import HttpRequest
 
 from dmr import Controller
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security import AuthenticatedHttpRequest, request_auth
 from dmr.security.jwt import JWTAsyncAuth, request_jwt
 from dmr.security.jwt.blocklist import JWTokenBlocklistAsyncMixin
-
-
-class AuthenticatedRequest(HttpRequest):
-    user: User
 
 
 class JWTAuthWithBlocklist(JWTokenBlocklistAsyncMixin, JWTAsyncAuth):
@@ -31,3 +26,6 @@ class APIController(Controller[PydanticSerializer]):
                 request_jwt(self.request, strict=True),
             )
         return 'authed'
+
+
+# openapi: {"controller": "APIController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001

--- a/docs/examples/auth/jwt/using_jwt.py
+++ b/docs/examples/auth/jwt/using_jwt.py
@@ -14,3 +14,6 @@ class APIController(Controller[PydanticSerializer]):
         # Let's test that `User` has the correct type:
         assert self.request.user.username
         return 'authed'
+
+
+# openapi: {"controller": "APIController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001

--- a/docs/examples/auth/per_controller.py
+++ b/docs/examples/auth/per_controller.py
@@ -11,3 +11,4 @@ class APIController(Controller[PydanticSerializer]):
 
 
 # run: {"controller": "APIController", "method": "get", "url": "/api/example/", "curl_args": ["-D", "-"], "assert-error-text": "Not authenticated", "fail-with-body": false}  # noqa: ERA001, E501
+# openapi: {"controller": "APIController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001

--- a/docs/examples/auth/per_endpoint.py
+++ b/docs/examples/auth/per_endpoint.py
@@ -10,3 +10,4 @@ class APIController(Controller[PydanticSerializer]):
 
 
 # run: {"controller": "APIController", "method": "get", "url": "/api/example/", "curl_args": ["-D", "-"], "assert-error-text": "Not authenticated", "fail-with-body": false}  # noqa: ERA001, E501
+# openapi: {"controller": "APIController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001

--- a/docs/examples/using_controller/first_example.py
+++ b/docs/examples/using_controller/first_example.py
@@ -1,0 +1,11 @@
+from dmr import Controller
+from dmr.plugins.msgspec import MsgspecSerializer
+
+
+class MyController(Controller[MsgspecSerializer]):
+    def post(self) -> str:
+        return 'ok'
+
+
+# run: {"controller": "MyController", "method": "post", "url": "/api/example/"}  # noqa: ERA001
+# openapi: {"controller": "MyController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001

--- a/docs/examples/using_controller/redirect_error.py
+++ b/docs/examples/using_controller/redirect_error.py
@@ -3,7 +3,7 @@ from typing import Final
 
 from django.http import HttpResponse
 
-from dmr import APIRedirectError, Controller, HeaderSpec, modify, validate
+from dmr import Controller, HeaderSpec, RedirectTo, modify, validate
 from dmr.metadata import ResponseSpec
 from dmr.plugins.pydantic import PydanticSerializer
 
@@ -17,11 +17,11 @@ _RedirectSpec: Final = ResponseSpec(
 class UserController(Controller[PydanticSerializer]):
     @validate(_RedirectSpec)
     def get(self) -> HttpResponse:
-        raise APIRedirectError('https://example.com/api/new/user/list')
+        raise RedirectTo('https://example.com/api/new/user/list')
 
     @modify(extra_responses=[_RedirectSpec])
     def post(self) -> dict[str, str]:
-        raise APIRedirectError('https://example.com/api/new/user/create')
+        raise RedirectTo('https://example.com/api/new/user/create')
 
 
 # run: {"controller": "UserController", "method": "get", "url": "/api/user/", "curl_args": ["-D", "-"]}  # noqa: ERA001, E501

--- a/docs/pages/using-controller/index.rst
+++ b/docs/pages/using-controller/index.rst
@@ -8,16 +8,12 @@ Controllers consist of :class:`~dmr.endpoint.Endpoint` objects.
 Each HTTP method is an independent endpoint.
 
 The simplest way to create an endpoint is to define sync
-or async method with the right name:
+or async method with the right name (any HTTP method verb):
 
-.. code:: python
-
-  >>> from dmr import Controller
-  >>> from dmr.plugins.msgspec import MsgspecSerializer
-
-  >>> class MyController(Controller[MsgspecSerializer]):
-  ...     def post(self) -> str:
-  ...         return 'ok'
+.. literalinclude:: /examples/using_controller/first_example.py
+  :caption: views.py
+  :language: python
+  :linenos:
 
 There will be several things that ``django-modern-rest`` will do for you here:
 

--- a/docs/pages/using-controller/redirects.rst
+++ b/docs/pages/using-controller/redirects.rst
@@ -2,12 +2,16 @@ Returning redirects
 ===================
 
 We support returning redirects from API endpoints with
-:class:`~dmr.response.APIRedirectError` exception:
+:class:`~dmr.response.RedirectTo` exception with :func:`~dmr.endpoint.modify`:
 
 .. literalinclude:: /examples/using_controller/redirect_error.py
   :caption: views.py
   :language: python
   :linenos:
+
+We model ``RedirectTo`` as an exception, because you are not allowed
+to return :class:`~django.http.HttpResponse` objects
+from :func:`~dmr.endpoint.modify` endpoints.
 
 .. note::
 
@@ -15,7 +19,8 @@ We support returning redirects from API endpoints with
   Redirects are different from regular errors.
 
 The second way is to use
-default Django's :class:`django.http.HttpResponseRedirect`:
+default Django's :class:`django.http.HttpResponseRedirect`
+together with :func:`~dmr.endpoint.validate`:
 
 .. literalinclude:: /examples/using_controller/redirect_response.py
   :caption: views.py
@@ -29,5 +34,5 @@ in a response spec.
 API Reference
 -------------
 
-.. autoexception:: dmr.response.APIRedirectError
+.. autoexception:: dmr.response.RedirectTo
   :members:

--- a/tests/test_unit/test_endpoint/test_return_redirect.py
+++ b/tests/test_unit/test_endpoint/test_return_redirect.py
@@ -4,7 +4,7 @@ from typing import Final, final
 import pytest
 from django.http import HttpResponse, HttpResponseRedirect
 
-from dmr import APIRedirectError, Controller, HeaderSpec, modify, validate
+from dmr import Controller, HeaderSpec, RedirectTo, modify, validate
 from dmr.metadata import ResponseSpec
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
@@ -21,7 +21,7 @@ _REDIRECT_SPEC: Final = ResponseSpec(
 class _RedirectController(Controller[PydanticSerializer]):
     @validate(_REDIRECT_SPEC)
     def get(self) -> HttpResponse:
-        raise APIRedirectError(
+        raise RedirectTo(
             _REDIRECT_URL,
             status_code=HTTPStatus.FOUND,
         )
@@ -35,7 +35,7 @@ class _RedirectController(Controller[PydanticSerializer]):
 
     @modify(extra_responses=[_REDIRECT_SPEC])
     def put(self) -> dict[str, str]:
-        raise APIRedirectError(
+        raise RedirectTo(
             _REDIRECT_URL,
             status_code=HTTPStatus.FOUND,
         )
@@ -50,7 +50,7 @@ class _RedirectController(Controller[PydanticSerializer]):
     ],
 )
 def test_api_redirect(dmr_rf: DMRRequestFactory, *, method: HTTPMethod) -> None:
-    """Ensures we can raise ``APIRedirectError`` in sync endpoint."""
+    """Ensures we can raise ``RedirectTo`` in sync endpoint."""
     request = dmr_rf.generic(str(method), '/whatever/')
 
     response = _RedirectController.as_view()(request)
@@ -68,7 +68,7 @@ def test_api_redirect(dmr_rf: DMRRequestFactory, *, method: HTTPMethod) -> None:
 class _AsyncRedirectController(Controller[PydanticSerializer]):
     @validate(_REDIRECT_SPEC)
     async def get(self) -> HttpResponse:
-        raise APIRedirectError(
+        raise RedirectTo(
             _REDIRECT_URL,
             status_code=HTTPStatus.FOUND,
         )
@@ -82,7 +82,7 @@ class _AsyncRedirectController(Controller[PydanticSerializer]):
 
     @modify(extra_responses=[_REDIRECT_SPEC])
     async def put(self) -> dict[str, str]:
-        raise APIRedirectError(
+        raise RedirectTo(
             _REDIRECT_URL,
             status_code=HTTPStatus.FOUND,
         )
@@ -102,7 +102,7 @@ async def test_async_api_redirect(
     *,
     method: HTTPMethod,
 ) -> None:
-    """Ensures we can raise ``APIRedirectError`` in async endpoint."""
+    """Ensures we can raise ``RedirectTo`` in async endpoint."""
     request = dmr_async_rf.generic(str(method), '/whatever/')
 
     response = await dmr_async_rf.wrap(

--- a/tests/test_unit/test_response/test_api_error.py
+++ b/tests/test_unit/test_response/test_api_error.py
@@ -401,7 +401,7 @@ def test_api_error_with_cookies(
 
 def test_api_error_redirect_status() -> None:
     """Ensures that we can't create APIError with redirect status code."""
-    with pytest.raises(DisallowedRedirect, match='APIRedirectError'):
+    with pytest.raises(DisallowedRedirect, match='RedirectTo'):
         APIError('whatever', status_code=HTTPStatus.FOUND)
 
 

--- a/tests/test_unit/test_response/test_api_redirect_error.py
+++ b/tests/test_unit/test_response/test_api_redirect_error.py
@@ -4,25 +4,25 @@ import pytest
 from django.core.exceptions import DisallowedRedirect
 from django.utils.http import MAX_URL_REDIRECT_LENGTH
 
-from dmr import APIRedirectError
+from dmr import RedirectTo
 
 
 def test_invalid_redirect_length() -> None:
     """We can't redirect to very long urls."""
     long_url = 'a' * MAX_URL_REDIRECT_LENGTH
     with pytest.raises(DisallowedRedirect, match='Unsafe redirect exceeding'):
-        APIRedirectError(f'custom://{long_url}.com')
+        RedirectTo(f'custom://{long_url}.com')
 
 
 def test_invalid_redirect_scheme() -> None:
     """We can't redirect to untrusted protocols."""
     with pytest.raises(DisallowedRedirect, match='with protocol'):
-        APIRedirectError('custom://url.com')
+        RedirectTo('custom://url.com')
 
 
 def test_invalid_status_code() -> None:
     """We can't redirect with wrong status code."""
     with pytest.raises(DisallowedRedirect, match='3xx statuses'):
-        APIRedirectError('https://url.com', status_code=HTTPStatus.BAD_REQUEST)
+        RedirectTo('https://url.com', status_code=HTTPStatus.BAD_REQUEST)
     with pytest.raises(DisallowedRedirect, match='3xx statuses'):
-        APIRedirectError('https://url.com', status_code=HTTPStatus.IM_USED)
+        RedirectTo('https://url.com', status_code=HTTPStatus.IM_USED)


### PR DESCRIPTION
While watchin https://www.youtube.com/watch?v=GLDaOWChvxI I realised that `APIResponseError` was never actually an error. It was a valid way to return a redirect. So, I renamed it to be cleaner.