### PR TITLE
Speedup slow test_schemathesis in local environment

### DIFF
--- a/schemathesis.toml
+++ b/schemathesis.toml
@@ -1,7 +1,3 @@
-[generation]
-# Limit the number of generated examples per API operation to keep tests fast.
-max-examples = 100
-
 [warnings]
 # Fail on any warning:
 fail-on = true

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -26,6 +26,7 @@ def tracecov_map() -> 'tracecov.CoverageMap | None':
 def _set_dmr_settings(settings: LazySettings) -> None:
     settings.DMR_SETTINGS = {
         Settings.openapi_examples_seed: 1,
+        # It might be already defined in some other place:
         **getattr(settings, 'DMR_SETTINGS', {}),
     }
 

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -22,16 +22,17 @@ def tracecov_map() -> 'tracecov.CoverageMap | None':
     return tracecov.CoverageMap.from_dict(schema.convert())
 
 
+@pytest.fixture(autouse=True)
+def _set_dmr_settings(settings: LazySettings) -> None:
+    settings.DMR_SETTINGS = {
+        Settings.openapi_examples_seed: 1,
+        **getattr(settings, 'DMR_SETTINGS', {}),
+    }
+
+
 @pytest.fixture(autouse=True, params=[True, False])
 def _modify_integration_settings(
     settings: LazySettings,
     request: pytest.FixtureRequest,
 ) -> None:
-    # Django common settings:
     settings.DEBUG = request.param  # We run tests in both modes.
-    # Our own settings:
-    settings.DMR_SETTINGS = {
-        Settings.openapi_examples_seed: 1,
-        # It might be already defined in some other place:
-        **getattr(settings, 'DMR_SETTINGS', {}),
-    }

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -81,12 +81,11 @@ st.openapi.format(
 )
 def test_schemathesis(
     case: st.Case,
-    settings: LazySettings,
     tracecov_map: 'tracecov.CoverageMap | None',
 ) -> None:
     """Ensure that API implementation matches the OpenAPI schema."""
-    if settings.DEBUG or tracecov_map is None:
-        pytest.skip(reason='DEBUG=True or missing `tracecov`')
+    if tracecov_map is None:
+        pytest.skip(reason='Missing `tracecov`')
 
     from tracecov.schemathesis import helpers  # noqa: PLC0415
 

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
@@ -7,11 +8,17 @@ import schemathesis as st
 from django.conf import LazySettings
 from django.contrib.auth.models import User
 from django.urls import reverse
+from hypothesis import settings as h_settings
 from hypothesis import strategies
 from schemathesis.specs.openapi.schemas import OpenApiSchema
 
 from django_test_app.server.wsgi import application
 from dmr.validation import ResponseValidator
+
+_LOCAL_MAX_EXAMPLES = 25
+_MAX_EXAMPLES = (
+    h_settings().max_examples if os.environ.get('CI') else _LOCAL_MAX_EXAMPLES
+)
 
 if TYPE_CHECKING:
     import tracecov
@@ -38,6 +45,14 @@ def _disable_logging(settings: LazySettings) -> Iterator[None]:
     logging.disable(logging.NOTSET)
 
 
+@pytest.fixture(autouse=True)
+def _modify_integration_settings(settings: LazySettings) -> None:
+    # Schemathesis tests only run meaningfully with DEBUG=False (the test
+    # explicitly skips when DEBUG=True), so there is no value in running
+    # the full suite twice via the parent conftest parametrisation.
+    settings.DEBUG = False
+
+
 # The `transactional_db` fixture is required to enable database access.
 # When `st.openapi.from_wsgi()` makes a WSGI request, Django's request
 # lifecycle triggers database operations.
@@ -61,6 +76,9 @@ st.openapi.format(
 
 
 @schema.parametrize()
+@h_settings(
+    max_examples=_MAX_EXAMPLES,
+)
 def test_schemathesis(
     case: st.Case,
     settings: LazySettings,

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 import schemathesis as st
@@ -15,10 +15,8 @@ from schemathesis.specs.openapi.schemas import OpenApiSchema
 from django_test_app.server.wsgi import application
 from dmr.validation import ResponseValidator
 
-_LOCAL_MAX_EXAMPLES = 25
-_MAX_EXAMPLES = (
-    h_settings().max_examples if os.environ.get('CI') else _LOCAL_MAX_EXAMPLES
-)
+_LOCAL_MAX_EXAMPLES: Final = 25
+_MAX_EXAMPLES: Final = 100 if os.environ.get('CI') else _LOCAL_MAX_EXAMPLES
 
 if TYPE_CHECKING:
     import tracecov

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -76,9 +76,7 @@ st.openapi.format(
 
 
 @schema.parametrize()
-@h_settings(
-    max_examples=_MAX_EXAMPLES,
-)
+@h_settings(max_examples=_MAX_EXAMPLES)
 def test_schemathesis(
     case: st.Case,
     tracecov_map: 'tracecov.CoverageMap | None',

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -84,8 +84,8 @@ def test_schemathesis(
     tracecov_map: 'tracecov.CoverageMap | None',
 ) -> None:
     """Ensure that API implementation matches the OpenAPI schema."""
-    if tracecov_map is None:
-        pytest.skip(reason='Missing `tracecov`')
+    if tracecov_map is None:  # pragma: no cover
+        pytest.skip(reason='missing `tracecov`')
 
     from tracecov.schemathesis import helpers  # noqa: PLC0415
 


### PR DESCRIPTION
# I have made things!

When developing locally, `just test` is a common command, though it's very slow on a schematesis test. 

What's changed:


1. Eliminating the `DEBUG=True` pass              

`@schema.parametrize()` expands test_schemathesis into N separate tests  one per API operation in the schema. The parent conftest's `params=[True, False]` doubles that to 2N runs. The `DEBUG=True` half all skip immediately, but "immediately" isn't free: each still goes through fixture setup - transactional_db and admin_user (creates a DB row) - before the test body even runs.

  2. Reduce max_examples locally
  
  Default 100 generated request payloads per API operation is probably overhead for local testing (though kept 100 unchanged for the CI)
  
  ----------

`time uv run pytest tests/test_integration/test_openapi/test_schema.py`
On my local machine **on `master`:**
```
real    2m0,807s
user    1m56,825s
sys     0m3,918s
```
On **this branch:**

```
real    0m51,862s
user    0m50,058s
sys     0m1,793s

```




## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
