### PR TITLE
Fix leaky bucket partial-drain rejection

### DIFF
--- a/dmr/throttling/algorithms.py
+++ b/dmr/throttling/algorithms.py
@@ -202,7 +202,7 @@ class LeakyBucket(BaseThrottleAlgorithm):
         )
         cache_object = CachedRateLimit(history=[level], time=now)
 
-        if cache_object['history'][0] >= (
+        if cache_object['history'][0] + throttle.duration_in_seconds > (
             throttle.max_requests * throttle.duration_in_seconds
         ):
             raise TooManyRequestsError(

--- a/dmr/throttling/lua.py
+++ b/dmr/throttling/lua.py
@@ -100,16 +100,16 @@ local last_time = tonumber(raw[2]) or now
 local elapsed = math.max(0, now - last_time)
 level         = math.max(0, level - elapsed * max_requests)
 
--- ── check capacity (mirrors `>= max_requests * duration_in_seconds`) ───────
-if level >= capacity then
-    -- Do NOT update stored state — the bucket is full, nothing changes.
-    return {0, level, capacity}
-end
-
 -- Only update values, when non-viewing:
 if view_only == 0 then
+    local next_level = level + duration
+    if next_level > capacity then
+        -- Do NOT update stored state — the bucket is full, nothing changes.
+        return {0, level, capacity}
+    end
+
     -- ── fill (+duration_in_seconds scaled units) ───────────────────────────
-    level = level + duration
+    level = next_level
 
     -- Persist level and the current timestamp.
     redis.call("HSET", key, "level", level, "last_time", now)

--- a/tests/test_integration/test_throttling/test_backends/test_redis_backend/test_redis_backend.py
+++ b/tests/test_integration/test_throttling/test_backends/test_redis_backend/test_redis_backend.py
@@ -103,6 +103,11 @@ def test_redis_sync_leaky_bucket(
         assert isinstance(response, HttpResponse)
         assert response.status_code == HTTPStatus.OK
 
+    keys = list(redis_client.scan_iter())
+    assert len(keys) == 1
+    # Simulate one elapsed Redis-server second without sleeping.
+    redis_client.hincrby(keys[0], 'last_time', -1)
+
     # Third is rejected:
     request = dmr_rf.get('/whatever/')
     response = _SyncController.as_view()(request)
@@ -121,6 +126,54 @@ def test_redis_sync_leaky_bucket(
             {'msg': 'Too many requests', 'type': 'ratelimit'},
         ],
     })
+
+
+def test_redis_bucket_full_slot(
+    dmr_rf: DMRRequestFactory,
+    redis_client: 'redis.Redis[Any]',
+) -> None:
+    """Redis leaky bucket rejects partial drains, but allows exact capacity."""
+
+    class _SyncController(Controller[PydanticFastSerializer]):
+        @modify(
+            throttling=[
+                SyncThrottle(
+                    _ATTEMPTS,
+                    _RATE,
+                    backend=SyncRedis(redis_client),
+                    algorithm=LeakyBucket(),
+                ),
+            ],
+        )
+        def get(self) -> str:
+            return 'inside'
+
+    # Two requests fill the bucket:
+    for _ in range(_ATTEMPTS):
+        request = dmr_rf.get('/whatever/')
+        response = _SyncController.as_view()(request)
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == HTTPStatus.OK
+
+    keys = list(redis_client.scan_iter())
+    assert len(keys) == 1
+    # Simulate one elapsed Redis-server second without sleeping.
+    redis_client.hincrby(keys[0], 'last_time', -1)
+
+    # A partial drain is not enough for another full request:
+    request = dmr_rf.get('/whatever/')
+    response = _SyncController.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+    # This is the `>` vs `>=` boundary: an exactly full bucket is allowed
+    # when the drained capacity leaves room for one whole request.
+    redis_client.hincrby(keys[0], 'last_time', -((_RATE // _ATTEMPTS) - 1))
+
+    request = dmr_rf.get('/whatever/')
+    response = _SyncController.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK
 
 
 @pytest.mark.asyncio

--- a/tests/test_unit/test_throttling/test_algorithms/test_leaky_bucket.py
+++ b/tests/test_unit/test_throttling/test_algorithms/test_leaky_bucket.py
@@ -95,6 +95,35 @@ def test_leaky_bucket_smooth_drain(
     assert response.status_code == HTTPStatus.TOO_MANY_REQUESTS
 
 
+def test_leaky_bucket_waits_for_full_slot(
+    dmr_rf: DMRRequestFactory,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Reject requests until enough capacity drains for a whole request."""
+    # Fill the bucket:
+    for _ in range(_ATTEMPTS):
+        request = dmr_rf.get('/whatever/')
+        response = _SyncController.as_view()(request)
+        assert response.status_code == HTTPStatus.OK
+
+    # A partial drain is not enough for another full request:
+    freezer.tick(delta=1)
+
+    request = dmr_rf.get('/whatever/')
+    response = _SyncController.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+    # This is the `>` vs `>=` boundary: an exactly full bucket is allowed
+    # when the drained capacity leaves room for one whole request.
+    freezer.tick(delta=(_RATE // _ATTEMPTS) - 1)
+
+    request = dmr_rf.get('/whatever/')
+    response = _SyncController.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK
+
+
 def test_leaky_bucket_full_drain(
     dmr_rf: DMRRequestFactory,
     freezer: FrozenDateTimeFactory,


### PR DESCRIPTION
﻿Fixes #1043.

This was a small boundary bug in the leaky bucket check: after the bucket was full, a short drain could make the stored level lower than capacity, so the next request could sneak through even though adding a full request would overflow the bucket.

This changes the check to require enough free capacity for the whole request before accepting it, and keeps the Redis Lua script aligned with the Python implementation.

Tests run:

- uv run --all-extras --group unit-test pytest tests/test_unit/test_throttling/test_algorithms/test_leaky_bucket.py -q -o addopts=""
- uv run --all-extras --group unit-test --group dev-and-docs pytest tests/test_unit/test_throttling/test_algorithms/test_leaky_bucket.py tests/test_integration/test_throttling/test_backends/test_redis_backend/test_redis_backend.py -q -o addopts=""
- uv run --all-extras --group dev ruff check dmr/throttling/algorithms.py dmr/throttling/lua.py tests/test_unit/test_throttling/test_algorithms/test_leaky_bucket.py tests/test_integration/test_throttling/test_backends/test_redis_backend/test_redis_backend.py
- uv run --all-extras --group dev ruff format --check dmr/throttling/algorithms.py dmr/throttling/lua.py tests/test_unit/test_throttling/test_algorithms/test_leaky_bucket.py tests/test_integration/test_throttling/test_backends/test_redis_backend/test_redis_backend.py
