### PR TITLE
issue-1006: Add compatibility with Django 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ of requirements for an API to count as public.
 
 - Fixed how `msgspec` generates `null` in `anyOf`,
   it is now always the last item, #990
+- Fixed ImportError while using with `django==5.2.0`
 
 
 ## Version 0.8.0 (2026-04-26)

--- a/dmr/response.py
+++ b/dmr/response.py
@@ -6,7 +6,10 @@ from urllib.parse import urlsplit
 from django.core.exceptions import DisallowedRedirect
 from django.http import HttpResponse
 from django.utils.encoding import iri_to_uri
-from django.utils.http import MAX_URL_REDIRECT_LENGTH
+try:
+    from django.utils.http import MAX_URL_REDIRECT_LENGTH
+except ImportError:
+    MAX_URL_REDIRECT_LENGTH = 16384  # Django 5.2 compat
 from typing_extensions import TypeVar
 
 from dmr.cookies import NewCookie, set_cookies

--- a/dmr/response.py
+++ b/dmr/response.py
@@ -10,7 +10,8 @@ from django.utils.encoding import iri_to_uri
 try:
     from django.utils.http import MAX_URL_REDIRECT_LENGTH
 except ImportError:  # pragma: no cover
-    MAX_URL_REDIRECT_LENGTH = 16384  # Django 5.2 compat
+    # Django 5.2.0 compat:
+    MAX_URL_REDIRECT_LENGTH = 16384  # pyright: ignore[reportConstantRedefinition]
 from typing_extensions import TypeVar
 
 from dmr.cookies import NewCookie, set_cookies

--- a/dmr/response.py
+++ b/dmr/response.py
@@ -9,7 +9,7 @@ from django.utils.encoding import iri_to_uri
 
 try:
     from django.utils.http import MAX_URL_REDIRECT_LENGTH
-except ImportError:
+except ImportError:  # pragma: no cover
     MAX_URL_REDIRECT_LENGTH = 16384  # Django 5.2 compat
 from typing_extensions import TypeVar
 

--- a/dmr/response.py
+++ b/dmr/response.py
@@ -6,6 +6,7 @@ from urllib.parse import urlsplit
 from django.core.exceptions import DisallowedRedirect
 from django.http import HttpResponse
 from django.utils.encoding import iri_to_uri
+
 try:
     from django.utils.http import MAX_URL_REDIRECT_LENGTH
 except ImportError:


### PR DESCRIPTION
Handle ImportError for MAX_URL_REDIRECT_LENGTH for compatibility with Django 5.2.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
    - Not sure I shall make this type of tests by myself while implementing minor fix
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

- Closes #1006

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
