### PR TITLE
Add `allow_unsafe_throttle_cache` setting for cache backend safety cheks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ of requirements for an API to count as public.
 
 ### Features
 
+- Added `allow_unsafe_throttle_cache` setting to control whether unsafe
+  cache backends (`LocMemCache`, `DummyCache`) are allowed for throttling.
+  Raises `ImproperlyConfigured` by default; when explicitly set to `True`,
+  emits `UserWarning` on each use, #978
 - Added `--no-ensure-ascii` flag to `dmr_export_schema` management command
 
 ### Bugfixes

--- a/django_test_app/server/settings.py
+++ b/django_test_app/server/settings.py
@@ -152,6 +152,12 @@ STATIC_ROOT = Path(tempfile.gettempdir()) / 'dmr-example-staticfiles'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# DMR settings for the test application:
+DMR_SETTINGS = {
+    # Allow unsafe cache backends (LocMemCache) for testing:
+    'allow_unsafe_throttle_cache': True,
+}
+
 # Content Security Policy:
 # https://django-csp.readthedocs.io/en/latest/configuration.html
 

--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -69,6 +69,7 @@ class Settings(enum.StrEnum):
     openapi_examples_seed = 'openapi_examples_seed'
     django_treat_as_post = 'django_treat_as_post'
     openapi_static_cdn = 'openapi_static_cdn'
+    allow_unsafe_throttle_cache = 'allow_unsafe_throttle_cache'
 
 
 @final
@@ -119,6 +120,7 @@ class SettingsDict(TypedDict, total=False):
     openapi_examples_seed: int | None
     django_treat_as_post: Set[str]
     openapi_static_cdn: dict[str, str]
+    allow_unsafe_throttle_cache: bool
 
 
 assert SettingsDict.__optional_keys__ == set(Settings), (  # noqa: S101
@@ -155,6 +157,9 @@ _DEFAULTS: Final[Mapping[str, Any]] = {  # noqa: WPS407
     Settings.django_treat_as_post: frozenset(('PUT', 'PATCH')),
     # OpenAPI static CDN configuration:
     Settings.openapi_static_cdn: {},
+    # When True, allows using unsafe cache backends for throttling
+    # in production (LocMemCache, DummyCache). Not recommended.
+    Settings.allow_unsafe_throttle_cache: False,
 }
 
 assert all(setting_key in _DEFAULTS for setting_key in Settings), (  # noqa: S101

--- a/dmr/throttling/backends/_cache_safety.py
+++ b/dmr/throttling/backends/_cache_safety.py
@@ -1,0 +1,58 @@
+import warnings
+
+from django.core.cache import caches
+from django.core.exceptions import ImproperlyConfigured
+
+_UNSAFE_CACHE_BACKENDS = frozenset((
+    'django.core.cache.backends.locmem.LocMemCache',
+    'django.core.cache.backends.dummy.DummyCache',
+))
+
+_WARNING_MSG = (
+    "Throttling is using '{backend}' cache backend which is not safe for "
+    'production: counters are NOT shared between processes/instances. '
+    'Use Redis or Memcached instead.'
+)
+
+_ERROR_MSG = (
+    _WARNING_MSG
+    + ' To suppress this error and run at your own risk, set '
+    + "'allow_unsafe_throttle_cache': True in DMR_SETTINGS."
+)
+
+# Tracks which cache names have already been checked to avoid redundant
+# checks on every throttling operation:
+_CHECKED_CACHES: set[str] = set()
+
+
+def is_cache_checked(cache_name: str) -> bool:
+    """Return whether the given cache name has already been checked."""
+    return cache_name in _CHECKED_CACHES
+
+
+def clear_safety_checks() -> None:
+    """Clear the set of checked cache names.
+
+    Useful in tests when re-checking with different settings.
+    """
+    _CHECKED_CACHES.clear()
+
+
+def check_throttle_cache_safety(cache_name: str) -> None:
+    cache = caches[cache_name]
+    backend = f'{type(cache).__module__}.{type(cache).__qualname__}'
+
+    if backend not in _UNSAFE_CACHE_BACKENDS:
+        _CHECKED_CACHES.add(cache_name)
+        return
+
+    from dmr.settings import Settings, resolve_setting  # noqa: PLC0415
+
+    allow_unsafe = resolve_setting(Settings.allow_unsafe_throttle_cache)
+    _CHECKED_CACHES.add(cache_name)
+    if allow_unsafe:
+        warnings.warn(  # noqa: B028
+            _WARNING_MSG.format(backend=backend),
+        )
+    else:
+        raise ImproperlyConfigured(_ERROR_MSG.format(backend=backend))

--- a/dmr/throttling/backends/django_cache.py
+++ b/dmr/throttling/backends/django_cache.py
@@ -30,6 +30,16 @@ class _DjangoCache:
         """Initialize the cache backend."""
         object.__setattr__(self, '_cache', caches[self.cache_name])
 
+    def _ensure_safety(self) -> None:
+        from dmr.throttling.backends._cache_safety import (  # noqa: PLC0415
+            check_throttle_cache_safety,
+            is_cache_checked,
+        )
+
+        if is_cache_checked(self.cache_name):
+            return
+        check_throttle_cache_safety(self.cache_name)
+
     def _load_cache(
         self,
         controller: 'Controller[BaseSerializer]',
@@ -77,6 +87,7 @@ class SyncDjangoCache(_DjangoCache, BaseThrottleSyncBackend):
         cache_key: str,
         algorithm: 'BaseThrottleAlgorithm',
     ) -> CachedRateLimit:
+        self._ensure_safety()
         # It is not atomic, but this is fine, we document this:
         cache_object = algorithm.access(
             endpoint,
@@ -103,6 +114,7 @@ class SyncDjangoCache(_DjangoCache, BaseThrottleSyncBackend):
         cache_key: str,
     ) -> CachedRateLimit | None:
         """Sync get the cached rate limit state."""
+        self._ensure_safety()
         stored_cache = self._cache.get(cache_key)
         return self._load_cache(controller, stored_cache)
 
@@ -144,6 +156,7 @@ class AsyncDjangoCache(_DjangoCache, BaseThrottleAsyncBackend):
         cache_key: str,
         algorithm: 'BaseThrottleAlgorithm',
     ) -> CachedRateLimit:
+        self._ensure_safety()
         # It is not atomic, but this is fine, we document this:
         cache_object = algorithm.access(
             endpoint,
@@ -170,6 +183,7 @@ class AsyncDjangoCache(_DjangoCache, BaseThrottleAsyncBackend):
         cache_key: str,
     ) -> CachedRateLimit | None:
         """Async get the cached rate limit state."""
+        self._ensure_safety()
         stored_cache = await self._cache.aget(cache_key)
         return self._load_cache(controller, stored_cache)
 

--- a/docs/pages/throttling.rst
+++ b/docs/pages/throttling.rst
@@ -164,6 +164,22 @@ Full list of backends that we ship in ``django-modern-rest``:
 
   Some like ``django.core.cache.backends.dummy.DummyCache`` do nothing at all.
 
+  By default, **django-modern-rest** raises
+  :exc:`~django.core.exceptions.ImproperlyConfigured`
+  when detecting an unsafe cache backend for throttling.
+  To suppress this check and run at your own risk,
+  set ``allow_unsafe_throttle_cache`` to ``True`` in
+  :ref:`DMR_SETTINGS <dmr-settings>`:
+
+  .. code-block:: python
+
+    DMR_SETTINGS = {
+        'allow_unsafe_throttle_cache': True,
+    }
+
+  When explicitly allowed, a :class:`UserWarning` is emitted on each use.
+  Always prefer a shared backend like Redis or Memcached in production.
+
 Choosing a backend
 ^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,6 +281,7 @@ select = [
 ]
 ignore = [
   "A005",   # allow to shadow stdlib and builtin module names
+  "COM812", # trailing commas — conflicts with ruff formatter
   # Different doc rules that we don't really care about:
   "D100",
   "D104",
@@ -336,7 +337,10 @@ isort.known-first-party = ["server", "examples"]
 # Strict `@xfail` by default:
 xfail_strict = true
 # Fail on warnings:
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "always::UserWarning:dmr.throttling.backends._cache_safety",
+]
 
 # Django options:
 # https://pytest-django.readthedocs.io/en/latest/

--- a/tests/test_unit/test_throttling/test_throttling.py
+++ b/tests/test_unit/test_throttling/test_throttling.py
@@ -213,6 +213,7 @@ async def test_throttle_async_per_settings(
     """Ensures that async throttling from settings work."""
     settings.DMR_SETTINGS = {
         Settings.throttling: [AsyncThrottle(_ATTEMPTS, Rate.second)],
+        Settings.allow_unsafe_throttle_cache: True,
     }
 
     class _AsyncController(
@@ -270,6 +271,7 @@ def test_throttle_sync_multiple_sources(
     """Ensures that sync throttling from settings work."""
     settings.DMR_SETTINGS = {
         Settings.throttling: [SyncThrottle(_ATTEMPTS, Rate.second)],
+        Settings.allow_unsafe_throttle_cache: True,
     }
 
     class _SyncController(

--- a/tests/test_unit/test_throttling/test_unsafe_cache_warning.py
+++ b/tests/test_unit/test_throttling/test_unsafe_cache_warning.py
@@ -1,0 +1,99 @@
+import warnings
+from collections.abc import Generator
+from types import MappingProxyType
+from typing import Final
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+from dmr.internal.cache import clear_settings_cache
+from dmr.throttling.backends._cache_safety import (
+    check_throttle_cache_safety,
+    clear_safety_checks,
+)
+
+LOCMEM_CACHES: Final = MappingProxyType({
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+})
+DUMMY_CACHES: Final = MappingProxyType({
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+})
+REDIS_CACHES: Final = MappingProxyType({
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': 'redis://localhost:6379',
+    },
+})
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> Generator[None, None, None]:
+    """Reset DMR settings cache and safety checks before/after each test."""
+    clear_settings_cache()
+    clear_safety_checks()
+    yield
+    clear_settings_cache()
+    clear_safety_checks()
+
+
+@override_settings(CACHES=LOCMEM_CACHES, DMR_SETTINGS={})
+def test_raises_by_default_with_locmem() -> None:
+    """ImproperlyConfigured is raised for LocMemCache by default."""
+    with pytest.raises(
+        ImproperlyConfigured,
+        match='allow_unsafe_throttle_cache',
+    ):
+        check_throttle_cache_safety('default')
+
+
+@override_settings(CACHES=DUMMY_CACHES, DMR_SETTINGS={})
+def test_raises_by_default_with_dummy() -> None:
+    """ImproperlyConfigured is raised for DummyCache by default."""
+    with pytest.raises(
+        ImproperlyConfigured,
+        match='allow_unsafe_throttle_cache',
+    ):
+        check_throttle_cache_safety('default')
+
+
+@override_settings(
+    CACHES=LOCMEM_CACHES,
+    DMR_SETTINGS={'allow_unsafe_throttle_cache': True},
+)
+def test_warns_when_allow_unsafe_with_locmem() -> None:
+    """Warning is emitted when allow_unsafe_throttle_cache=True."""
+    with pytest.warns(UserWarning, match='not safe for production'):
+        check_throttle_cache_safety('default')
+
+
+@override_settings(
+    CACHES=DUMMY_CACHES,
+    DMR_SETTINGS={'allow_unsafe_throttle_cache': True},
+)
+def test_warns_when_allow_unsafe_with_dummy() -> None:
+    """Warning is emitted when allow_unsafe_throttle_cache=True."""
+    with pytest.warns(UserWarning, match='not safe for production'):
+        check_throttle_cache_safety('default')
+
+
+@override_settings(
+    CACHES=REDIS_CACHES,
+    DMR_SETTINGS={'allow_unsafe_throttle_cache': True},
+)
+def test_no_warning_for_safe_backend() -> None:
+    """No warning or error for safe backends like Redis."""
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        check_throttle_cache_safety('default')
+    assert len(record) == 0
+
+
+@override_settings(CACHES=REDIS_CACHES, DMR_SETTINGS={})
+def test_no_error_for_safe_backend_default() -> None:
+    """No error for safe backends with default settings."""
+    check_throttle_cache_safety('default')


### PR DESCRIPTION
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues
Closes #978

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
`LocMemCache` and `DummyCache` don't share state between processes, so using them for throttling silently breaks rate limiting in production. This PR makes that configuration fail loudly.

By default, an `ImproperlyConfigured` exception is raised when an unsafe backend is detected. Setting `allow_unsafe_throttle_cache = True` in `DMR_SETTINGS` opts in to unsafe behavior — in that case a `UserWarning` is emitted on the first throttling operation so at least you know it's on.

The check is lazy (fires on first incr/get, not at instantiation) to avoid breaking tests that create backend instances early. `_CHECKED_CACHES` is module-level so the check doesn't repeat on every request, and it's intentionally not tied to `clear_settings_cache()`.