### PR TITLE
Rename default OpenAPI title and document OpenAPIConfig fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ for both sync and async controllers at the same time.
 - Fixed that `dmr.plugins.msgspec.msgpack` cache was not cleared
   on `clear_settings_cache` calls
 
+### Misc
+
+- Renamed the default OpenAPI title from `Django Modern Rest`
+  to `Your Awesome Project` and documented all `OpenAPIConfig`
+  fields, #1021
+
 
 ## Version 0.10.0 (2026-05-26)
 

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -25,6 +25,28 @@ class OpenAPIConfig:
     specification that will be generated for your API documentation. It allows
     you to customize the API information, contact details, licensing, security
     requirements, and other metadata that appears in the generated OpenAPI spec.
+
+    Attributes:
+        title: Human-readable title of the API,
+            shown in the generated documentation.
+        version: Version of your API
+            (your application's own version, not the OpenAPI spec version).
+        openapi_version: Version of the OpenAPI specification to target.
+            Defaults to ``'3.1.0'``.
+        summary: Short, one-line summary of the API.
+        description: Longer description of the API. May use CommonMark syntax.
+        terms_of_service: URL to the terms of service for the API.
+        contact: Contact information for the exposed API.
+        external_docs: Link to additional external documentation.
+        security: Global security requirements applied across the API.
+            Each entry may be overridden per operation.
+        license: License information for the exposed API.
+        components: Reusable components (schemas, responses, parameters, etc.)
+            to include in the spec.
+        servers: Connectivity information for the target servers.
+        tags: Metadata tags used to group operations in the documentation.
+        webhooks: Webhook definitions that may be initiated by the API,
+            keyed by name.
     """
 
     title: str

--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -139,7 +139,7 @@ _DEFAULTS: Final[Mapping[str, Any]] = {  # noqa: WPS407
     Settings.throttling_allow_unsafe_cache: True,
     # OpenAPI settings:
     Settings.openapi_config: OpenAPIConfig(
-        title='Django Modern Rest',
+        title='Your Awesome Project',
         version='0.1.0',
     ),
     Settings.openapi_examples_seed: None,  # turned off by default

--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -408,7 +408,7 @@ OpenAPI
 
 .. data:: dmr.settings.Settings.openapi_config
 
-  Default: ``OpenAPIConfig(title='Django Modern Rest', version='0.1.0')``
+  Default: ``OpenAPIConfig(title='Your Awesome Project', version='0.1.0')``
 
   Metadata to be used in the OpenAPI schema.
 

--- a/tests/test_unit/test_metadata/__snapshots__/test_response_spec_meta.ambr
+++ b/tests/test_unit/test_metadata/__snapshots__/test_response_spec_meta.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/__snapshots__/test_example_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_example_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -171,7 +171,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -374,7 +374,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/__snapshots__/test_files_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_files_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -123,7 +123,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -305,7 +305,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -458,7 +458,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -572,7 +572,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/__snapshots__/test_overrides_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_overrides_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -112,7 +112,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -218,7 +218,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/__snapshots__/test_router_tags_deprecated.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_router_tags_deprecated.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/__snapshots__/test_schema_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_schema_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -258,7 +258,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -496,7 +496,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -735,7 +735,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -943,7 +943,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/__snapshots__/test_semantic_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_semantic_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -85,7 +85,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_exclude_semantic_responses.ambr
+++ b/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_exclude_semantic_responses.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_semantic_responses.ambr
+++ b/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_semantic_responses.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_openapi/test_views.py
+++ b/tests/test_unit/test_openapi/test_views.py
@@ -33,7 +33,7 @@ def test_json_view(dmr_rf: DMRRequestFactory) -> None:
     assert response['Content-Type'] == 'application/json'
     assert json.loads(response.content.decode('utf-8')) == snapshot({
         'openapi': '3.1.0',
-        'info': {'title': 'Django Modern Rest', 'version': '0.1.0'},
+        'info': {'title': 'Your Awesome Project', 'version': '0.1.0'},
         'paths': {},
         'components': {'schemas': {}, 'securitySchemes': {}},
     })
@@ -51,7 +51,7 @@ def test_yaml_view(dmr_rf: DMRRequestFactory) -> None:
     assert response['Content-Type'] == 'application/yaml'
     assert yaml.safe_load(response.content) == snapshot({
         'components': {'schemas': {}, 'securitySchemes': {}},
-        'info': {'title': 'Django Modern Rest', 'version': '0.1.0'},
+        'info': {'title': 'Your Awesome Project', 'version': '0.1.0'},
         'openapi': '3.1.0',
         'paths': {},
     })

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_attrs.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_attrs.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgpack.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgpack.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgspec_snapshots.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgspec_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -159,7 +159,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -307,7 +307,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -482,7 +482,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -629,7 +629,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -792,7 +792,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_plugins/test_pydantic/__snapshots__/test_pydantic_snapshots.ambr
+++ b/tests/test_unit/test_plugins/test_pydantic/__snapshots__/test_pydantic_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -205,7 +205,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -374,7 +374,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_problem_details/__snapshots__/test_problem_details_view.ambr
+++ b/tests/test_unit/test_problem_details/__snapshots__/test_problem_details_view.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",

--- a/tests/test_unit/test_throttling/__snapshots__/test_throttling_snapshots.ambr
+++ b/tests/test_unit/test_throttling/__snapshots__/test_throttling_snapshots.ambr
@@ -3,7 +3,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -288,7 +288,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",
@@ -467,7 +467,7 @@
   '''
   {
     "info": {
-      "title": "Django Modern Rest",
+      "title": "Your Awesome Project",
       "version": "0.1.0"
     },
     "openapi": "3.1.0",


### PR DESCRIPTION
Resolves #1021.

As discussed in the issue, this makes two small improvements:

1. **Default title:** renames the default `OpenAPIConfig` title from `Django Modern Rest` to `Your Awesome Project`, so it reads as a placeholder users are meant to override (the original looked like it could be the framework's own version/title).
2. **Docs:** adds a Google-style `Attributes:` section documenting every field of `OpenAPIConfig`, which renders via the existing `.. autoclass:: ... :members:` directive.

Snapshots, the `configuration.rst` default reference, and `CHANGELOG.md` are updated accordingly. `just lint` and `just unit` pass locally (the only errors are Redis integration tests that require a running Redis server).