### PR TITLE
Change `NotImplementError` message

### DIFF
--- a/dmr/renderers.py
+++ b/dmr/renderers.py
@@ -192,8 +192,9 @@ class FileRenderer(Renderer):
     ) -> bytes:
         """Render a file."""
         raise NotImplementedError(
-            'FileRenderer.render() must not be called, '
-            'instead return a FileResponse directly',
+            'FileRenderer cannot serialize regular response bodies. '
+            'Return a FileResponse directly for file responses, or configure '
+            'a non-file renderer for responses that need serialization.',
         )
 
     @property

--- a/tests/test_unit/test_endpoint/test_return_file.py
+++ b/tests/test_unit/test_endpoint/test_return_file.py
@@ -109,9 +109,7 @@ def test_file_renderer_render_error(
 
     with pytest.raises(
         NotImplementedError,
-        match=(
-            'FileRenderer cannot serialize regular response bodies'
-        ),
+        match=('FileRenderer cannot serialize regular response bodies'),
     ):
         _RegularBodyWithFileRendererController.as_view()(request)
 

--- a/tests/test_unit/test_endpoint/test_return_file.py
+++ b/tests/test_unit/test_endpoint/test_return_file.py
@@ -53,6 +53,14 @@ class _InlineFileSyncController(Controller[PydanticSerializer]):
         )
 
 
+@final
+class _RegularBodyWithFileRendererController(Controller[PydanticSerializer]):
+    renderers = (FileRenderer(),)
+
+    def get(self) -> dict[str, str]:
+        return {'detail': 'not a file'}
+
+
 @pytest.mark.django_db
 def test_return_file_sync(dmr_rf: DMRRequestFactory) -> None:
     """Ensures we can return files from a sync endpoint."""
@@ -91,6 +99,21 @@ def test_return_file_without_attachment_sync(
         }
         assert isinstance(response.streaming_content, Iterator)
         assert response.getvalue() == b'Hello'
+
+
+def test_file_renderer_render_error(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures file renderer errors explain how to return regular data."""
+    request = dmr_rf.get('/whatever/')
+
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            'FileRenderer cannot serialize regular response bodies'
+        ),
+    ):
+        _RegularBodyWithFileRendererController.as_view()(request)
 
 
 def test_file_attachment_headers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2065,16 +2065,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

I think now we have correct behavior but need more friendly error text.

## AI Policy

- [ ] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1026 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

