### PR TITLE
Raise original exc in `schema_generator.get_schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ of requirements for an API to count as public.
   `application/json` (the default browser `EventSource` case), which
   made 4xx/5xx error bodies and response validation crash with a 500
   instead of rendering the configured non-streaming default, #962
+- Fixed that original traceback was not shown
+  for `BaseSchemaGenerator.get_schema`, #961
 
 ### Misc
 

--- a/dmr/openapi/generators/schema.py
+++ b/dmr/openapi/generators/schema.py
@@ -82,21 +82,22 @@ class SchemaGenerator:
         if existing_reference is not None:
             return existing_reference
 
-        schemas = serializer.schema_generator.get_schema(
-            annotation,
-            ref_template=self._context.registries.schema.schema_prefix,
-            used_for_response=used_for_response,
-        )
-        if schemas is not None:
-            return self._maybe_generate_reference(
+        try:
+            schemas = serializer.schema_generator.get_schema(
                 annotation,
-                *schemas,
-                serializer,
-                skip_registration=skip_registration,
+                ref_template=self._context.registries.schema.schema_prefix,
+                used_for_response=used_for_response,
             )
-        raise UnsolvableAnnotationsError(
-            f'Cannot generate OpenAPI schema from {annotation}, '
-            'consider registering it as described in your serializer',
+        except Exception as exc:
+            raise UnsolvableAnnotationsError(
+                f'Cannot generate OpenAPI schema from {annotation}, '
+                'consider registering it as described in your serializer',
+            ) from exc
+        return self._maybe_generate_reference(
+            annotation,
+            *schemas,
+            serializer,
+            skip_registration=skip_registration,
         )
 
     def _resolve_schema_override(

--- a/dmr/plugins/msgspec/schema.py
+++ b/dmr/plugins/msgspec/schema.py
@@ -17,15 +17,12 @@ class MsgspecSchemaGenerator(BaseSchemaGenerator):
         ref_template: str,
         *,
         used_for_response: bool = False,
-    ) -> SchemaDef | None:
+    ) -> SchemaDef:
         """Proxies the JSON schema generation to msgspec itself."""
-        try:
-            out = schema(
-                model,
-                ref_template=ref_template + '{name}',  # noqa: WPS336
-            )
-        except Exception:
-            return None
+        out = schema(
+            model,
+            ref_template=ref_template + '{name}',  # noqa: WPS336
+        )
         components = out.pop('$defs', {})
         return out, components
 
@@ -33,5 +30,8 @@ class MsgspecSchemaGenerator(BaseSchemaGenerator):
     @classmethod
     def schema_name(cls, model: Any) -> str | None:
         """Return a schema name for a model, if it exists."""
-        schema = cls.get_schema(model, ref_template='')
-        return schema[0].get('title') if schema else None
+        try:
+            schema = cls.get_schema(model, ref_template='')
+        except Exception:
+            return None
+        return schema[0].get('title')

--- a/dmr/plugins/pydantic/schema.py
+++ b/dmr/plugins/pydantic/schema.py
@@ -16,20 +16,16 @@ class PydanticSchemaGenerator(BaseSchemaGenerator):
         ref_template: str,
         *,
         used_for_response: bool = False,
-    ) -> SchemaDef | None:
+    ) -> SchemaDef:
         """Proxies the JSON schema generation to pydantic itself."""
         from dmr.plugins.pydantic.serializer import (  # noqa: PLC0415
             _get_cached_type_adapter,  # pyright: ignore[reportPrivateUsage]
         )
 
-        try:
-            schema = _get_cached_type_adapter(model).json_schema(
-                ref_template=ref_template + '{model}',  # noqa: WPS336, RUF027
-                mode='serialization' if used_for_response else 'validation',
-            )
-        except Exception:
-            return None
-
+        schema = _get_cached_type_adapter(model).json_schema(
+            ref_template=ref_template + '{model}',  # noqa: WPS336, RUF027
+            mode='serialization' if used_for_response else 'validation',
+        )
         components = schema.pop('$defs', {})
         return schema, components
 
@@ -37,5 +33,8 @@ class PydanticSchemaGenerator(BaseSchemaGenerator):
     @classmethod
     def schema_name(cls, model: Any) -> str | None:
         """Return a schema name for a model, if it exists."""
-        schema = cls.get_schema(model, ref_template='')
-        return schema[0].get('title') if schema else None
+        try:
+            schema = cls.get_schema(model, ref_template='')
+        except Exception:
+            return None
+        return schema[0].get('title')

--- a/dmr/serializer.py
+++ b/dmr/serializer.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias
 
 from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
@@ -16,7 +16,69 @@ _CANNOT_DESERIALIZE_MSG: Final = _(
     'Value {value} of type {type} is not supported for {target_type}',
 )
 
-_ModelT = TypeVar('_ModelT')
+SchemaDef: TypeAlias = tuple[
+    dict[str, Any],
+    dict[str, Any],
+]
+
+
+class BaseEndpointOptimizer:
+    """
+    Plugins might often need to run some specific preparations for endpoints.
+
+    To achieve that we provide an explicit API for that.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def optimize_endpoint(cls, metadata: 'EndpointMetadata') -> None:
+        """
+        Optimize the endpoint.
+
+        Args:
+            metadata: Endpoint metadata to optimize.
+
+        """
+        raise NotImplementedError
+
+
+class BaseSchemaGenerator:
+    """Generates JSON schema by the native serializer API."""
+
+    @classmethod
+    @abc.abstractmethod
+    def get_schema(
+        cls,
+        model: Any,
+        ref_template: str,
+        *,
+        used_for_response: bool = False,
+    ) -> SchemaDef:
+        """
+        Provide JSON schema / OpenAPI spec for the given model.
+
+        Args:
+            model: Model to generate JSON schema for.
+            ref_template: Reference template to use for the references.
+            used_for_response: Is this schema used for the response or request.
+
+        Raises:
+            Exception: when schema cannot be built.
+                Can be any :exc:`Exception` subclass instance.
+
+        """
+        raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def schema_name(cls, model: Any) -> str | None:
+        """
+        Return a schema name for a model, if it exists.
+
+        It is done directly by the serializer,
+        we don't store any specific logic for it.
+        """
+        raise NotImplementedError
 
 
 class BaseSerializer:  # noqa: WPS214
@@ -41,7 +103,7 @@ class BaseSerializer:  # noqa: WPS214
         optimizer: Endpoint optimizer.
             Type that pre-compiles / creates / caches models in import time.
             Required to be set in subclasses.
-        openapi:
+        schema_generator: Generates schema and schema names for the OpenAPI.
 
     """
 
@@ -49,8 +111,8 @@ class BaseSerializer:  # noqa: WPS214
 
     # API that needs to be set in subclasses:
     validation_error: ClassVar[type[Exception]]
-    optimizer: ClassVar[type['BaseEndpointOptimizer']]
-    schema_generator: ClassVar[type['BaseSchemaGenerator']]
+    optimizer: ClassVar[type[BaseEndpointOptimizer]]
+    schema_generator: ClassVar[type[BaseSchemaGenerator]]
 
     @classmethod
     @abc.abstractmethod
@@ -190,64 +252,3 @@ class BaseSerializer:  # noqa: WPS214
         will raise an import-time validation error.
         """
         return True  # By default all are supported
-
-
-class BaseEndpointOptimizer:
-    """
-    Plugins might often need to run some specific preparations for endpoints.
-
-    To achieve that we provide an explicit API for that.
-    """
-
-    @classmethod
-    @abc.abstractmethod
-    def optimize_endpoint(cls, metadata: 'EndpointMetadata') -> None:
-        """
-        Optimize the endpoint.
-
-        Args:
-            metadata: Endpoint metadata to optimize.
-
-        """
-        raise NotImplementedError
-
-
-SchemaDef: TypeAlias = tuple[
-    dict[str, Any],
-    dict[str, Any],
-]
-
-
-class BaseSchemaGenerator:
-    """Generates JSON schema by the native serializer API."""
-
-    @classmethod
-    @abc.abstractmethod
-    def get_schema(
-        cls,
-        model: Any,
-        ref_template: str,
-        *,
-        used_for_response: bool = False,
-    ) -> SchemaDef | None:
-        """
-        Provide JSON schema / OpenAPI spec for the given model.
-
-        Args:
-            model: Model to generate JSON schema for.
-            ref_template: Reference template to use for the references.
-            used_for_response: Is this schema used for the response or request.
-
-        """
-        raise NotImplementedError
-
-    @classmethod
-    @abc.abstractmethod
-    def schema_name(cls, model: Any) -> str | None:
-        """
-        Return a schema name for a model, if it exists.
-
-        It is done directly by the serializer,
-        we don't store any specific logic for it.
-        """
-        raise NotImplementedError

--- a/tests/test_unit/test_plugins/test_msgspec/test_msgspec_schema_errors.py
+++ b/tests/test_unit/test_plugins/test_msgspec/test_msgspec_schema_errors.py
@@ -1,0 +1,50 @@
+import pytest
+
+try:
+    import msgspec
+except ImportError:  # pragma: no cover
+    pytest.skip(reason='msgspec is not installed', allow_module_level=True)
+
+from dmr import Controller
+from dmr.exceptions import UnsolvableAnnotationsError
+from dmr.openapi import build_schema
+from dmr.plugins.msgspec import MsgspecSerializer
+from dmr.routing import Router, path
+
+
+class _EventA(msgspec.Struct, frozen=True):
+    field_a: str
+
+
+class _EventB(msgspec.Struct, frozen=True):
+    field_b: int
+
+
+class _ControllerWithUnion(Controller[MsgspecSerializer]):
+    async def get(self) -> _EventA | _EventB:
+        raise NotImplementedError
+
+
+def test_schema_error_contains_original_error() -> None:
+    """Ensures that errors from schema generation are propagated."""
+    router = Router(
+        'api/v1/',
+        [path('/whatever', _ControllerWithUnion.as_view())],
+    )
+
+    with pytest.raises(
+        UnsolvableAnnotationsError,
+        match='Cannot generate OpenAPI schema',
+    ) as exc:
+        build_schema(router).convert()
+
+    assert isinstance(exc.value.__cause__, TypeError)
+    assert 'union' in str(exc.value.__cause__)
+
+
+def test_schema_error_name() -> None:
+    """Ensures that schema name does not error out."""
+    assert (
+        MsgspecSerializer.schema_generator.schema_name(_EventA | _EventB)
+        is None
+    )

--- a/tests/test_unit/test_plugins/test_pydantic/test_pyndatic_schema_errors.py
+++ b/tests/test_unit/test_plugins/test_pydantic/test_pyndatic_schema_errors.py
@@ -1,0 +1,55 @@
+from typing import Final
+
+import pydantic
+import pytest
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema as cs
+
+from dmr import Controller
+from dmr.exceptions import UnsolvableAnnotationsError
+from dmr.openapi import build_schema
+from dmr.plugins.pydantic import PydanticFastSerializer
+from dmr.routing import Router, path
+
+_ERR_MSG: Final = 'from __get_pydantic_json_schema__'
+
+
+class _NotModel(pydantic.BaseModel):
+    email: str
+
+    @classmethod
+    def __get_pydantic_json_schema__(  # noqa: PLW3201
+        cls,
+        core_schema: cs.CoreSchema,
+        handler: pydantic.GetJsonSchemaHandler,  # noqa: WPS110
+    ) -> JsonSchemaValue:
+        raise TypeError(_ERR_MSG)
+
+
+class _ControllerWithNotModel(Controller[PydanticFastSerializer]):
+    async def get(self) -> _NotModel:
+        raise NotImplementedError
+
+
+def test_schema_error_contains_original_error() -> None:
+    """Ensures that errors from schema generation are propagated."""
+    router = Router(
+        'api/v1/',
+        [path('/whatever', _ControllerWithNotModel.as_view())],
+    )
+
+    with pytest.raises(
+        UnsolvableAnnotationsError,
+        match='Cannot generate OpenAPI schema',
+    ) as exc:
+        build_schema(router).convert()
+
+    assert isinstance(exc.value.__cause__, TypeError)
+    assert _ERR_MSG in str(exc.value.__cause__)
+
+
+def test_schema_error_name() -> None:
+    """Ensures that schema name does not error out."""
+    assert (
+        PydanticFastSerializer.schema_generator.schema_name(_NotModel) is None
+    )

--- a/tests/test_unit/test_plugins/test_pydantic/test_pyndatic_schema_errors.py
+++ b/tests/test_unit/test_plugins/test_pydantic/test_pyndatic_schema_errors.py
@@ -4,6 +4,7 @@ import pydantic
 import pytest
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema as cs
+from typing_extensions import override
 
 from dmr import Controller
 from dmr.exceptions import UnsolvableAnnotationsError
@@ -18,7 +19,8 @@ class _NotModel(pydantic.BaseModel):
     email: str
 
     @classmethod
-    def __get_pydantic_json_schema__(  # noqa: PLW3201
+    @override
+    def __get_pydantic_json_schema__(
         cls,
         core_schema: cs.CoreSchema,
         handler: pydantic.GetJsonSchemaHandler,  # noqa: WPS110


### PR DESCRIPTION
After thinking on https://github.com/wemake-services/django-modern-rest/issues/961 more, I decided that we need to show the original error message, otherwise - it would be confusing for end users not to know what happened.

Closes #961