### PR TITLE
ci: add Valkey test job to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           - python-version: '3.14t'
             force_free_gil: true
             docker-compose-services: 'redis'
+          - python-version: '3.13'
+            docker-compose-services: 'valkey'
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,7 +63,7 @@ jobs:
         # No way to exclude the platform on a file level.
         uv pip install orjson || true
 
-    - name: Wait for Redis to come online
+    - name: Wait for database to come online
       if: ${{ matrix.docker-compose-services }}
       run: wait-for-it --host='localhost' --port=6379 --timeout=30 --strict
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,14 @@ services:
       timeout: 30s
       retries: 5
       start_period: 1s
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: valkey-cli --raw incr ping
+      interval: 2s
+      timeout: 30s
+      retries: 5
+      start_period: 1s


### PR DESCRIPTION
Adds Valkey alongside Redis in CI to verify throttling backend compatibility.

**Changes:**
- : valkey/valkey:8-alpine service on port 6379
- : single matrix include (Python 3.13, valkey)

Scope per [maintainer guidance](https://github.com/wemake-services/django-modern-rest/issues/980#issuecomment-2793537085): single job, not full suite. Valkey is wire-compatible with Redis, so the same wait-for-it and test harness applies.

Closes #980