### PR TITLE
Allow custom token models in token_create

### DIFF
--- a/dmr/security/token/logic/token.py
+++ b/dmr/security/token/logic/token.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import secrets
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, TypeVar
 
 from django.conf import settings
 from django.utils.crypto import salted_hmac
@@ -14,10 +14,7 @@ if TYPE_CHECKING:
     from dmr.security.token.models import Token
 
 _RAW_TOKEN_SIZE: Final = 32
-
-# TODO(blocking): all these functions break abstraction on the auth class.
-# they work with the specific `Token` model, not `Auth.token_model()` type.
-# We need to refactor this before shipping a new release.
+_TokenT = TypeVar('_TokenT', bound='Token')
 
 
 def token_hash(raw_token: str) -> str:
@@ -35,11 +32,13 @@ def token_create(
     user: 'AbstractBaseUser',
     name: str,
     expires_at: dt.datetime | Sentinel | None = EMPTY,
+    token_model: 'type[Token] | None' = None,
 ) -> 'tuple[Token, str]':
     """Create a new token, returning ``(Token instance, raw token string)``."""
     from dmr.security.token.models import Token  # noqa: PLC0415
     from dmr.settings import Settings, resolve_setting  # noqa: PLC0415
 
+    model = token_model or Token
     resolved_expires_at: dt.datetime | None
     if expires_at is EMPTY:
         default_expiry: dt.timedelta | None = resolve_setting(
@@ -53,7 +52,7 @@ def token_create(
         resolved_expires_at = expires_at  # type: ignore[assignment]
 
     raw_token = secrets.token_urlsafe(_RAW_TOKEN_SIZE)
-    token = Token.objects.create(
+    token = model.objects.create(
         user=user,
         name=name,
         token_hash=token_hash(raw_token),
@@ -67,11 +66,13 @@ async def token_acreate(
     user: 'AbstractBaseUser',
     name: str,
     expires_at: dt.datetime | Sentinel | None = EMPTY,
+    token_model: 'type[Token] | None' = None,
 ) -> 'tuple[Token, str]':
     """Async version of :func:`token_create`."""
     from dmr.security.token.models import Token  # noqa: PLC0415
     from dmr.settings import Settings, resolve_setting  # noqa: PLC0415
 
+    model = token_model or Token
     resolved_expires_at: dt.datetime | None
     if expires_at is EMPTY:
         default_expiry: dt.timedelta | None = resolve_setting(
@@ -85,7 +86,7 @@ async def token_acreate(
         resolved_expires_at = expires_at  # type: ignore[assignment]
 
     raw_token = secrets.token_urlsafe(_RAW_TOKEN_SIZE)
-    token = await Token.objects.acreate(
+    token = await model.objects.acreate(
         user=user,
         name=name,
         token_hash=token_hash(raw_token),
@@ -107,10 +108,10 @@ def token_is_active(token: 'Token') -> bool:
 
 
 def token_revoke(
-    token: 'Token',
+    token: '_TokenT',
     *,
     at: dt.datetime | None = None,
-) -> 'Token':
+) -> '_TokenT':
     """Mark this token as revoked."""
     token.revoked_at = at or dt.datetime.now(dt.UTC)
     token.save(update_fields=['revoked_at', 'updated_at'])
@@ -118,10 +119,10 @@ def token_revoke(
 
 
 async def token_arevoke(
-    token: 'Token',
+    token: '_TokenT',
     *,
     at: dt.datetime | None = None,
-) -> 'Token':
+) -> '_TokenT':
     """Async version of :func:`token_revoke`."""
     token.revoked_at = at or dt.datetime.now(dt.UTC)
     await token.asave(update_fields=['revoked_at', 'updated_at'])

--- a/dmr/security/token/logic/token.py
+++ b/dmr/security/token/logic/token.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import secrets
-from typing import TYPE_CHECKING, Final, TypeVar
+from typing import TYPE_CHECKING, Final, TypeVar, overload
 
 from django.conf import settings
 from django.utils.crypto import salted_hmac
@@ -25,6 +25,26 @@ def token_hash(raw_token: str) -> str:
         secret=settings.SECRET_KEY,
         algorithm='sha256',
     ).hexdigest()
+
+
+@overload
+def token_create(
+    *,
+    user: 'AbstractBaseUser',
+    name: str,
+    expires_at: dt.datetime | Sentinel | None = ...,
+    token_model: 'type[_TokenT]',
+) -> 'tuple[_TokenT, str]': ...
+
+
+@overload
+def token_create(
+    *,
+    user: 'AbstractBaseUser',
+    name: str,
+    expires_at: dt.datetime | Sentinel | None = ...,
+    token_model: None = ...,
+) -> 'tuple[Token, str]': ...
 
 
 def token_create(
@@ -59,6 +79,26 @@ def token_create(
         expires_at=resolved_expires_at,
     )
     return token, raw_token
+
+
+@overload
+async def token_acreate(
+    *,
+    user: 'AbstractBaseUser',
+    name: str,
+    expires_at: dt.datetime | Sentinel | None = ...,
+    token_model: 'type[_TokenT]',
+) -> 'tuple[_TokenT, str]': ...
+
+
+@overload
+async def token_acreate(
+    *,
+    user: 'AbstractBaseUser',
+    name: str,
+    expires_at: dt.datetime | Sentinel | None = ...,
+    token_model: None = ...,
+) -> 'tuple[Token, str]': ...
 
 
 async def token_acreate(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,7 @@ nitpick_ignore = [
     (_PY_CLASS, 'dmr.security.jwt.views._RefreshTokensT'),
     (_PY_CLASS, 'dmr.security.jwt.views._VerifyTokenT'),
     (_PY_CLASS, 'dmr.security.jwt.views._TokensResponseT'),
+    (_PY_CLASS, 'dmr.security.token.logic.token._TokenT'),
     (
         _PY_CLASS,
         'dmr.security.django_session.views._RequestModelT',

--- a/docs/examples/auth/token/custom_token_model.py
+++ b/docs/examples/auth/token/custom_token_model.py
@@ -1,0 +1,24 @@
+from django.db import models
+from typing_extensions import override
+
+from dmr.security.token import HeaderTokenSyncAuth
+from dmr.security.token.models import Token
+
+
+class ProjectToken(Token):
+    """Extends Token with an extra project FK."""
+
+    project = models.ForeignKey(  # type: ignore[var-annotated]
+        'myapp.Project',
+        on_delete=models.CASCADE,
+        related_name='tokens',
+    )
+
+    class Meta:
+        app_label = 'myapp'
+
+
+class ProjectTokenAuth(HeaderTokenSyncAuth):
+    @override
+    def token_model(self) -> type[Token]:
+        return ProjectToken

--- a/docs/examples/auth/token/issue_custom_token.py
+++ b/docs/examples/auth/token/issue_custom_token.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.models import User
+from myapp.models import ProjectToken  # type: ignore[import-not-found]
+
+from dmr import Controller
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.security import AuthenticatedHttpRequest
+from dmr.security.django_session import DjangoSessionSyncAuth
+from dmr.security.token.logic import token_create
+
+
+class IssueProjectTokenController(Controller[PydanticSerializer]):
+    """Issue a token using the custom ProjectToken model."""
+
+    request: AuthenticatedHttpRequest[User]
+    auth = (DjangoSessionSyncAuth(),)
+
+    def post(self) -> None:
+        token, raw_token = token_create(  # noqa: RUF059
+            user=self.request.user,
+            name='project-api-key',
+            token_model=ProjectToken,
+        )
+        # raw_token is only available here - return it to the client now.
+        # Only its hash is stored; it cannot be recovered after this point.

--- a/docs/pages/auth/token.rst
+++ b/docs/pages/auth/token.rst
@@ -120,6 +120,45 @@ for example from a Django shell:
   is a common choice, since the user already has a session
   from logging in.
 
+Using a custom token model
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The built-in :class:`~dmr.security.token.models.Token` model covers most
+use cases, but you may need to store extra fields alongside a token, for
+example a project, workspace, or organisation that the key belongs to.
+The cleanest way to do this is to subclass ``Token`` and register that
+subclass with both the auth class and the creation helpers so they
+always read from and write to the same token model.
+
+**Step 1: Define your model.** Subclass
+:class:`~dmr.security.token.models.Token` to add the extra columns your app
+needs, then override :meth:`~dmr.security.token.HeaderTokenSyncAuth.token_model`
+on your auth class so every lookup uses your table:
+
+.. literalinclude:: /examples/auth/token/custom_token_model.py
+  :caption: models.py
+  :linenos:
+  :language: python
+  :no-run:
+
+**Step 2: Issue tokens with the same model.** Pass the identical class to
+:func:`~dmr.security.token.logic.token_create` (or
+:func:`~dmr.security.token.logic.token_acreate`) via ``token_model`` so
+that newly created rows land in the right table:
+
+.. literalinclude:: /examples/auth/token/issue_custom_token.py
+  :caption: issue_token.py
+  :linenos:
+  :language: python
+  :no-run:
+
+.. important::
+
+  Always pass the same model class to both ``token_model()`` and
+  ``token_create``/``token_acreate``. Mismatching them means tokens are
+  written to one table and looked up in another, causing every
+  authenticated request to fail with a ``401``.
+
 Revoking a token
 ~~~~~~~~~~~~~~~~
 

--- a/tests/test_unit/test_security/test_token/test_logic/test_token_logic.py
+++ b/tests/test_unit/test_security/test_token/test_logic/test_token_logic.py
@@ -198,3 +198,38 @@ async def test_acreate_token_uses_none_default_expiry(
         name='async-custom-none',
     )
     assert token.expires_at is None
+
+
+@pytest.mark.django_db
+def test_create_token_with_explicit_token_model(admin_user: User) -> None:
+    """Test token_create accepts an explicit token_model and uses it."""
+    token, raw_token = token_create(
+        user=admin_user,
+        name='explicit-model',
+        token_model=Token,
+    )
+
+    assert isinstance(token, Token)
+    assert isinstance(raw_token, str)
+    assert token.user == admin_user
+    assert token.name == 'explicit-model'
+    assert token_is_active(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_acreate_token_with_explicit_token_model(
+    admin_user: User,
+) -> None:
+    """token_acreate accepts an explicit token_model and uses it (async)."""
+    token, raw_token = await token_acreate(
+        user=admin_user,
+        name='async-explicit-model',
+        token_model=Token,
+    )
+
+    assert isinstance(token, Token)
+    assert isinstance(raw_token, str)
+    assert token.user == admin_user
+    assert token.name == 'async-explicit-model'
+    assert token_is_active(token)


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

Refs #1122 and [`token.py` TODO](https://github.com/wemake-services/django-modern-rest/blob/master/dmr/security/token/logic/token.py#L18-L20)

@sobolevn - curious your thoughts on this. Took a quick stab at the TODO called out. I didn't do documentation yet, but I think a section on `Customing the Token() Model` or something that would show what needs to be done (mainly overriding `Auth.token_model()`

Another thing: I'm also thinking of adding a `create_token()` / `acreate_token()` convenience method on `_BaseTokenAuth`. The idea is that users who override `token_model()` shouldn't also have to remember to manually pass (and import) the custom model every time they call `token_create()`:

```python
# with the helper `token_model()` is called automatically
token, raw = self.create_token(user=user, name='api-key')

# without it, the caller must remember to pass the model through
token, raw = token_create(user=user, name='api-key', token_model=MyToken)
```

Happy to add it if you think it's worth it - no worries if not!