### PR TITLE
feat: add JWT access token verification flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ of requirements for an API to count as public.
 ### Features
 
 - Adds "Opaque Token" auth backend, #1051
+- Added `VerifyTokenSyncController` and `VerifyTokenAsyncController`
+  reusable controllers to verify JWT access tokens, #1129
 
 
 ## Version 0.11.0 (2026-06-27)

--- a/django_test_app/server/apps/jwt_auth/urls.py
+++ b/django_test_app/server/apps/jwt_auth/urls.py
@@ -25,6 +25,16 @@ router = Router(
             name='jwt_refresh_async',
         ),
         path(
+            'jwt-verify-sync/',
+            views.VerifySyncController.as_view(),
+            name='jwt_verify_sync',
+        ),
+        path(
+            'jwt-verify-async/',
+            views.VerifyAsyncController.as_view(),
+            name='jwt_verify_async',
+        ),
+        path(
             'jwt-sync-auth/',
             views.ControllerWithJWTSyncAuth.as_view(),
             name='jwt_sync_auth',

--- a/django_test_app/server/apps/jwt_auth/views.py
+++ b/django_test_app/server/apps/jwt_auth/views.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 from dmr import Controller
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security.jwt import JWTAsyncAuth, JWTSyncAuth
-from dmr.security.jwt.views import (
+from dmr.security.jwt.views import (  # noqa: WPS235
     ObtainTokensAsyncController,
     ObtainTokensPayload,
     ObtainTokensResponse,
@@ -16,6 +16,9 @@ from dmr.security.jwt.views import (
     RefreshTokenAsyncController,
     RefreshTokenPayload,
     RefreshTokenSyncController,
+    VerifyTokenAsyncController,
+    VerifyTokenPayload,
+    VerifyTokenSyncController,
 )
 
 
@@ -156,6 +159,33 @@ class RefreshAsyncController(
                 token_type='refresh',  # noqa: S106
             ),
         }
+
+
+@final
+class VerifySyncController(
+    VerifyTokenSyncController[
+        PydanticSerializer,
+        VerifyTokenPayload,
+    ],
+):
+    @override
+    def convert_verify_payload(self, payload: VerifyTokenPayload) -> str:
+        return payload['access_token']
+
+
+@final
+class VerifyAsyncController(
+    VerifyTokenAsyncController[
+        PydanticSerializer,
+        VerifyTokenPayload,
+    ],
+):
+    @override
+    async def convert_verify_payload(
+        self,
+        payload: VerifyTokenPayload,
+    ) -> str:
+        return payload['access_token']
 
 
 @final

--- a/dmr/security/jwt/views.py
+++ b/dmr/security/jwt/views.py
@@ -21,6 +21,7 @@ from dmr.serializer import BaseSerializer
 
 _ObtainTokensT = TypeVar('_ObtainTokensT', bound=Mapping[str, Any])
 _RefreshTokensT = TypeVar('_RefreshTokensT', bound=Mapping[str, Any])
+_VerifyTokenT = TypeVar('_VerifyTokenT', bound=Mapping[str, Any])
 _TokensResponseT = TypeVar('_TokensResponseT')
 _SerializerT = TypeVar(
     '_SerializerT',
@@ -432,4 +433,156 @@ class RefreshTokenAsyncController(
     @abstractmethod
     async def make_api_response(self) -> _TokensResponseT:
         """Build the token pair response after a successful refresh."""
+        raise NotImplementedError
+
+
+class VerifyTokenPayload(TypedDict):
+    """Default request body type for the verify token endpoint."""
+
+    access_token: str
+
+
+class _BaseVerifyTokenController(_BaseTokenController[_SerializerT]):
+    jwt_user_id_field: ClassVar[str] = 'pk'
+
+    def _decode_and_validate_access_token(self, encoded_token: str) -> JWToken:
+        token = self.jwt_token_cls.decode(
+            encoded_token=encoded_token,
+            secret=self.jwt_secret or settings.SECRET_KEY,
+            algorithm=self.jwt_algorithm,
+            accepted_audiences=self.jwt_audiences,
+            accepted_issuers=self.jwt_issuer,
+        )
+        if token.extras.get('type') != 'access':
+            raise NotAuthenticatedError
+        return token
+
+
+class VerifyTokenSyncController(
+    _BaseVerifyTokenController[_SerializerT],
+    Generic[_SerializerT, _VerifyTokenT],
+):
+    """
+    Sync controller to verify an access token.
+
+    Accepts an access token in the request body, decodes and validates it,
+    ensures it is an access token (not a refresh token), and confirms that
+    the token subject belongs to an existing, active user.
+
+    Returns an empty ``204 No Content`` response when the token is valid.
+
+    Attributes:
+        jwt_user_id_field: User model field matched against ``token.sub``.
+            Defaults to ``'pk'``.
+        jwt_audiences: String or sequence of string of audiences for JWT token.
+        jwt_issuer: String of who issued this JWT token.
+        jwt_algorithm: Default algorithm to use for token signing.
+        jwt_expiration: Default token expiration timedelta.
+        jwt_refresh_expiration: Default refresh token expiration timedelta.
+        jwt_secret: Alternative token secret for signing.
+            By default uses ``secret.SECRET_KEY``
+        jwt_token_cls: Possible custom JWT token class.
+
+    """
+
+    responses = (
+        ResponseSpec(
+            return_type=ErrorModel,
+            status_code=HTTPStatus.UNAUTHORIZED,
+        ),
+    )
+
+    @modify(status_code=HTTPStatus.NO_CONTENT)
+    def post(self, parsed_body: Body[_VerifyTokenT]) -> None:
+        """Verify the token on POST."""
+        self.verify(parsed_body)
+
+    def verify(self, parsed_body: _VerifyTokenT) -> None:
+        """Validate the access token and load its user."""
+        from django.contrib.auth import get_user_model  # noqa: PLC0415
+
+        token = self._decode_and_validate_access_token(
+            self.convert_verify_payload(parsed_body),
+        )
+        try:
+            user = get_user_model().objects.get(**{
+                self.jwt_user_id_field: token.sub,
+            })
+        except ObjectDoesNotExist:
+            raise NotAuthenticatedError from None
+        self.check_auth(user)
+
+    def check_auth(self, user: Any) -> None:
+        """Run extra checks on the token's user, raise if something is off."""
+        if not user.is_active:
+            raise NotAuthenticatedError
+
+    @abstractmethod
+    def convert_verify_payload(self, payload: _VerifyTokenT) -> str:
+        """Extract the access token string from the request payload."""
+        raise NotImplementedError
+
+
+class VerifyTokenAsyncController(
+    _BaseVerifyTokenController[_SerializerT],
+    Generic[_SerializerT, _VerifyTokenT],
+):
+    """
+    Async controller to verify an access token.
+
+    Accepts an access token in the request body, decodes and validates it,
+    ensures it is an access token (not a refresh token), and confirms that
+    the token subject belongs to an existing, active user.
+
+    Returns an empty ``204 No Content`` response when the token is valid.
+
+    Attributes:
+        jwt_user_id_field: User model field matched against ``token.sub``.
+            Defaults to ``'pk'``.
+        jwt_audiences: String or sequence of string of audiences for JWT token.
+        jwt_issuer: String of who issued this JWT token.
+        jwt_algorithm: Default algorithm to use for token signing.
+        jwt_expiration: Default token expiration timedelta.
+        jwt_refresh_expiration: Default refresh token expiration timedelta.
+        jwt_secret: Alternative token secret for signing.
+            By default uses ``secret.SECRET_KEY``
+        jwt_token_cls: Possible custom JWT token class.
+
+    """
+
+    responses = (
+        ResponseSpec(
+            return_type=ErrorModel,
+            status_code=HTTPStatus.UNAUTHORIZED,
+        ),
+    )
+
+    @modify(status_code=HTTPStatus.NO_CONTENT)
+    async def post(self, parsed_body: Body[_VerifyTokenT]) -> None:
+        """Verify the token on POST."""
+        await self.verify(parsed_body)
+
+    async def verify(self, parsed_body: _VerifyTokenT) -> None:
+        """Validate the access token and load its user."""
+        from django.contrib.auth import get_user_model  # noqa: PLC0415
+
+        token = self._decode_and_validate_access_token(
+            await self.convert_verify_payload(parsed_body),
+        )
+        try:
+            user = await get_user_model().objects.aget(**{
+                self.jwt_user_id_field: token.sub,
+            })
+        except ObjectDoesNotExist:
+            raise NotAuthenticatedError from None
+        await self.check_auth(user)
+
+    async def check_auth(self, user: Any) -> None:
+        """Run extra checks on the token's user, raise if something is off."""
+        if not user.is_active:
+            raise NotAuthenticatedError
+
+    @abstractmethod
+    async def convert_verify_payload(self, payload: _VerifyTokenT) -> str:
+        """Extract the access token string from the request payload."""
         raise NotImplementedError

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,7 @@ nitpick_ignore = [
     (_PY_CLASS, 'dmr.internal.negotiation.ConditionalType'),
     (_PY_CLASS, 'dmr.security.jwt.views._ObtainTokensT'),
     (_PY_CLASS, 'dmr.security.jwt.views._RefreshTokensT'),
+    (_PY_CLASS, 'dmr.security.jwt.views._VerifyTokenT'),
     (_PY_CLASS, 'dmr.security.jwt.views._TokensResponseT'),
     (
         _PY_CLASS,

--- a/docs/examples/auth/jwt/jwt_verify_tokens.py
+++ b/docs/examples/auth/jwt/jwt_verify_tokens.py
@@ -1,0 +1,22 @@
+from typing_extensions import override
+
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.security.jwt.views import (
+    VerifyTokenPayload,
+    VerifyTokenSyncController,
+)
+
+
+# You can also use `VerifyTokenAsyncController` if needed:
+class VerifySyncController(
+    VerifyTokenSyncController[
+        PydanticSerializer,
+        VerifyTokenPayload,
+    ],
+):
+    @override
+    def convert_verify_payload(self, payload: VerifyTokenPayload) -> str:
+        return payload['access_token']
+
+
+# openapi: {"controller": "VerifySyncController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/pages/auth/jwt.rst
+++ b/docs/pages/auth/jwt.rst
@@ -132,6 +132,40 @@ The controller validates that the submitted token:
   :language: python
 
 
+Verifying tokens
+~~~~~~~~~~~~~~~~
+
+Sometimes you need a dedicated endpoint to check whether an access token
+is still valid, without accessing any protected resource.
+We provide two :ref:`reusable-controllers` for this:
+
+1. :class:`~dmr.security.jwt.views.VerifyTokenSyncController`
+   for sync controllers
+2. :class:`~dmr.security.jwt.views.VerifyTokenAsyncController`
+   for async controllers
+
+To use them, you only need to:
+
+1. Provide actual types for serializer and request payload
+2. Redefine
+   :meth:`~dmr.security.jwt.views.VerifyTokenSyncController.convert_verify_payload`
+   to extract the access token string from your request payload
+
+The controller validates that the submitted token:
+
+- Is a valid, non-expired JWT signed with the configured secret
+- Has ``extras.type == 'access'`` (i.e. it is an access token, not a refresh one)
+- Belongs to an existing, active user
+
+On success it returns an empty ``204 No Content`` response.
+On any validation failure it returns ``401 Unauthorized``.
+
+.. literalinclude:: /examples/auth/jwt/jwt_verify_tokens.py
+  :caption: views.py
+  :linenos:
+  :language: python
+
+
 Blocklisting tokens
 -------------------
 
@@ -202,6 +236,16 @@ Pre-defined views to fetch JWT tokens
   :members: post, refresh, check_auth, convert_refresh_payload, make_api_response, create_jwt_token, make_jwt_id
 
 .. autoclass:: dmr.security.jwt.views.RefreshTokenPayload
+  :members:
+  :show-inheritance:
+
+.. autoclass:: dmr.security.jwt.views.VerifyTokenSyncController
+  :members: post, verify, check_auth, convert_verify_payload, create_jwt_token, make_jwt_id
+
+.. autoclass:: dmr.security.jwt.views.VerifyTokenAsyncController
+  :members: post, verify, check_auth, convert_verify_payload, create_jwt_token, make_jwt_id
+
+.. autoclass:: dmr.security.jwt.views.VerifyTokenPayload
   :members:
   :show-inheritance:
 

--- a/tests/test_integration/test_jwt_auth/test_jwt_views.py
+++ b/tests/test_integration/test_jwt_auth/test_jwt_views.py
@@ -450,3 +450,215 @@ def test_refresh_inactive_user(
     assert response.json() == snapshot({
         'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
     })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+@pytest.mark.parametrize(
+    'obtain_url',
+    [
+        reverse('api:jwt_auth:jwt_obtain_access_refresh_sync'),
+        reverse('api:jwt_auth:jwt_obtain_access_refresh_async'),
+    ],
+)
+def test_verify_valid_token(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    *,
+    url: str,
+    obtain_url: str,
+) -> None:
+    """Ensures that a valid access token returns an empty 204 response."""
+    obtain_response = dmr_client.post(
+        obtain_url,
+        data={'username': user.username, 'password': password},
+    )
+    assert obtain_response.status_code == HTTPStatus.OK
+    access_token = obtain_response.json()['access_token']
+
+    response = dmr_client.post(url, data={'access_token': access_token})
+
+    assert response.status_code == HTTPStatus.NO_CONTENT, response.content
+    assert response.content == b''
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+def test_verify_with_refresh_token(
+    dmr_client: DMRClient,
+    user: User,
+    password: str,
+    *,
+    url: str,
+) -> None:
+    """Ensures posting a refresh token to the verify endpoint raises 401."""
+    obtain_response = dmr_client.post(
+        reverse('api:jwt_auth:jwt_obtain_access_refresh_sync'),
+        data={'username': user.username, 'password': password},
+    )
+    assert obtain_response.status_code == HTTPStatus.OK
+    refresh_token = obtain_response.json()['refresh_token']
+
+    response = dmr_client.post(url, data={'access_token': refresh_token})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+def test_verify_expired_token(
+    dmr_client: DMRClient,
+    user: User,
+    freezer: FrozenDateTimeFactory,
+    *,
+    url: str,
+) -> None:
+    """Ensures that an expired access token raises 401."""
+    expired_token = JWToken(
+        sub=str(user.pk),
+        exp=dt.datetime.now(dt.UTC) + dt.timedelta(seconds=1),
+        extras={'type': 'access'},
+    ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
+
+    next_day = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
+    freezer.move_to(next_day)
+
+    response = dmr_client.post(url, data={'access_token': expired_token})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+def test_verify_malformed_token(
+    dmr_client: DMRClient,
+    *,
+    url: str,
+) -> None:
+    """Ensures that a malformed token raises 401."""
+    response = dmr_client.post(url, data={'access_token': 'not-a-jwt'})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+@pytest.mark.parametrize(
+    'body',
+    [
+        {'wrong_key': 'value'},
+        {'access': 'value'},
+        {},
+    ],
+)
+def test_verify_wrong_structure(
+    dmr_client: DMRClient,
+    *,
+    url: str,
+    body: dict[str, str],
+) -> None:
+    """Ensures that incorrect body raises 400."""
+    response = dmr_client.post(url, data=body)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.content
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json()['detail']
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+def test_verify_deleted_user(
+    dmr_client: DMRClient,
+    user: User,
+    *,
+    url: str,
+) -> None:
+    """Ensures that an access token for a deleted user raises 401."""
+    token = JWToken(
+        sub=str(user.pk),
+        exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
+    ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
+    user.delete()
+
+    response = dmr_client.post(url, data={'access_token': token})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+def test_verify_inactive_user(
+    dmr_client: DMRClient,
+    inactive_user: User,
+    *,
+    url: str,
+) -> None:
+    """Ensures that an access token for an inactive user raises 401."""
+    token = JWToken(
+        sub=str(inactive_user.pk),
+        exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
+    ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
+
+    response = dmr_client.post(url, data={'access_token': token})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
* Add VerifyTokenSyncController/VerifyTokenAsyncController to dmr/security/jwt/views.py (modeled after RefreshTokenAsyncController/RefreshTokenSyncController).
* Implement token decoding and validation logic (204 if token is valid, 401 if token is incorrect or expired, user is unauthenticated or it is a refresh token).
* Add tests and docs, update changelog.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1129 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
