### PR TITLE
fix: make sse ping tests deterministic and cancel stale ping timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ of requirements for an API to count as public.
 - Added `VerifyTokenSyncController` and `VerifyTokenAsyncController`
   reusable controllers to verify JWT access tokens, #1129
 
+### Bugfixes
+
+- Streaming with `streaming_ping_seconds` no longer leaves the pending
+  ping timer task behind on every produced event, #1046
+
 
 ## Version 0.11.0 (2026-06-27)
 

--- a/dmr/streaming/stream.py
+++ b/dmr/streaming/stream.py
@@ -179,6 +179,10 @@ class StreamingResponse(HttpResponseBase):  # noqa: WPS338
                 return_when=asyncio.FIRST_COMPLETED,
             )
 
+            # The ping timer is recreated on each iteration,
+            # so a still pending one must not be left running.
+            ping_task.cancel()
+
             if ping_task in done and event_task not in done:
                 # Ping fired before the next real event: send the
                 # ping comment and do not touch the original task.

--- a/tests/test_unit/test_streaming/test_sse/test_sse_ping.py
+++ b/tests/test_unit/test_streaming/test_sse/test_sse_ping.py
@@ -1,9 +1,11 @@
 import asyncio
 from collections.abc import AsyncIterator
 from http import HTTPStatus
+from typing import Any
 
 import pydantic
 import pytest
+from typing_extensions import override
 
 from dmr import Body
 from dmr.plugins.pydantic import PydanticSerializer
@@ -18,28 +20,44 @@ class _BodyModel(pydantic.BaseModel):
 
 
 class _PingSSE(SSEController[PydanticSerializer]):
-    streaming_ping_seconds = 0.2
+    # We don't sleep between the events, we wait for the exact
+    # number of pings instead. Otherwise, the test would be flaky
+    # on slow machines: a late event might miss its ping window.
+    streaming_ping_seconds = 0.1
+
+    _pings: int
+    _new_ping: asyncio.Event
 
     async def post(
         self,
         parsed_body: Body[_BodyModel],
     ) -> AsyncIterator[SSEvent[int]]:
+        self._pings = 0
+        self._new_ping = asyncio.Event()
         return self._valid_events(produce_last=parsed_body.produce_last)
+
+    @override
+    def ping_event(self) -> Any | None:
+        self._pings += 1
+        self._new_ping.set()
+        return super().ping_event()
 
     async def _valid_events(
         self,
         *,
         produce_last: bool,
     ) -> AsyncIterator[SSEvent[int]]:
-        ping = self.streaming_ping_seconds
-        assert isinstance(ping, float)
-
         yield SSEvent(1)
-        await asyncio.sleep(ping + 0.1)  # one ping
+        await self._wait_for_pings(1)  # one ping
         yield SSEvent(2)
-        await asyncio.sleep((2 * ping) + 0.1)  # two pings
+        await self._wait_for_pings(3)  # two more pings
         if produce_last:
             yield SSEvent(3)
+
+    async def _wait_for_pings(self, count: int) -> None:
+        while self._pings < count:
+            self._new_ping.clear()
+            await self._new_ping.wait()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# I have made things!
`_PingSSE` was sleeping `2 * ping + 0.1` seconds while waiting for pings. Because of this 0.1 second delay, data: 3 was sent before the second ping — test was expecting ":" and got "d".

Fixed that — now `_PingSSE` counts pings and waits for the exact number of pings instead of sleeping. Test ran 20 times without failing. Also cancel the pending ping timer task on each iteration, it was leaked on every produced event.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have updated the documentation for the changes I have made

## Related issues
Closes #1046 
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
