### PR TITLE
feat: add CSRF cookie to django session login response schema

### DIFF
--- a/dmr/security/django_session/views.py
+++ b/dmr/security/django_session/views.py
@@ -66,7 +66,6 @@ class DjangoSessionSyncController(
                 else {
                     settings.CSRF_COOKIE_NAME: CookieSpec(
                         skip_validation=True,
-                        required=False,
                         description='CSRF protection.',
                     ),
                 }
@@ -138,7 +137,6 @@ class DjangoSessionAsyncController(
                 else {
                     settings.CSRF_COOKIE_NAME: CookieSpec(
                         skip_validation=True,
-                        required=False,
                         description='CSRF protection.',
                     ),
                 }

--- a/dmr/security/django_session/views.py
+++ b/dmr/security/django_session/views.py
@@ -60,6 +60,17 @@ class DjangoSessionSyncController(
         status_code=HTTPStatus.OK,
         cookies={
             settings.SESSION_COOKIE_NAME: CookieSpec(skip_validation=True),
+            **(
+                {}
+                if settings.CSRF_USE_SESSIONS
+                else {
+                    settings.CSRF_COOKIE_NAME: CookieSpec(
+                        skip_validation=True,
+                        required=False,
+                        description='CSRF protection.',
+                    ),
+                }
+            ),
         },
     )
     def post(self, parsed_body: Body[_RequestModelT]) -> _ResponseT:
@@ -121,6 +132,17 @@ class DjangoSessionAsyncController(
         status_code=HTTPStatus.OK,
         cookies={
             settings.SESSION_COOKIE_NAME: CookieSpec(skip_validation=True),
+            **(
+                {}
+                if settings.CSRF_USE_SESSIONS
+                else {
+                    settings.CSRF_COOKIE_NAME: CookieSpec(
+                        skip_validation=True,
+                        required=False,
+                        description='CSRF protection.',
+                    ),
+                }
+            ),
         },
     )
     async def post(self, parsed_body: Body[_RequestModelT]) -> _ResponseT:

--- a/docs/pages/auth/django-session.rst
+++ b/docs/pages/auth/django-session.rst
@@ -67,6 +67,28 @@ To use them, you will need to:
 Any further customizations are also possible.
 
 
+CSRF
+~~~~
+
+When a user logs in through these controllers, Django automatically rotates
+the CSRF token and includes a ``csrftoken`` cookie in the login response
+(alongside the session cookie).
+
+Clients making subsequent non-safe requests (``POST``, ``PUT``, ``PATCH``,
+``DELETE``) to session-protected endpoints must send this token back via the
+``X-CSRFToken`` request header.
+
+.. note::
+
+  When ``CSRF_USE_SESSIONS`` is ``True``, Django stores the CSRF token
+  in the session instead of a cookie.  In that case no ``csrftoken`` cookie
+  appears in the login response — the token is already embedded in the
+  session used for authentication.
+
+  See also:
+    https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-CSRF_USE_SESSIONS
+
+
 API Reference
 -------------
 

--- a/tests/test_integration/test_django_session_auth/test_django_sessions_auth_views.py
+++ b/tests/test_integration/test_django_session_auth/test_django_sessions_auth_views.py
@@ -169,8 +169,10 @@ def test_login_sends_csrf_cookie(
     )
 
     assert response.status_code == HTTPStatus.OK, response.content
-    assert response.cookies[settings.SESSION_COOKIE_NAME]
-    assert response.cookies[settings.CSRF_COOKIE_NAME]
+    assert response.cookies.keys() == {
+        settings.SESSION_COOKIE_NAME,
+        settings.CSRF_COOKIE_NAME,
+    }
 
 
 @pytest.mark.django_db

--- a/tests/test_integration/test_django_session_auth/test_django_sessions_auth_views.py
+++ b/tests/test_integration/test_django_session_auth/test_django_sessions_auth_views.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 
 import pytest
-from django.conf import settings
+from django.conf import LazySettings, settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from faker import Faker
@@ -145,3 +145,58 @@ def test_wrong_auth_params(
     assert response.json() == snapshot({
         'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
     })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:django_session_auth:django_session_sync'),
+        reverse('api:django_session_auth:django_session_async'),
+    ],
+)
+def test_login_sends_csrf_cookie(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    *,
+    url: str,
+) -> None:
+    """Ensures the login response sets the CSRF cookie and session cookie."""
+    response = dmr_client.post(
+        url,
+        data={'username': user.username, 'password': password},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert response.cookies[settings.SESSION_COOKIE_NAME]
+    assert response.cookies[settings.CSRF_COOKIE_NAME]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:django_session_auth:django_session_sync'),
+        reverse('api:django_session_auth:django_session_async'),
+    ],
+)
+def test_login_with_csrf_use_sessions(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    settings: LazySettings,
+    *,
+    url: str,
+) -> None:
+    """Ensures with CSRF_USE_SESSIONS=True, CSRF_COOKIE is not set."""
+    settings.CSRF_USE_SESSIONS = True
+
+    response = dmr_client.post(
+        url,
+        data={'username': user.username, 'password': password},
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert response.cookies[settings.SESSION_COOKIE_NAME]
+    assert settings.CSRF_COOKIE_NAME not in response.cookies

--- a/tests/test_unit/test_security/test_django_session_auth.py
+++ b/tests/test_unit/test_security/test_django_session_auth.py
@@ -304,4 +304,4 @@ def test_login_schema_includes_csrf_cookie(
     csrf_spec = cookies[settings.CSRF_COOKIE_NAME]
     assert isinstance(csrf_spec, CookieSpec)
     assert csrf_spec.skip_validation is True
-    assert csrf_spec.required is False
+    assert csrf_spec.required is True

--- a/tests/test_unit/test_security/test_django_session_auth.py
+++ b/tests/test_unit/test_security/test_django_session_auth.py
@@ -7,14 +7,22 @@ from django.conf import LazySettings
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpResponse
 from inline_snapshot import snapshot
+from typing_extensions import override
 
 from dmr import Controller, modify
+from dmr.cookies import CookieSpec
 from dmr.openapi.objects import SecurityScheme
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security import request_auth
 from dmr.security.django_session import (
     DjangoSessionAsyncAuth,
     DjangoSessionSyncAuth,
+)
+from dmr.security.django_session.views import (
+    DjangoSessionAsyncController,
+    DjangoSessionPayload,
+    DjangoSessionResponse,
+    DjangoSessionSyncController,
 )
 from dmr.settings import Settings
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
@@ -234,3 +242,67 @@ def test_schema_with_custom_cookie_names(
             security_scheme_in='cookie',
         ),
     })
+
+
+@final
+class _SyncLoginController(  # pragma: no cover
+    DjangoSessionSyncController[
+        PydanticSerializer,
+        DjangoSessionPayload,
+        DjangoSessionResponse,
+    ],
+):
+    @override
+    def convert_auth_payload(
+        self,
+        payload: DjangoSessionPayload,
+    ) -> DjangoSessionPayload:
+        return payload
+
+    @override
+    def make_api_response(self) -> DjangoSessionResponse:
+        return {'user_id': str(self.request.user.pk)}
+
+
+@final
+class _AsyncLoginController(  # pragma: no cover
+    DjangoSessionAsyncController[
+        PydanticSerializer,
+        DjangoSessionPayload,
+        DjangoSessionResponse,
+    ],
+):
+    @override
+    async def convert_auth_payload(
+        self,
+        payload: DjangoSessionPayload,
+    ) -> DjangoSessionPayload:
+        return payload
+
+    @override
+    async def make_api_response(self) -> DjangoSessionResponse:
+        return {'user_id': str((await self.request.auser()).pk)}
+
+
+@pytest.mark.parametrize(
+    'controller_cls',
+    [_SyncLoginController, _AsyncLoginController],
+)
+def test_login_schema_includes_csrf_cookie(
+    settings: LazySettings,
+    *,
+    controller_cls: type[_SyncLoginController] | type[_AsyncLoginController],
+) -> None:
+    """Ensures the 200 response schema declares session and CSRF cookies."""
+    settings.CSRF_USE_SESSIONS = False
+    endpoint = controller_cls.api_endpoints['POST']
+    cookies = endpoint.metadata.responses[HTTPStatus.OK].cookies
+
+    assert cookies is not None
+    assert settings.SESSION_COOKIE_NAME in cookies
+    assert settings.CSRF_COOKIE_NAME in cookies
+
+    csrf_spec = cookies[settings.CSRF_COOKIE_NAME]
+    assert isinstance(csrf_spec, CookieSpec)
+    assert csrf_spec.skip_validation is True
+    assert csrf_spec.required is False

--- a/tests/test_unit/test_security/test_django_session_auth.py
+++ b/tests/test_unit/test_security/test_django_session_auth.py
@@ -245,7 +245,7 @@ def test_schema_with_custom_cookie_names(
 
 
 @final
-class _SyncLoginController(  # pragma: no cover
+class _SyncLoginController(
     DjangoSessionSyncController[
         PydanticSerializer,
         DjangoSessionPayload,
@@ -257,15 +257,15 @@ class _SyncLoginController(  # pragma: no cover
         self,
         payload: DjangoSessionPayload,
     ) -> DjangoSessionPayload:
-        return payload
+        raise NotImplementedError
 
     @override
     def make_api_response(self) -> DjangoSessionResponse:
-        return {'user_id': str(self.request.user.pk)}
+        raise NotImplementedError
 
 
 @final
-class _AsyncLoginController(  # pragma: no cover
+class _AsyncLoginController(
     DjangoSessionAsyncController[
         PydanticSerializer,
         DjangoSessionPayload,
@@ -277,11 +277,11 @@ class _AsyncLoginController(  # pragma: no cover
         self,
         payload: DjangoSessionPayload,
     ) -> DjangoSessionPayload:
-        return payload
+        raise NotImplementedError
 
     @override
     async def make_api_response(self) -> DjangoSessionResponse:
-        return {'user_id': str((await self.request.auser()).pk)}
+        raise NotImplementedError
 
 
 @pytest.mark.parametrize(
@@ -294,7 +294,6 @@ def test_login_schema_includes_csrf_cookie(
     controller_cls: type[_SyncLoginController] | type[_AsyncLoginController],
 ) -> None:
     """Ensures the 200 response schema declares session and CSRF cookies."""
-    settings.CSRF_USE_SESSIONS = False
     endpoint = controller_cls.api_endpoints['POST']
     cookies = endpoint.metadata.responses[HTTPStatus.OK].cookies
 


### PR DESCRIPTION
# I have made things!

  - Added CSRF cookie to the OpenAPI response schema for `DjangoSessionSyncController` and         
  `DjangoSessionAsyncController` login endpoints; omitted when `CSRF_USE_SESSIONS=True`
  - Added integration tests verifying the CSRF cookie is set on login and absent when            
  `CSRF_USE_SESSIONS=True`                                                                         
  - Added unit test asserting the schema correctly declares both cookies
  - Docs update                              
                                                    

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

Refs #911 
