### PR TITLE
fix: return 400 on request bodies with invalid utf-8 in msgspec parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ of requirements for an API to count as public.
 
 - Streaming with `streaming_ping_seconds` no longer leaves the pending
   ping timer task behind on every produced event, #1046
+- Fixes `500` error on request bodies containing invalid `utf-8` bytes
+  inside `msgspec`'s json and msgpack parsers,
+  now `400` is correctly returned, #1135
 
 
 ## Version 0.11.0 (2026-06-27)

--- a/dmr/plugins/msgspec/json.py
+++ b/dmr/plugins/msgspec/json.py
@@ -53,7 +53,7 @@ class MsgspecJsonParser(Parser):
                 deserializer_hook,
                 strict=self.strict,
             ).decode(to_deserialize)
-        except msgspec.DecodeError as exc:
+        except (msgspec.DecodeError, UnicodeDecodeError) as exc:
             # Corner case: when deserializing an empty body,
             # return `None` instead.
             # We do this here, because we don't want

--- a/dmr/plugins/msgspec/msgpack.py
+++ b/dmr/plugins/msgspec/msgpack.py
@@ -49,7 +49,7 @@ class MsgpackParser(Parser):
                 deserializer_hook,
                 strict=self.strict,
             ).decode(to_deserialize)
-        except msgspec.DecodeError as exc:
+        except (msgspec.DecodeError, UnicodeDecodeError) as exc:
             # Corner case: when deserializing an empty body,
             # return `None` instead.
             # We do this here, because we don't want

--- a/tests/test_integration/test_contollers/test_invalid_requests.py
+++ b/tests/test_integration/test_contollers/test_invalid_requests.py
@@ -2,6 +2,7 @@ import json
 from http import HTTPStatus
 
 import pytest
+from dirty_equals import IsStr
 from django.urls import reverse
 from faker import Faker
 from inline_snapshot import snapshot
@@ -112,6 +113,41 @@ async def test_parse_headers_ignored_async_content_type(
     assert response.status_code == HTTPStatus.CREATED, response.content
     assert response.headers['Content-Type'] == 'application/json'
     assert response.json() == {'X-API-Token': '123'}
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        b'"\xff"',
+        b'{"username": "\xff"}',
+    ],
+)
+def test_body_with_invalid_utf8(dmr_client: DMRClient, *, body: bytes) -> None:
+    """Ensure that non-utf8 bytes inside json strings are caught."""
+    response = dmr_client.post(
+        reverse('api:controllers:constrained_user_create'),
+        data=body,
+        content_type='application/json',
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.content
+    assert response.headers['Content-Type'] == 'application/json'
+    # The reported position differs between parsers, `msgspec` reports it
+    # relative to the string being decoded, while `json` reports
+    # the absolute one:
+    assert response.json() == {
+        'detail': [
+            {
+                'msg': IsStr(
+                    regex=(
+                        r"'utf-8' codec can't decode byte 0xff "
+                        r'in position \d+: invalid start byte'
+                    ),
+                ),
+                'type': 'value_error',
+            },
+        ],
+    }
 
 
 def test_single_view_sync405(

--- a/tests/test_unit/test_plugins/test_msgspec/test_msgpack.py
+++ b/tests/test_unit/test_plugins/test_msgspec/test_msgpack.py
@@ -112,6 +112,34 @@ def test_msgpack_missing_fields(
     })
 
 
+def test_msgpack_invalid_utf8(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures ``msgpack`` request with non-utf8 strings raise correctly."""
+    request = dmr_rf.post(
+        '/whatever/',
+        headers={'Content-Type': 'application/msgpack'},
+        data=msgspec.msgpack.encode({'username': 'x'}).replace(b'x', b'\xff'),
+    )
+
+    response = _MsgpackController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.content
+    assert response.headers == {'Content-Type': 'application/msgpack'}
+    assert msgspec.msgpack.decode(response.content) == snapshot({
+        'detail': [
+            {
+                'msg': (
+                    "'utf-8' codec can't decode byte 0xff "
+                    'in position 0: invalid start byte'
+                ),
+                'type': 'value_error',
+            },
+        ],
+    })
+
+
 def test_msgpack_wrong_bytes(
     dmr_rf: DMRRequestFactory,
 ) -> None:


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
If invalid utf-8 bytes are encountered inside JSON strings, msgspec raises `UnicodeDecodeError`. But the msgspec parser was not catching this error, and so strings with invalid bytes (like '"�I"ױ���') were raising a 500 error, resulting in a test failure because of an undocumented status code.

Add `UnicodeDecodeError` to the try-except block in `MsgpackParser` and `MsgspecJsonParser` so invalid utf-8 bytes inside JSON strings raise a 400 error instead of a 500.
Add tests for invalid utf-8.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1135 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
