### PR TITLE
Rework `backend` throttling API to include atomic `.incr` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ of requirements for an API to count as public.
   and `BaseThrottleSyncBackend`, #942
 - *Breaking*: Renamed `DjangoCache` into `DjangoSyncCache`,
   added `DjangoAsyncCache`, #942
+- *Breaking*: Changed `BaseThrottleBackend` API: now it requires
+  `.incr` and `.get` methods, the first one should ideally
+  be an atomic increment, the second one is for reading objects only, #942
 - *Breaking*: Removed `BaseThrottleAlgorithm.record` method,
   now `BaseThrottleAlgorithm.access` must also record accesses.
   This will help to make throttling more atomic, #942

--- a/dmr/throttling/backends.py
+++ b/dmr/throttling/backends.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from dmr.controller import Controller
     from dmr.endpoint import Endpoint
     from dmr.serializer import BaseSerializer
+    from dmr.throttling import AsyncThrottle, SyncThrottle
+    from dmr.throttling.algorithms import BaseThrottleAlgorithm
 
 
 class CachedRateLimit(TypedDict):
@@ -34,26 +36,31 @@ class BaseThrottleSyncBackend:
     __slots__ = ()
 
     @abc.abstractmethod
+    def incr(
+        self,
+        endpoint: 'Endpoint',
+        controller: 'Controller[BaseSerializer]',
+        throttle: 'SyncThrottle',
+        *,
+        cache_key: str,
+        algorithm: 'BaseThrottleAlgorithm',
+        ttl_seconds: int,
+    ) -> CachedRateLimit:
+        """
+        Sync increment cached rate limit state.
+
+        Can be atomic, can be non atomic. Atomicity needs to be documented.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def get(
         self,
         endpoint: 'Endpoint',
         controller: 'Controller[BaseSerializer]',
         cache_key: str,
     ) -> CachedRateLimit | None:
-        """Sync get the cached rate limit state."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def set(
-        self,
-        endpoint: 'Endpoint',
-        controller: 'Controller[BaseSerializer]',
-        cache_key: str,
-        cache_object: CachedRateLimit,
-        *,
-        ttl_seconds: int,
-    ) -> None:
-        """Sync set the cached rate limit state."""
+        """Sync get the state with no increments."""
         raise NotImplementedError
 
 
@@ -67,26 +74,27 @@ class BaseThrottleAsyncBackend:
     __slots__ = ()
 
     @abc.abstractmethod
-    async def aget(
+    async def incr(
+        self,
+        endpoint: 'Endpoint',
+        controller: 'Controller[BaseSerializer]',
+        throttle: 'AsyncThrottle',
+        *,
+        cache_key: str,
+        algorithm: 'BaseThrottleAlgorithm',
+        ttl_seconds: int,
+    ) -> CachedRateLimit:
+        """Async increment cached rate limit state."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def get(
         self,
         endpoint: 'Endpoint',
         controller: 'Controller[BaseSerializer]',
         cache_key: str,
     ) -> CachedRateLimit | None:
-        """Async get the cached rate limit state."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    async def aset(
-        self,
-        endpoint: 'Endpoint',
-        controller: 'Controller[BaseSerializer]',
-        cache_key: str,
-        cache_object: CachedRateLimit,
-        *,
-        ttl_seconds: int,
-    ) -> None:
-        """Async set the cached rate limit state."""
+        """Sync get the state with no increments."""
         raise NotImplementedError
 
 
@@ -139,6 +147,33 @@ class DjangoSyncCache(_DjangoCache, BaseThrottleSyncBackend):
     """
 
     @override
+    def incr(
+        self,
+        endpoint: 'Endpoint',
+        controller: 'Controller[BaseSerializer]',
+        throttle: 'SyncThrottle',
+        *,
+        cache_key: str,
+        algorithm: 'BaseThrottleAlgorithm',
+        ttl_seconds: int,
+    ) -> CachedRateLimit:
+        # It is not atomic, but this is fine, we document this:
+        cache_object = algorithm.access(
+            endpoint,
+            controller,
+            throttle,
+            self.get(endpoint, controller, cache_key),
+        )
+        self._set(
+            endpoint,
+            controller,
+            cache_key,
+            cache_object,
+            ttl_seconds=ttl_seconds,
+        )
+        return cache_object
+
+    @override
     def get(
         self,
         endpoint: 'Endpoint',
@@ -149,8 +184,7 @@ class DjangoSyncCache(_DjangoCache, BaseThrottleSyncBackend):
         stored_cache = self._cache.get(cache_key)
         return self._load_cache(controller, stored_cache)
 
-    @override
-    def set(
+    def _set(
         self,
         endpoint: 'Endpoint',
         controller: 'Controller[BaseSerializer]',
@@ -179,7 +213,34 @@ class DjangoAsyncCache(_DjangoCache, BaseThrottleAsyncBackend):
     """
 
     @override
-    async def aget(
+    async def incr(
+        self,
+        endpoint: 'Endpoint',
+        controller: 'Controller[BaseSerializer]',
+        throttle: 'AsyncThrottle',
+        *,
+        cache_key: str,
+        algorithm: 'BaseThrottleAlgorithm',
+        ttl_seconds: int,
+    ) -> CachedRateLimit:
+        # It is not atomic, but this is fine, we document this:
+        cache_object = algorithm.access(
+            endpoint,
+            controller,
+            throttle,
+            await self.get(endpoint, controller, cache_key),
+        )
+        await self._set(
+            endpoint,
+            controller,
+            cache_key,
+            cache_object,
+            ttl_seconds=ttl_seconds,
+        )
+        return cache_object
+
+    @override
+    async def get(
         self,
         endpoint: 'Endpoint',
         controller: 'Controller[BaseSerializer]',
@@ -189,8 +250,7 @@ class DjangoAsyncCache(_DjangoCache, BaseThrottleAsyncBackend):
         stored_cache = await self._cache.aget(cache_key)
         return self._load_cache(controller, stored_cache)
 
-    @override
-    async def aset(
+    async def _set(
         self,
         endpoint: 'Endpoint',
         controller: 'Controller[BaseSerializer]',

--- a/dmr/throttling/base.py
+++ b/dmr/throttling/base.py
@@ -236,17 +236,12 @@ class SyncThrottle(_BaseThrottle[BaseThrottleSyncBackend]):
     ) -> None:
         """Check whether this request has rate limiting quota left."""
         # NOTE: this is locked on endpoint.py level, don't worry:
-        cache_object = self._algorithm.access(
+        self._backend.incr(
             endpoint,
             controller,
             self,
-            self._backend.get(endpoint, controller, cache_key),
-        )
-        self._backend.set(
-            endpoint,
-            controller,
-            cache_key,
-            cache_object,
+            cache_key=cache_key,
+            algorithm=self._algorithm,
             ttl_seconds=self.duration_in_seconds,
         )
 
@@ -306,17 +301,12 @@ class AsyncThrottle(_BaseThrottle[BaseThrottleAsyncBackend]):
     ) -> None:
         """Check whether this request has rate limiting quota left."""
         # NOTE: this is locked on endpoint.py level, don't worry:
-        cache_object = self._algorithm.access(
+        await self._backend.incr(
             endpoint,
             controller,
             self,
-            await self._backend.aget(endpoint, controller, cache_key),
-        )
-        await self._backend.aset(
-            endpoint,
-            controller,
-            cache_key,
-            cache_object,
+            cache_key=cache_key,
+            algorithm=self._algorithm,
             ttl_seconds=self.duration_in_seconds,
         )
 
@@ -333,7 +323,7 @@ class AsyncThrottle(_BaseThrottle[BaseThrottleAsyncBackend]):
             endpoint,
             controller,
             self,
-            await self._backend.aget(endpoint, controller, cache_key),
+            await self._backend.get(endpoint, controller, cache_key),
         )
 
 

--- a/docs/pages/throttling.rst
+++ b/docs/pages/throttling.rst
@@ -118,7 +118,7 @@ to store throttling information in memory, filesystem, or somewhere else.
 To do so, you would need to subclass
 :class:`dmr.throttling.backends.BaseThrottleSyncBackend`
 or :class:`dmr.throttling.backends.BaseThrottleAsyncBackend`
-and override 4 methods.
+and override 2 methods.
 
 Full list of backends that we ship in ``django-modern-rest``:
 

--- a/schemathesis.toml
+++ b/schemathesis.toml
@@ -3,6 +3,8 @@
 fail-on = true
 
 [auth.openapi.http_basic]
+# Our own credentials from
+# django_test_app/server/apps/controllers/auth.py
 username = 'test'
 password = 'pass'
 

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -57,7 +57,7 @@ def _modify_integration_settings(settings: LazySettings) -> None:
 # The `transactional_db` fixture is required to enable database access.
 # When `st.openapi.from_wsgi()` makes a WSGI request, Django's request
 # lifecycle triggers database operations.
-# The `admin_user` fixture is required here so that `JWTAuth` can use
+# The `admin_user` fixture is required here so that auth can use
 # its credentials (username and password) for authentication.
 # This follows the `pytest-django` pattern for creating user fixtures:
 # https://github.com/pytest-dev/pytest-django/blob/main/pytest_django/fixtures.py#L483


### PR DESCRIPTION
Refs #942 
Closes #959