### PR TITLE
Add SyncOrAsyncAuth support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ for both sync and async controllers at the same time.
 
 - Added `SyncOrAsyncThrottle` class to apply a single throttle rule
   to both sync and async endpoints via global settings, #1075
+- Added `SyncOrAsyncAuth` class to apply a single auth rule
+  to both sync and async endpoints via global settings, #1102
 
 ### Bugfixes
 

--- a/dmr/security/__init__.py
+++ b/dmr/security/__init__.py
@@ -1,5 +1,6 @@
 from dmr.security.base import AsyncAuth as AsyncAuth
 from dmr.security.base import SyncAuth as SyncAuth
+from dmr.security.base import SyncOrAsyncAuth as SyncOrAsyncAuth
 from dmr.security.base import request_auth as request_auth
 from dmr.security.types import (
     AuthenticatedHttpRequest as AuthenticatedHttpRequest,

--- a/dmr/security/base.py
+++ b/dmr/security/base.py
@@ -1,7 +1,8 @@
+import dataclasses
 from abc import abstractmethod
 from collections.abc import Mapping
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Literal, Self, overload
+from typing import TYPE_CHECKING, Literal, Self, final, overload
 
 from django.http import HttpRequest
 from typing_extensions import override
@@ -119,6 +120,31 @@ class AsyncAuth(_BaseAuth):
         if you want to change the return code, for example,
         when some data is missing or has wrong format.
         """
+
+
+@final
+@dataclasses.dataclass(slots=True, frozen=True)
+class SyncOrAsyncAuth:
+    """
+    Auth that selects between a sync and async instance.
+
+    Use in global settings to apply a single auth rule to both
+    sync and async endpoints. Not allowed on controller or endpoint level.
+
+    .. versionadded:: 0.11.0
+    """
+
+    _sync_auth: SyncAuth
+    _async_auth: AsyncAuth
+
+    def resolve(
+        self,
+        auth_cls: type[SyncAuth] | type[AsyncAuth],
+    ) -> SyncAuth | AsyncAuth:
+        """Return the auth instance matching *auth_cls*."""
+        if issubclass(auth_cls, SyncAuth):
+            return self._sync_auth
+        return self._async_auth
 
 
 @overload

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -25,7 +25,7 @@ from dmr.metadata import (
 from dmr.parsers import Parser
 from dmr.renderers import Renderer
 from dmr.response import infer_status_code
-from dmr.security.base import AsyncAuth, SyncAuth
+from dmr.security.base import AsyncAuth, SyncAuth, SyncOrAsyncAuth
 from dmr.serializer import BaseSerializer
 from dmr.settings import HttpSpec, Settings, resolve_setting
 from dmr.throttling import AsyncThrottle, SyncOrAsyncThrottle, SyncThrottle
@@ -479,19 +479,34 @@ class EndpointMetadataBuilder:  # noqa: WPS214
         self,
     ) -> list[SyncAuth | AsyncAuth] | None:
         payload_auth = () if self.payload is None else (self.payload.auth or ())
-        settings_auth: Sequence[SyncAuth | AsyncAuth] = resolve_setting(
-            Settings.auth,
+        settings_auth: Sequence[SyncAuth | AsyncAuth | SyncOrAsyncAuth] = (
+            resolve_setting(Settings.auth)
         )
-
-        auth = [
+        # SyncOrAsyncAuth is settings-only — reject controller/endpoint usage:
+        for candidate_auth in (
             *payload_auth,
             *(self.controller_cls.auth or ()),
-            *settings_auth,
-        ]
-        # Validate that auth matches the sync / async endpoints:
+        ):
+            if isinstance(candidate_auth, SyncOrAsyncAuth):  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise EndpointMetadataError(
+                    'SyncOrAsyncAuth can only be used in settings, '
+                    'not at controller or endpoint level '
+                    f'for {self.endpoint_name=}',
+                )
         base_type = (
             AsyncAuth if inspect.iscoroutinefunction(self.func) else SyncAuth
         )
+        auth = [
+            *payload_auth,
+            *(self.controller_cls.auth or ()),
+            *(
+                setting_auth.resolve(base_type)
+                if isinstance(setting_auth, SyncOrAsyncAuth)
+                else setting_auth
+                for setting_auth in settings_auth
+            ),
+        ]
+        # Validate that auth matches the sync / async endpoints:
         if not all(
             isinstance(auth_instance, base_type)  # pyright: ignore[reportUnnecessaryIsInstance]
             for auth_instance in auth

--- a/dmr/validation/settings.py
+++ b/dmr/validation/settings.py
@@ -8,7 +8,7 @@ from dmr.metadata import ResponseSpec
 from dmr.openapi import OpenAPIConfig
 from dmr.parsers import Parser
 from dmr.renderers import Renderer
-from dmr.security import AsyncAuth, SyncAuth
+from dmr.security import AsyncAuth, SyncAuth, SyncOrAsyncAuth
 from dmr.serializer import BaseSerializer
 from dmr.settings import (
     Settings,
@@ -104,11 +104,12 @@ class SettingsValidator:
 
         # Auth:
         if not all(
-            isinstance(auth, (SyncAuth, AsyncAuth))
+            isinstance(auth, (SyncAuth, AsyncAuth, SyncOrAsyncAuth))
             for auth in settings.get('auth', [])
         ):
             raise EndpointMetadataError(
-                'Settings.auth must all be SyncAuth or AsyncAuth instances',
+                'Settings.auth must all be SyncAuth, AsyncAuth, '
+                'or SyncOrAsyncAuth instances',
             )
 
         # Throttling:

--- a/docs/pages/auth/common.rst
+++ b/docs/pages/auth/common.rst
@@ -76,6 +76,31 @@ There are 4 ways to provide auth classes for an endpoint:
 
       >>> DMR_SETTINGS = {Settings.auth: [DjangoSessionSyncAuth()]}
 
+When your project mixes sync and async endpoints,
+use :class:`~dmr.security.SyncOrAsyncAuth` in settings:
+
+.. code-block:: python
+   :caption: settings.py
+
+   >>> from dmr.settings import Settings
+   >>> from dmr.security import SyncOrAsyncAuth
+   >>> from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth
+
+   >>> DMR_SETTINGS = {
+   ...     Settings.auth: [
+   ...         SyncOrAsyncAuth(
+   ...             HttpBasicSyncAuth(),
+   ...             HttpBasicAsyncAuth(),
+   ...         ),
+   ...     ],
+   ... }
+
+.. note::
+
+   :class:`~dmr.security.SyncOrAsyncAuth` is only allowed
+   in ``DMR_SETTINGS``. Using it on a controller or endpoint
+   raises :exc:`~dmr.exceptions.EndpointMetadataError`.
+
 Providing several auth instances means that at least one of them must succeed.
 
 
@@ -160,6 +185,9 @@ API Reference
 .. autoclass:: dmr.security.AsyncAuth
   :members:
   :inherited-members:
+
+.. autoclass:: dmr.security.SyncOrAsyncAuth
+  :members:
 
 .. autofunction:: dmr.security.request_auth
 

--- a/tests/test_unit/test_security/test_sync_or_async_auth_dynamic.py
+++ b/tests/test_unit/test_security/test_sync_or_async_auth_dynamic.py
@@ -1,0 +1,120 @@
+import json
+from http import HTTPStatus
+from typing import Final, Self
+
+import pytest
+from django.conf import LazySettings
+from django.http import HttpResponse
+from inline_snapshot import snapshot
+from typing_extensions import override
+
+from dmr import Controller
+from dmr.endpoint import Endpoint
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.security import SyncOrAsyncAuth
+from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth, basic_auth
+from dmr.serializer import BaseSerializer
+from dmr.settings import Settings
+from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+
+
+class _SyncAuth(HttpBasicSyncAuth):
+    @override
+    def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        if username == 'test' and password == 'pass':  # noqa: S105
+            return self
+        return None
+
+
+class _AsyncAuth(HttpBasicAsyncAuth):
+    @override
+    async def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        if username == 'test' and password == 'pass':  # noqa: S105
+            return self
+        return None
+
+
+_AUTH: Final = SyncOrAsyncAuth(_SyncAuth(), _AsyncAuth())
+
+
+def test_sync_or_async_auth_settings_sync(
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures SyncOrAsyncAuth in settings resolves and enforces sync auth."""
+    settings.DMR_SETTINGS = {Settings.auth: [_AUTH]}
+
+    class _SyncController(Controller[PydanticSerializer]):
+        def get(self) -> str:
+            return 'authed'
+
+    metadata = _SyncController.api_endpoints['GET'].metadata
+    assert metadata.auth is not None
+    assert isinstance(metadata.auth[0], _SyncAuth)
+
+    # Valid credentials succeed:
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={'Authorization': basic_auth('test', 'pass')},
+    )
+    response = _SyncController.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert json.loads(response.content) == 'authed'
+
+    # No credentials fail:
+    request = dmr_rf.get('/whatever/')
+    response = _SyncController.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.asyncio
+async def test_sync_or_async_auth_settings_async(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures SyncOrAsyncAuth in settings resolves and enforces async auth."""
+    settings.DMR_SETTINGS = {Settings.auth: [_AUTH]}
+
+    class _AsyncController(Controller[PydanticSerializer]):
+        async def get(self) -> str:
+            return 'authed'
+
+    metadata = _AsyncController.api_endpoints['GET'].metadata
+    assert metadata.auth is not None
+    assert isinstance(metadata.auth[0], _AsyncAuth)
+
+    # Valid credentials succeed:
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={'Authorization': basic_auth('test', 'pass')},
+    )
+    response = await dmr_async_rf.wrap(_AsyncController.as_view()(request))
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert json.loads(response.content) == 'authed'
+
+    # No credentials fail:
+    request = dmr_async_rf.get('/whatever/')
+    response = await dmr_async_rf.wrap(_AsyncController.as_view()(request))
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })

--- a/tests/test_unit/test_security/test_sync_or_async_auth_dynamic.py
+++ b/tests/test_unit/test_security/test_sync_or_async_auth_dynamic.py
@@ -27,9 +27,7 @@ class _SyncAuth(HttpBasicSyncAuth):
         username: str,
         password: str,
     ) -> Self | None:
-        if username == 'test' and password == 'pass':  # noqa: S105
-            return self
-        return None
+        return self
 
 
 class _AsyncAuth(HttpBasicAsyncAuth):
@@ -41,9 +39,7 @@ class _AsyncAuth(HttpBasicAsyncAuth):
         username: str,
         password: str,
     ) -> Self | None:
-        if username == 'test' and password == 'pass':  # noqa: S105
-            return self
-        return None
+        return self
 
 
 _AUTH: Final = SyncOrAsyncAuth(_SyncAuth(), _AsyncAuth())

--- a/tests/test_unit/test_security/test_sync_or_async_auth_validation.py
+++ b/tests/test_unit/test_security/test_sync_or_async_auth_validation.py
@@ -24,7 +24,7 @@ class _SyncAuth(HttpBasicSyncAuth):
         username: str,
         password: str,
     ) -> Self | None:
-        return self
+        return self  # pragma: no cover
 
 
 class _AsyncAuth(HttpBasicAsyncAuth):
@@ -36,7 +36,7 @@ class _AsyncAuth(HttpBasicAsyncAuth):
         username: str,
         password: str,
     ) -> Self | None:
-        return self
+        return self  # pragma: no cover
 
 
 _AUTH: Final = SyncOrAsyncAuth(_SyncAuth(), _AsyncAuth())

--- a/tests/test_unit/test_security/test_sync_or_async_auth_validation.py
+++ b/tests/test_unit/test_security/test_sync_or_async_auth_validation.py
@@ -1,17 +1,45 @@
-from typing import Any, Final
+from typing import Any, Final, Self
 
 import pytest
 from django.conf import LazySettings
+from typing_extensions import override
 
 from dmr import Controller, modify
+from dmr.endpoint import Endpoint
 from dmr.exceptions import EndpointMetadataError
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security import SyncOrAsyncAuth
 from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth
+from dmr.serializer import BaseSerializer
 from dmr.settings import Settings
 from dmr.test import DMRRequestFactory
 
-_AUTH: Final = SyncOrAsyncAuth(HttpBasicSyncAuth(), HttpBasicAsyncAuth())
+
+class _SyncAuth(HttpBasicSyncAuth):
+    @override
+    def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        return self
+
+
+class _AsyncAuth(HttpBasicAsyncAuth):
+    @override
+    async def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        return self
+
+
+_AUTH: Final = SyncOrAsyncAuth(_SyncAuth(), _AsyncAuth())
 
 
 def test_sync_or_async_auth_resolves_to_sync_via_settings(  # noqa: WPS118
@@ -94,8 +122,8 @@ def test_same_instance_reused_for_sync_and_async(
     settings: LazySettings,
 ) -> None:
     """Ensures the same SyncOrAsyncAuth yields the same inner instances."""
-    sync_auth = HttpBasicSyncAuth()
-    async_auth = HttpBasicAsyncAuth()
+    sync_auth = _SyncAuth()
+    async_auth = _AsyncAuth()
     instance = SyncOrAsyncAuth(sync_auth, async_auth)
     settings.DMR_SETTINGS = {Settings.auth: [instance]}
 
@@ -121,7 +149,7 @@ def test_sync_auth_in_settings_raises_for_async_endpoint(  # noqa: WPS118
     settings: LazySettings,
 ) -> None:
     """Ensures sync auth in settings raises for async endpoints."""
-    settings.DMR_SETTINGS = {Settings.auth: [HttpBasicSyncAuth()]}
+    settings.DMR_SETTINGS = {Settings.auth: [_SyncAuth()]}
 
     with pytest.raises(EndpointMetadataError, match='AsyncAuth'):
 
@@ -135,7 +163,7 @@ def test_async_auth_in_settings_raises_for_sync_endpoint(  # noqa: WPS118
     settings: LazySettings,
 ) -> None:
     """Ensures async auth in settings raises for sync endpoints."""
-    settings.DMR_SETTINGS = {Settings.auth: [HttpBasicAsyncAuth()]}
+    settings.DMR_SETTINGS = {Settings.auth: [_AsyncAuth()]}
 
     with pytest.raises(EndpointMetadataError, match='SyncAuth'):
 

--- a/tests/test_unit/test_security/test_sync_or_async_auth_validation.py
+++ b/tests/test_unit/test_security/test_sync_or_async_auth_validation.py
@@ -1,0 +1,144 @@
+from typing import Any, Final
+
+import pytest
+from django.conf import LazySettings
+
+from dmr import Controller, modify
+from dmr.exceptions import EndpointMetadataError
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.security import SyncOrAsyncAuth
+from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth
+from dmr.settings import Settings
+from dmr.test import DMRRequestFactory
+
+_AUTH: Final = SyncOrAsyncAuth(HttpBasicSyncAuth(), HttpBasicAsyncAuth())
+
+
+def test_sync_or_async_auth_resolves_to_sync_via_settings(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures SyncOrAsyncAuth resolves to SyncAuth for sync endpoints."""
+    settings.DMR_SETTINGS = {Settings.auth: [_AUTH]}
+
+    class _SyncController(Controller[PydanticSerializer]):
+        def get(self) -> str:
+            raise NotImplementedError
+
+    metadata = _SyncController.api_endpoints['GET'].metadata
+    assert metadata.auth is not None
+    assert isinstance(metadata.auth[0], HttpBasicSyncAuth)
+
+
+def test_sync_or_async_auth_resolves_to_async_via_settings(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures SyncOrAsyncAuth resolves to AsyncAuth for async endpoints."""
+    settings.DMR_SETTINGS = {Settings.auth: [_AUTH]}
+
+    class _AsyncController(Controller[PydanticSerializer]):
+        async def get(self) -> str:
+            raise NotImplementedError
+
+    metadata = _AsyncController.api_endpoints['GET'].metadata
+    assert metadata.auth is not None
+    assert isinstance(metadata.auth[0], HttpBasicAsyncAuth)
+
+
+def test_sync_or_async_auth_not_allowed_at_controller_level(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures SyncOrAsyncAuth raises an error at controller level."""
+    with pytest.raises(EndpointMetadataError, match='SyncOrAsyncAuth'):
+
+        class _SyncController(Controller[PydanticSerializer]):
+            auth = (_AUTH,)  # type: ignore[assignment]
+
+            def get(self) -> str:
+                raise NotImplementedError
+
+
+def test_sync_or_async_auth_not_allowed_at_endpoint_level(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures SyncOrAsyncAuth raises an error at endpoint level."""
+    wrong_auth: Any = [_AUTH]
+    with pytest.raises(EndpointMetadataError, match='SyncOrAsyncAuth'):
+
+        class _SyncController(Controller[PydanticSerializer]):
+            @modify(auth=wrong_auth)
+            def get(self) -> str:
+                raise NotImplementedError
+
+
+def test_endpoint_metadata_never_has_sync_or_async_auth_instance(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures resolved metadata contains no SyncOrAsyncAuth instances."""
+    settings.DMR_SETTINGS = {Settings.auth: [_AUTH]}
+
+    class _SyncController(Controller[PydanticSerializer]):
+        def get(self) -> str:
+            raise NotImplementedError
+
+    metadata = _SyncController.api_endpoints['GET'].metadata
+    assert metadata.auth is not None
+    for auth in metadata.auth:
+        assert not isinstance(auth, SyncOrAsyncAuth)  # type: ignore[unreachable]
+
+
+def test_same_instance_reused_for_sync_and_async(
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures the same SyncOrAsyncAuth yields the same inner instances."""
+    sync_auth = HttpBasicSyncAuth()
+    async_auth = HttpBasicAsyncAuth()
+    instance = SyncOrAsyncAuth(sync_auth, async_auth)
+    settings.DMR_SETTINGS = {Settings.auth: [instance]}
+
+    class _SyncController(Controller[PydanticSerializer]):
+        def get(self) -> str:
+            raise NotImplementedError
+
+    class _AsyncController(Controller[PydanticSerializer]):
+        async def get(self) -> str:
+            raise NotImplementedError
+
+    sync_meta = _SyncController.api_endpoints['GET'].metadata
+    async_meta = _AsyncController.api_endpoints['GET'].metadata
+
+    assert sync_meta.auth is not None
+    assert async_meta.auth is not None
+    assert sync_meta.auth[0] is sync_auth
+    assert async_meta.auth[0] is async_auth
+
+
+def test_sync_auth_in_settings_raises_for_async_endpoint(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures sync auth in settings raises for async endpoints."""
+    settings.DMR_SETTINGS = {Settings.auth: [HttpBasicSyncAuth()]}
+
+    with pytest.raises(EndpointMetadataError, match='AsyncAuth'):
+
+        class _AsyncController(Controller[PydanticSerializer]):
+            async def get(self) -> str:
+                raise NotImplementedError
+
+
+def test_async_auth_in_settings_raises_for_sync_endpoint(  # noqa: WPS118
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures async auth in settings raises for sync endpoints."""
+    settings.DMR_SETTINGS = {Settings.auth: [HttpBasicAsyncAuth()]}
+
+    with pytest.raises(EndpointMetadataError, match='SyncAuth'):
+
+        class _SyncController(Controller[PydanticSerializer]):
+            def get(self) -> str:
+                raise NotImplementedError


### PR DESCRIPTION
Implements `SyncOrAsyncAuth` mirroring the `SyncOrAsyncThrottle` pattern. Accepts pre-built sync and async auth instances and resolves to the correct one at endpoint metadata build time based on the endpoint type.

- Add `SyncOrAsyncAuth` dataclass to `dmr/security/base.py`
- Export from `dmr/security/__init__.py`
- Wire `_build_auth()` in `endpoint_metadata.py`: settings-only validation and resolution of `SyncOrAsyncAuth` into concrete `SyncAuth`/`AsyncAuth`
- Accept `SyncOrAsyncAuth` in `validation/settings.py`
- Add validation and dynamic tests (10 tests total)
- Add CHANGELOG entry and docs section

- Closes #1102
