### PR TITLE
fix: fall back to non-streaming default when Accept only matches stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ of requirements for an API to count as public.
 - Fixed a bug that `ObtainTokensAsyncController` was not setting
   the `request.auser` attribute, #953
 - Fixed a bug that `JWTSyncAuth` was not setting `request.auser`, #953
+- Fixed `ResponseNegotiator` raising `NotAcceptableError` on streaming
+  endpoints when `Accept: text/event-stream` was sent without
+  `application/json` (the default browser `EventSource` case), which
+  made 4xx/5xx error bodies and response validation crash with a 500
+  instead of rendering the configured non-streaming default, #962
 
 ### Misc
 

--- a/dmr/negotiation.py
+++ b/dmr/negotiation.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING, Any, Final, Literal, final, overload
 from django.http.request import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
-from dmr.exceptions import EndpointMetadataError, RequestSerializationError
+from dmr.exceptions import (
+    EndpointMetadataError,
+    NotAcceptableError,
+    RequestSerializationError,
+)
 from dmr.internal.negotiation import ConditionalType as _ConditionalType
 from dmr.internal.negotiation import media_by_precedence
 from dmr.internal.negotiation import negotiate_renderer as _negotiate_renderer
@@ -188,11 +192,21 @@ class ResponseNegotiator:
         )
         request.__dmr_renderer__ = renderer  # type: ignore[attr-defined]
         if self._streaming:
-            request.__dmr_nonstreaming_renderer__ = _negotiate_renderer(  # type: ignore[attr-defined]
-                request,
-                self._non_streaming_renderers,
-                default=self._non_streaming_default,
-            )
+            try:
+                non_streaming = _negotiate_renderer(
+                    request,
+                    self._non_streaming_renderers,
+                    default=self._non_streaming_default,
+                )
+            except NotAcceptableError:
+                # Main (streaming) negotiation already succeeded.
+                # A non-streaming renderer is only needed for 4xx/5xx
+                # error bodies and response validation — fall back to
+                # the configured default so those paths keep working
+                # for clients that only accept the streaming media
+                # type (e.g. browser ``EventSource``).
+                non_streaming = self._non_streaming_default
+            request.__dmr_nonstreaming_renderer__ = non_streaming  # type: ignore[attr-defined]
         return renderer
 
 

--- a/tests/test_unit/test_streaming/test_streaming_negotiation.py
+++ b/tests/test_unit/test_streaming/test_streaming_negotiation.py
@@ -3,8 +3,12 @@ from http import HTTPStatus
 from typing import Any
 
 import pytest
+from django.http import HttpResponse
 from typing_extensions import override
 
+from dmr import APIError, ResponseSpec, modify
+from dmr.errors import ErrorModel, format_error
+from dmr.exceptions import NotAcceptableError
 from dmr.negotiation import ContentType
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.renderers import JsonRenderer
@@ -13,7 +17,7 @@ from dmr.streaming import StreamingController, StreamingResponse
 from dmr.streaming.jsonl.renderer import JsonLinesRenderer
 from dmr.streaming.jsonl.validation import JsonLinesStreamingValidator
 from dmr.streaming.renderer import StreamingRenderer
-from dmr.streaming.sse import SSEvent
+from dmr.streaming.sse import SSEController, SSEvent
 from dmr.streaming.sse.renderer import SSERenderer
 from dmr.streaming.sse.validation import SSEStreamingValidator
 from dmr.test import DMRAsyncRequestFactory
@@ -102,3 +106,87 @@ async def test_valid_sse_different_methods(
         'Connection': 'keep-alive',
     }
     assert await get_streaming_content(response) == expected_data
+
+
+def test_stream_only_accept_fallback(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """Ensure the ``EventSource`` accept header still negotiates a fallback.
+
+    ``Accept: text/event-stream`` without ``application/json`` — the
+    real-world browser ``EventSource`` case — must still populate
+    ``__dmr_nonstreaming_renderer__`` with the non-streaming default so
+    error bodies and response validation can serialize dict error bodies.
+    """
+    endpoint = _ClassBasedStreaming.api_endpoints['GET']
+    negotiator = endpoint.response_negotiator
+
+    request = dmr_async_rf.get(
+        '/sse/',
+        headers={'Accept': str(ContentType.event_stream)},
+    )
+    renderer = negotiator(request)
+
+    assert isinstance(renderer, SSERenderer)
+    assert request.__dmr_renderer__ is renderer  # type: ignore[attr-defined]
+    assert (
+        request.__dmr_nonstreaming_renderer__  # type: ignore[attr-defined]
+        is negotiator._non_streaming_default
+    )
+
+
+def test_stream_no_match_raises_not_acceptable(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """Ensure the fallback only applies when the main negotiation succeeded.
+
+    An ``Accept`` that matches **no** renderer on a streaming endpoint
+    must still raise ``NotAcceptableError``.
+    """
+    endpoint = _ClassBasedStreaming.api_endpoints['GET']
+    negotiator = endpoint.response_negotiator
+
+    request = dmr_async_rf.get(
+        '/sse/',
+        headers={'Accept': 'application/xml'},
+    )
+    with pytest.raises(NotAcceptableError):
+        negotiator(request)
+
+
+class _SSEWithAPIError(SSEController[PydanticSerializer]):
+    responses = (
+        ResponseSpec(
+            return_type=ErrorModel,
+            status_code=HTTPStatus.NOT_FOUND,
+        ),
+    )
+
+    @modify(validate_responses=True)
+    async def get(self) -> AsyncIterator[SSEvent[str]]:
+        raise APIError(
+            format_error('nope'),
+            status_code=HTTPStatus.NOT_FOUND,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sse_api_error_with_stream_only_accept(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """End-to-end regression for the browser ``EventSource`` case.
+
+    A request with ``Accept: text/event-stream`` only that hits an
+    ``APIError`` before the first yield must render the JSON error
+    body instead of crashing with ``DataRenderingError`` and a 500.
+    """
+    request = dmr_async_rf.get(
+        '/sse-errors/',
+        headers={'Accept': str(ContentType.event_stream)},
+    )
+
+    response = await dmr_async_rf.wrap(_SSEWithAPIError.as_view()(request))
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.NOT_FOUND, response.content
+    assert response.headers == {'Content-Type': 'application/json'}


### PR DESCRIPTION
When a streaming endpoint received `Accept: text/event-stream` without `application/json` — the default browser `EventSource` case — the `ResponseNegotiator` raised `NotAcceptableError` during the non-streaming pass. Any 4xx/5xx error body (or response-validation path) then tried to render a dict through `SSERenderer` and crashed with a 500.

The main (streaming) negotiation has already succeeded at that point, so cascading to a 500 is wrong. Catch `NotAcceptableError` in that second pass and fall back to the configured non-streaming default.

Closes #962

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [ ] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

- Closes #962 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
