### PR TITLE
Add support for $dynamicRef, $dynamicAnchor and $defs in openapi schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ of requirements for an API to count as public.
   `FileResponseSpec(as_attachment=True)` when returning Django's
   `FileResponse(..., as_attachment=True)`, #1020
 
+### Features
+
+- Added support for JSON Schema 2020-12 dynamic reference keywords
+  (`$dynamicRef`, `$dynamicAnchor`, `$defs`) in OpenAPI schema generation.
+  These can now be propagated through `extra_json_schema` 
+  for generic type definitions, #1039
+
 ### Misc
 
 - Use `typing_extensions.Sentinel` for `dmr.types.EMPTY`, #995

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ of requirements for an API to count as public.
 
 - Added support for JSON Schema 2020-12 dynamic reference keywords
   (`$dynamicRef`, `$dynamicAnchor`, `$defs`) in OpenAPI schema generation.
-  These can now be propagated through `extra_json_schema` 
+  These can now be propagated through `extra_json_schema`
   for generic type definitions, #1039
 
 ### Misc

--- a/dmr/openapi/mappers/schema_loader.py
+++ b/dmr/openapi/mappers/schema_loader.py
@@ -121,6 +121,9 @@ def load_schema(
         external_docs=_try_external_documentation(raw_data.get('externalDocs')),
         examples=examples,
         example=example,
+        dynamic_ref=raw_data.get('$dynamicRef'),
+        dynamic_anchor=raw_data.get('$dynamicAnchor'),
+        defs=_try_dict(raw_data.get('$defs')),
     )
 
 

--- a/dmr/openapi/objects/openapi.py
+++ b/dmr/openapi/objects/openapi.py
@@ -134,8 +134,8 @@ def normalize_key(key: str) -> str:
         'contentMediaType'
 
     """
-    if key == 'ref':
-        return '$ref'
+    if key in {'ref', 'defs'}:
+        return f'${key}'
 
     if key in {'param_in', 'security_scheme_in'}:
         return 'in'
@@ -145,9 +145,12 @@ def normalize_key(key: str) -> str:
 
     if '_' in key:
         components = key.split('_')
-        return components[0].lower() + ''.join(
+        camel_case_component = components[0].lower() + ''.join(
             component.title() for component in components[1:]
         )
+        if camel_case_component in {'dynamicAnchor', 'dynamicRef'}:
+            return f'${camel_case_component}'
+        return camel_case_component
 
     return key
 

--- a/dmr/openapi/objects/schema.py
+++ b/dmr/openapi/objects/schema.py
@@ -74,3 +74,6 @@ class Schema:
     xml: 'XML | None' = None
     external_docs: 'ExternalDocumentation | None' = None
     example: Any | None = None
+    dynamic_anchor: str | None = None
+    dynamic_ref: str | None = None
+    defs: dict[str, 'Reference | Schema'] | None = None

--- a/tests/test_unit/test_openapi/test_objects/test_openapi_obj.py
+++ b/tests/test_unit/test_openapi/test_objects/test_openapi_obj.py
@@ -3,7 +3,13 @@ from typing import Any
 
 import pytest
 
-from dmr.openapi.objects import OpenAPIFormat, OpenAPIType, Schema, Tag
+from dmr.openapi.objects import (
+    OpenAPIFormat,
+    OpenAPIType,
+    Reference,
+    Schema,
+    Tag,
+)
 from dmr.openapi.objects.openapi import convert, normalize_key, normalize_value
 
 
@@ -12,6 +18,9 @@ from dmr.openapi.objects.openapi import convert, normalize_key, normalize_value
     [
         # Special cases for reserved keywords
         ('ref', '$ref'),
+        ('defs', '$defs'),
+        ('dynamic_ref', '$dynamicRef'),
+        ('dynamic_anchor', '$dynamicAnchor'),
         ('param_in', 'in'),
         # Schema prefix removal
         ('schema_not', 'not'),
@@ -189,6 +198,44 @@ def test_normalize_value_dict(
             {
                 'not': {'type': 'string'},
                 'allOf': [{'type': 'object'}],
+            },
+        ),
+        # Generic List<T> base schema
+        (
+            Schema(
+                type=OpenAPIType.ARRAY,
+                defs={
+                    'content': Schema(dynamic_anchor='T'),
+                },
+                items=Schema(dynamic_ref='#T'),
+            ),
+            {
+                'type': 'array',
+                '$defs': {
+                    'content': {'$dynamicAnchor': 'T'},
+                },
+                'items': {'$dynamicRef': '#T'},
+            },
+        ),
+        # Concrete List<string> referencing the generic via Reference
+        (
+            Schema(
+                defs={
+                    'string-items': Schema(
+                        dynamic_anchor='T',
+                        type=OpenAPIType.STRING,
+                    ),
+                },
+                all_of=[Reference(ref='list-of-t')],
+            ),
+            {
+                '$defs': {
+                    'string-items': {
+                        '$dynamicAnchor': 'T',
+                        'type': 'string',
+                    },
+                },
+                'allOf': [{'$ref': 'list-of-t'}],
             },
         ),
     ],

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgspec_snapshots.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgspec_snapshots.ambr
@@ -155,6 +155,154 @@
   }
   '''
 # ---
+# name: test_dynamic_refs_schema
+  '''
+  {
+    "info": {
+      "title": "Django Modern Rest",
+      "version": "0.1.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {
+      "/api/v1/dynamic-refs": {
+        "post": {
+          "operationId": "postDynamicrefscontrollerApiV1DynamicRefs",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_DynamicRefsModel"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Raised when request components cannot be parsed",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Raised when returned response does not match the response schema",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Raised when provided `Accept` header cannot be satisfied",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            }
+          },
+          "deprecated": false
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "ErrorDetail": {
+          "properties": {
+            "loc": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "msg"
+          ],
+          "title": "ErrorDetail",
+          "description": "Base schema for error details description."
+        },
+        "ErrorModel": {
+          "properties": {
+            "detail": {
+              "items": {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "required": [
+            "detail"
+          ],
+          "title": "ErrorModel",
+          "description": "Default error response schema.\n\nCan be customized.\nSee :ref:`customizing-error-messages` for more details."
+        },
+        "_DynamicRefsModel": {
+          "properties": {
+            "anchored": {
+              "type": "string",
+              "$dynamicAnchor": "T"
+            },
+            "referenced": {
+              "type": "string",
+              "$dynamicRef": "#T"
+            },
+            "with_defs": {
+              "type": "string",
+              "$defs": {
+                "helper": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "type": "object",
+          "required": [
+            "anchored",
+            "referenced",
+            "with_defs"
+          ],
+          "title": "_DynamicRefsModel"
+        }
+      },
+      "securitySchemes": {}
+    }
+  }
+  '''
+# ---
 # name: test_example_schema
   '''
   {

--- a/tests/test_unit/test_plugins/test_msgspec/test_msgspec_snapshots.py
+++ b/tests/test_unit/test_plugins/test_msgspec/test_msgspec_snapshots.py
@@ -190,3 +190,44 @@ def test_issue990(snapshot: SnapshotAssertion) -> None:
         )
         == snapshot
     )
+
+
+class _DynamicRefsModel(msgspec.Struct):
+    # See https://github.com/wemake-services/django-modern-rest/issues/1039
+    anchored: Annotated[
+        str,
+        msgspec.Meta(extra_json_schema={'$dynamicAnchor': 'T'}),
+    ]
+    referenced: Annotated[
+        str,
+        msgspec.Meta(extra_json_schema={'$dynamicRef': '#T'}),
+    ]
+    with_defs: Annotated[
+        str,
+        msgspec.Meta(
+            extra_json_schema={
+                '$defs': {'helper': {'type': 'integer'}},
+            },
+        ),
+    ]
+
+
+class _DynamicRefsController(Controller[MsgspecSerializer]):
+    def post(self, parsed_body: Body[_DynamicRefsModel]) -> str:
+        raise NotImplementedError
+
+
+def test_dynamic_refs_schema(snapshot: SnapshotAssertion) -> None:
+    """Ensure $dynamicRef, $dynamicAnchor and $defs propagate."""
+    assert (
+        json.dumps(
+            build_schema(
+                Router(
+                    'api/v1/',
+                    [path('/dynamic-refs', _DynamicRefsController.as_view())],
+                ),
+            ).convert(skip_validation=True),
+            indent=2,
+        )
+        == snapshot
+    )


### PR DESCRIPTION
# I have made things!

According to issue I added support for `$dynamicRef` and `$dynamicAnchor`. Since without `$defs` user can't add any definitions for schemas added it too (please let me know if you'd prefer a different approach there)

About docs: I see that we already have basic example with `extra_json_schema`. Should I add specific example for my changes or not?

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

- Closes #1039