### PR TITLE
Add changelog entry for enum parameter schema fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ of requirements for an API to count as public.
 ### Bugfixes
 
 - Fixes `LeakyBucket` throttling algorithm corner cases, #1044
+- Fixed OpenAPI schema generation for enum values used
+  in path, query, header, and cookie parameters, #1059
 
 
 ## Version 0.10.0 (2026-05-26)


### PR DESCRIPTION
This adds the missing changelog entry for #1059, as requested.