### PR TITLE
Convert Empty class usage to typing_extensions.Sentinel

### DIFF
--- a/dmr/controller.py
+++ b/dmr/controller.py
@@ -33,7 +33,7 @@ from dmr.security.base import AsyncAuth, SyncAuth
 from dmr.serializer import BaseSerializer
 from dmr.settings import HttpSpec
 from dmr.throttling import AsyncThrottle, SyncThrottle
-from dmr.types import AnnotationsContext, EMPTY, infer_type_args
+from dmr.types import EMPTY, AnnotationsContext, infer_type_args
 from dmr.validation import ControllerValidator, SettingsValidator
 
 if TYPE_CHECKING:

--- a/dmr/controller.py
+++ b/dmr/controller.py
@@ -15,7 +15,7 @@ from django.utils.functional import classproperty
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
-from typing_extensions import deprecated, override
+from typing_extensions import Sentinel, deprecated, override
 
 from dmr.cookies import NewCookie
 from dmr.endpoint import Endpoint
@@ -33,7 +33,7 @@ from dmr.security.base import AsyncAuth, SyncAuth
 from dmr.serializer import BaseSerializer
 from dmr.settings import HttpSpec
 from dmr.throttling import AsyncThrottle, SyncThrottle
-from dmr.types import AnnotationsContext, Empty, EmptyObj, infer_type_args
+from dmr.types import AnnotationsContext, EMPTY, infer_type_args
 from dmr.validation import ControllerValidator, SettingsValidator
 
 if TYPE_CHECKING:
@@ -162,7 +162,7 @@ class Controller(Generic[_SerializerT_co], View):  # noqa: WPS214
     throttling: ClassVar[
         Sequence[SyncThrottle] | Sequence[AsyncThrottle] | None
     ] = ()
-    throttling_allow_unsafe_cache: ClassVar[bool | Empty | None] = EmptyObj
+    throttling_allow_unsafe_cache: ClassVar[bool | Sentinel | None] = EMPTY
     error_model: ClassVar[Any] = ErrorModel
     is_abstract: ClassVar[bool] = True
     is_async: ClassVar[bool | None] = None  # `None` means that nothing's found

--- a/dmr/endpoint.py
+++ b/dmr/endpoint.py
@@ -1,4 +1,4 @@
-﻿import asyncio
+import asyncio
 import inspect
 import threading
 from collections.abc import Awaitable, Callable, Mapping, Sequence, Set

--- a/dmr/endpoint.py
+++ b/dmr/endpoint.py
@@ -1,4 +1,4 @@
-import asyncio
+﻿import asyncio
 import inspect
 import threading
 from collections.abc import Awaitable, Callable, Mapping, Sequence, Set
@@ -46,7 +46,7 @@ from dmr.security.base import AsyncAuth, SyncAuth
 from dmr.serializer import BaseSerializer
 from dmr.settings import HttpSpec, Settings, resolve_setting
 from dmr.throttling import AsyncThrottle, SyncThrottle
-from dmr.types import Empty, EmptyObj
+from dmr.types import EMPTY
 from dmr.validation import (
     EndpointMetadataBuilder,
     EndpointMetadataValidator,
@@ -608,7 +608,7 @@ def validate(  # noqa: WPS234
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -639,7 +639,7 @@ def validate(
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -670,7 +670,7 @@ def validate(
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -700,7 +700,7 @@ def validate(  # noqa: WPS211  # pyright: ignore[reportInconsistentOverload]
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -861,7 +861,7 @@ def modify(
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -892,7 +892,7 @@ def modify(
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -924,7 +924,7 @@ def modify(
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
@@ -955,7 +955,7 @@ def modify(  # noqa: WPS211
     validate_negotiation: bool | None = None,
     auth: Sequence[AsyncAuth] | Sequence[SyncAuth] | None = (),
     throttling: Sequence[AsyncThrottle] | Sequence[SyncThrottle] | None = (),
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj,
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY,
     summary: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,

--- a/dmr/endpoint.py
+++ b/dmr/endpoint.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, overload
 
 from django.http import HttpResponse, HttpResponseBase
 from django.urls import URLPattern
-from typing_extensions import ParamSpec, TypeVar
+from typing_extensions import ParamSpec, Sentinel, TypeVar
 
 from dmr.cookies import CookieSpec, NewCookie
 from dmr.errors import AsyncErrorHandler, SyncErrorHandler

--- a/dmr/openapi/core/registry.py
+++ b/dmr/openapi/core/registry.py
@@ -1,7 +1,9 @@
 from typing import Any, ClassVar, Protocol
 
+from typing_extensions import Sentinel
+
 from dmr.openapi.objects import Reference, Schema, SecurityScheme
-from dmr.types import Empty, EmptyObj
+from dmr.types import EMPTY
 
 
 class SchemaCallback(Protocol):
@@ -65,7 +67,7 @@ class SchemaRegistry:
         self,
         schema_name: str,
         schema: Schema,
-        annotation: Any | Empty = EmptyObj,
+        annotation: Any | Sentinel = EMPTY,
     ) -> Reference:
         """Register Schema in registry."""
         existing_schema = self._schemas.get(schema_name)
@@ -83,7 +85,7 @@ class SchemaRegistry:
     def get_reference(
         self,
         schema_name: str | None,
-        annotation: Any | Empty = EmptyObj,
+        annotation: Any | Sentinel = EMPTY,
     ) -> Reference | None:
         """Get registered reference."""
         if schema_name:
@@ -136,10 +138,10 @@ class SecuritySchemeRegistry:
 
 def _check_hashes(
     schema_name: str,
-    annotation: Any | Empty,
+    annotation: Any | Sentinel,
     other_hash: int | None,
 ) -> None:
-    if annotation is EmptyObj:
+    if annotation is EMPTY:
         return
     ann_hash = _safe_hash(annotation)
     if (
@@ -153,7 +155,7 @@ def _check_hashes(
 
 
 def _safe_hash(annotation: Any) -> int | None:
-    if annotation is EmptyObj:
+    if annotation is EMPTY:
         return None
     try:
         return hash(annotation)

--- a/dmr/openapi/mappers/example.py
+++ b/dmr/openapi/mappers/example.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from dmr.openapi.objects import Example
-from dmr.types import EmptyObj
+from dmr.types import EMPTY
 
 if TYPE_CHECKING:
     from dmr.serializer import BaseSerializer
@@ -32,7 +32,7 @@ else:
         serializer: type['BaseSerializer'],
     ) -> Any | None:
         """Generates examples based on the type annotation."""
-        if annotation is EmptyObj:  # pragma: no cover
+        if annotation is EMPTY:  # pragma: no cover
             return None
 
         # Import cycle:

--- a/dmr/openapi/mappers/schema_loader.py
+++ b/dmr/openapi/mappers/schema_loader.py
@@ -3,6 +3,8 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
+from typing_extensions import Sentinel
+
 from dmr.openapi.mappers.example import generate_example
 from dmr.openapi.objects import (
     XML,
@@ -13,7 +15,7 @@ from dmr.openapi.objects import (
     Reference,
     Schema,
 )
-from dmr.types import Empty, EmptyObj
+from dmr.types import EMPTY
 
 if TYPE_CHECKING:
     from dmr.serializer import BaseSerializer
@@ -43,7 +45,7 @@ def load_schema(
     raw_data: dict[str, Any],
     *,
     should_generate_example: bool = False,
-    annotation: Any | Empty = EmptyObj,
+    annotation: Any | Sentinel = EMPTY,
     serializer: type['BaseSerializer'] | None = None,
 ) -> Schema:
     """

--- a/dmr/types.py
+++ b/dmr/types.py
@@ -1,4 +1,3 @@
-import dataclasses
 from collections.abc import Callable, Iterator, Mapping
 from typing import (  # noqa: WPS235
     TYPE_CHECKING,
@@ -13,7 +12,7 @@ from typing import (  # noqa: WPS235
     get_origin,
 )
 
-from typing_extensions import Format, get_original_bases, get_type_hints
+from typing_extensions import Format, Sentinel, get_original_bases, get_type_hints
 
 from dmr.exceptions import UnsolvableAnnotationsError
 
@@ -45,14 +44,8 @@ else:
     """
 
 
-@final
-@dataclasses.dataclass(slots=True, frozen=True)
-class Empty:
-    """Special value for empty defaults."""
-
-
 #: Default singleton for empty values.
-EmptyObj: Final = Empty()
+EMPTY: Final = Sentinel('EMPTY')
 
 
 def infer_type_args(

--- a/dmr/types.py
+++ b/dmr/types.py
@@ -7,12 +7,16 @@ from typing import (  # noqa: WPS235
     Generic,
     TypeAlias,
     TypeVar,
-    final,
     get_args,
     get_origin,
 )
 
-from typing_extensions import Format, Sentinel, get_original_bases, get_type_hints
+from typing_extensions import (
+    Format,
+    Sentinel,
+    get_original_bases,
+    get_type_hints,
+)
 
 from dmr.exceptions import UnsolvableAnnotationsError
 

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -6,6 +6,8 @@ from http import HTTPMethod, HTTPStatus
 from types import NoneType
 from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeVar, assert_never
 
+from typing_extensions import Sentinel
+
 from django.contrib.admindocs.utils import parse_docstring
 from django.core.cache.backends import dummy, locmem
 from django.http import HttpResponseBase
@@ -33,7 +35,7 @@ from dmr.throttling.backends.django_cache import (
     SyncDjangoCache,
     UnsafeCacheBackendWarning,
 )
-from dmr.types import Empty, EmptyObj, infer_annotation, is_safe_subclass
+from dmr.types import EMPTY, infer_annotation, is_safe_subclass
 from dmr.validation.payload import (
     ModifyEndpointPayload,
     Payload,
@@ -583,12 +585,12 @@ class EndpointMetadataBuilder:  # noqa: WPS214
     def _build_throttling_allow_unsafe_cache(self) -> bool | None:
         if self.payload and not isinstance(
             self.payload.throttling_allow_unsafe_cache,
-            Empty,
+            Sentinel,
         ):
             return self.payload.throttling_allow_unsafe_cache
         if not isinstance(
             self.controller_cls.throttling_allow_unsafe_cache,
-            Empty,
+            Sentinel,
         ):
             return self.controller_cls.throttling_allow_unsafe_cache
         return resolve_setting(  # type: ignore[no-any-return]
@@ -948,8 +950,8 @@ def _resolve_return_annotation(
     controller_cls: type['Controller[BaseSerializer]'],
     endpoint_func: Callable[..., Any],
 ) -> Any:
-    return_annotation = type_annotations.get('return', EmptyObj)
-    if return_annotation is EmptyObj:
+    return_annotation = type_annotations.get('return', EMPTY)
+    if return_annotation is EMPTY:
         raise UnsolvableAnnotationsError(
             f'Function {endpoint_func!r} is missing return type annotation',
         )

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -6,11 +6,10 @@ from http import HTTPMethod, HTTPStatus
 from types import NoneType
 from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeVar, assert_never
 
-from typing_extensions import Sentinel
-
 from django.contrib.admindocs.utils import parse_docstring
 from django.core.cache.backends import dummy, locmem
 from django.http import HttpResponseBase
+from typing_extensions import Sentinel
 
 from dmr.components import BodyComponent
 from dmr.cookies import CookieSpec, NewCookie

--- a/dmr/validation/payload.py
+++ b/dmr/validation/payload.py
@@ -3,6 +3,8 @@ from collections.abc import Mapping, Sequence, Set
 from http import HTTPStatus
 from typing import TYPE_CHECKING, TypeAlias
 
+from typing_extensions import Sentinel
+
 from dmr.cookies import CookieSpec, NewCookie
 from dmr.errors import AsyncErrorHandler, SyncErrorHandler
 from dmr.headers import HeaderSpec, NewHeader
@@ -10,7 +12,7 @@ from dmr.metadata import ResponseSpec
 from dmr.parsers import Parser
 from dmr.renderers import Renderer
 from dmr.settings import HttpSpec
-from dmr.types import Empty, EmptyObj
+from dmr.types import EMPTY
 
 if TYPE_CHECKING:
     from dmr.openapi.objects import (
@@ -50,7 +52,7 @@ class _BasePayload:
     validate_negotiation: bool | None = None
     auth: Sequence['SyncAuth'] | Sequence['AsyncAuth'] | None = ()
     throttling: Sequence['SyncThrottle'] | Sequence['AsyncThrottle'] | None = ()
-    throttling_allow_unsafe_cache: bool | Empty | None = EmptyObj
+    throttling_allow_unsafe_cache: bool | Sentinel | None = EMPTY
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)

--- a/dmr/validation/response.py
+++ b/dmr/validation/response.py
@@ -20,7 +20,7 @@ from dmr.internal.negotiation import (
 from dmr.metadata import EndpointMetadata, ResponseSpec
 from dmr.negotiation import get_conditional_types, request_renderer
 from dmr.serializer import BaseSerializer
-from dmr.types import EmptyObj
+from dmr.types import EMPTY
 
 if TYPE_CHECKING:
     from dmr.controller import Controller
@@ -215,8 +215,8 @@ class ResponseValidator:  # noqa: WPS214
 
         content_types = get_conditional_types(schema.return_type, ())
         if content_types:
-            model = content_types.get(content_type, EmptyObj)
-            if model is EmptyObj:
+            model = content_types.get(content_type, EMPTY)
+            if model is EMPTY:
                 hint = [stringify(ct) for ct in content_types]
                 raise ResponseSchemaError(
                     f'Content-Type {content_type!r} is not '

--- a/dmr/validation/settings.py
+++ b/dmr/validation/settings.py
@@ -16,7 +16,7 @@ from dmr.settings import (
     _resolve_defaults,  # pyright: ignore[reportPrivateUsage]
 )
 from dmr.throttling import AsyncThrottle, SyncThrottle
-from dmr.types import EmptyObj
+from dmr.types import EMPTY
 
 
 class _SettingsModel(SettingsDict, total=False):
@@ -132,8 +132,8 @@ class SettingsValidator:
                 'Settings.responses must all be ResponseSpec instances',
             )
 
-        openapi_config = settings.get('openapi_config', EmptyObj)
-        if openapi_config is not EmptyObj and not isinstance(
+        openapi_config = settings.get('openapi_config', EMPTY)
+        if openapi_config is not EMPTY and not isinstance(
             openapi_config,
             OpenAPIConfig,
         ):
@@ -141,8 +141,8 @@ class SettingsValidator:
                 'Settings.openapi_config must be an OpenAPIConfig instance',
             )
 
-        global_error_handler = settings.get('global_error_handler', EmptyObj)
-        if global_error_handler is not EmptyObj and not (
+        global_error_handler = settings.get('global_error_handler', EMPTY)
+        if global_error_handler is not EMPTY and not (
             isinstance(global_error_handler, str)
             or callable(global_error_handler)
         ):

--- a/docs/pages/deep-dive/public-api.rst
+++ b/docs/pages/deep-dive/public-api.rst
@@ -165,10 +165,7 @@ Utilities
 
 .. autodata:: dmr.types.Json
 
-.. autoclass:: dmr.types.Empty
-  :members:
-
-.. autodata:: dmr.types.EmptyObj
+.. autodata:: dmr.types.EMPTY
 
 .. autoclass:: dmr.types.AnnotationsContext
   :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ classifiers = [
 dynamic = ["readme"]
 
 dependencies = [
-  "typing_extensions>=4",
+  "typing_extensions>=4.12",
   "django>=4.2,<6.1",
 ]
 


### PR DESCRIPTION
# I have made things!

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made (existing tests cover the refactoring)
- [x] I have updated the documentation for the changes I have made

## Related issues

- Closes #995

---

## What I changed

Replaces our custom empty-value marker with the industry-standard approach.

## Why now
I wasn't see someone working on this issue at that time. Issue #995 mentioned this improvement, so I took the opportunity. It’s a drop-in replacement - same behavior, all existing tests pass.