### PR TITLE
fix: update session auth OpenAPI schema for session-backed CSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ of requirements for an API to count as public.
 
 ### Bugfixes
 
+- Fixed OpenAPI schema for Django session auth
+  when `CSRF_USE_SESSIONS=True`, #674
 - Fixed that `itemSchema` was possible to be rendered
   in OpenAPI `3.0.0` and `3.1.0`, #908
 - Fixed response validation when global error handler returns

--- a/dmr/security/django_session/auth.py
+++ b/dmr/security/django_session/auth.py
@@ -9,7 +9,11 @@ from django.utils.translation import gettext_lazy as _
 from typing_extensions import override
 
 from dmr.exceptions import NotAuthenticatedError
-from dmr.metadata import EndpointMetadata, ResponseSpec, ResponseSpecProvider
+from dmr.metadata import (
+    EndpointMetadata,
+    ResponseSpec,
+    ResponseSpecProvider,
+)
 from dmr.openapi.objects import Reference, SecurityRequirement, SecurityScheme
 from dmr.response import APIError
 from dmr.security.base import AsyncAuth, SyncAuth

--- a/dmr/security/django_session/auth.py
+++ b/dmr/security/django_session/auth.py
@@ -53,29 +53,36 @@ class _DjangoSessionAuth(ResponseSpecProvider):
         self.security_scheme_name = security_scheme_name
         self.csrf_scheme_name = csrf_scheme_name
 
+    def _uses_csrf_cookie(self) -> bool:
+        return not settings.CSRF_USE_SESSIONS
+
     @property
     def security_schemes(self) -> dict[str, SecurityScheme | Reference]:
         """Provides a security schema definition."""
-        return {
+        schemes = {
             self.security_scheme_name: SecurityScheme(
                 type='apiKey',
                 name=settings.SESSION_COOKIE_NAME,
                 security_scheme_in='cookie',
                 description='Reusing standard Django auth flow for API',
             ),
-            # TODO: this is not right if `CSRF_USE_SESSIONS` is used:
-            self.csrf_scheme_name: SecurityScheme(
+        }
+        if self._uses_csrf_cookie():
+            schemes[self.csrf_scheme_name] = SecurityScheme(
                 type='apiKey',
                 name=settings.CSRF_COOKIE_NAME,
                 security_scheme_in='cookie',
                 description='CSRF protection',
-            ),
-        }
+            )
+        return schemes
 
     @property
     def security_requirement(self) -> SecurityRequirement:
         """Provides a security schema usage requirement."""
-        return {self.security_scheme_name: [], self.csrf_scheme_name: []}
+        requirement = {self.security_scheme_name: []}
+        if self._uses_csrf_cookie():
+            requirement[self.csrf_scheme_name] = []
+        return requirement
 
     @override
     def provide_response_specs(

--- a/dmr/security/django_session/auth.py
+++ b/dmr/security/django_session/auth.py
@@ -53,13 +53,10 @@ class _DjangoSessionAuth(ResponseSpecProvider):
         self.security_scheme_name = security_scheme_name
         self.csrf_scheme_name = csrf_scheme_name
 
-    def _uses_csrf_cookie(self) -> bool:
-        return not settings.CSRF_USE_SESSIONS
-
     @property
     def security_schemes(self) -> dict[str, SecurityScheme | Reference]:
         """Provides a security schema definition."""
-        schemes = {
+        schemes: dict[str, SecurityScheme | Reference] = {
             self.security_scheme_name: SecurityScheme(
                 type='apiKey',
                 name=settings.SESSION_COOKIE_NAME,
@@ -79,7 +76,7 @@ class _DjangoSessionAuth(ResponseSpecProvider):
     @property
     def security_requirement(self) -> SecurityRequirement:
         """Provides a security schema usage requirement."""
-        requirement = {self.security_scheme_name: []}
+        requirement: SecurityRequirement = {self.security_scheme_name: []}
         if self._uses_csrf_cookie():
             requirement[self.csrf_scheme_name] = []
         return requirement
@@ -110,6 +107,9 @@ class _DjangoSessionAuth(ResponseSpecProvider):
                 existing_responses,
             ),
         ]
+
+    def _uses_csrf_cookie(self) -> bool:
+        return not settings.CSRF_USE_SESSIONS
 
     def _ensure_csrf(self, controller: 'Controller[BaseSerializer]') -> None:
         reason = _get_csrf_failure_reason(controller.request)

--- a/tests/test_unit/test_security/test_django_session_auth.py
+++ b/tests/test_unit/test_security/test_django_session_auth.py
@@ -206,3 +206,31 @@ def test_schema_with_csrf_sessions(
     assert instance.security_requirement == snapshot({
         'django_session': [],
     })
+
+
+@pytest.mark.parametrize('typ', [DjangoSessionSyncAuth, DjangoSessionAsyncAuth])
+def test_schema_with_custom_cookie_names(
+    settings: LazySettings,
+    *,
+    typ: type[DjangoSessionSyncAuth] | type[DjangoSessionAsyncAuth],
+) -> None:
+    """Ensures that custom cookie names from settings are respected."""
+    settings.SESSION_COOKIE_NAME = 'custom_session_id'
+    settings.CSRF_COOKIE_NAME = 'custom_csrf_token'
+    settings.CSRF_USE_SESSIONS = False
+    instance = typ()
+
+    assert instance.security_schemes == snapshot({
+        'django_session': SecurityScheme(
+            type='apiKey',
+            description='Reusing standard Django auth flow for API',
+            name='custom_session_id',
+            security_scheme_in='cookie',
+        ),
+        'csrf': SecurityScheme(
+            type='apiKey',
+            description='CSRF protection',
+            name='custom_csrf_token',
+            security_scheme_in='cookie',
+        ),
+    })

--- a/tests/test_unit/test_security/test_django_session_auth.py
+++ b/tests/test_unit/test_security/test_django_session_auth.py
@@ -156,11 +156,13 @@ def test_global_settings_override(
 
 
 @pytest.mark.parametrize('typ', [DjangoSessionSyncAuth, DjangoSessionAsyncAuth])
-def test_schema(
+def test_schema_with_csrf_cookie(
+    settings: LazySettings,
     *,
     typ: type[DjangoSessionSyncAuth] | type[DjangoSessionAsyncAuth],
 ) -> None:
     """Ensures that security scheme is correct for django session auth."""
+    settings.CSRF_USE_SESSIONS = False
     instance = typ()
 
     assert instance.security_schemes == snapshot({
@@ -180,4 +182,27 @@ def test_schema(
     assert instance.security_requirement == snapshot({
         'django_session': [],
         'csrf': [],
+    })
+
+
+@pytest.mark.parametrize('typ', [DjangoSessionSyncAuth, DjangoSessionAsyncAuth])
+def test_schema_with_csrf_sessions(
+    settings: LazySettings,
+    *,
+    typ: type[DjangoSessionSyncAuth] | type[DjangoSessionAsyncAuth],
+) -> None:
+    """Ensures that CSRF cookie schema is omitted for session-backed CSRF."""
+    settings.CSRF_USE_SESSIONS = True
+    instance = typ()
+
+    assert instance.security_schemes == snapshot({
+        'django_session': SecurityScheme(
+            type='apiKey',
+            description='Reusing standard Django auth flow for API',
+            name='sessionid',
+            security_scheme_in='cookie',
+        ),
+    })
+    assert instance.security_requirement == snapshot({
+        'django_session': [],
     })


### PR DESCRIPTION
# I have made things!

Stop advertising CSRF as a cookie-based OpenAPI security scheme when Django is configured with CSRF_USE_SESSIONS=True.

This updates DjangoSessionSyncAuth and DjangoSessionAsyncAuth to make the generated security schema environment-aware, while keeping the existing behavior for the default cookie-backed CSRF mode. Tests were added to cover both configurations.

-------

**NB(!)**: this is an attempt to finish #674 

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
