### PR TITLE
Add per-controller request validation error status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ of requirements for an API to count as public.
 - Adds "Opaque Token" auth backend, #1051
 - Added `VerifyTokenSyncController` and `VerifyTokenAsyncController`
   reusable controllers to verify JWT access tokens, #1129
+- Adds `request_validation_error_status` controller attribute
+  to customize the HTTP status code returned on request
+  validation errors, #1130
 
 ### Bugfixes
 

--- a/dmr/controller.py
+++ b/dmr/controller.py
@@ -114,6 +114,8 @@ class Controller(Generic[_SerializerT_co], View):  # noqa: WPS214
             unsafe throttle Django cache backends?
         error_model: Schema type that represents
             and validates common error responses.
+        request_validation_error_status: HTTP status code returned when an
+            incoming request fails validation. Defaults to ``400``.
         is_abstract: Whether or not this controller is abstract.
             We consider controller "abstract" when it does not have
             exact serializer type or exact ``api_endpoints`` instances.
@@ -145,6 +147,9 @@ class Controller(Generic[_SerializerT_co], View):  # noqa: WPS214
     csrf_exempt: ClassVar[bool] = True
     serializer: ClassVar[type[BaseSerializer]]
     endpoint_cls: ClassVar[type[Endpoint]] = Endpoint
+    request_validation_error_status: ClassVar[HTTPStatus] = (
+        HTTPStatus.BAD_REQUEST
+    )
     no_validate_http_spec: ClassVar[Set[HttpSpec] | None] = frozenset()
     validate_responses: ClassVar[bool | None] = None
     semantic_responses: ClassVar[bool | None] = None

--- a/dmr/internal/context.py
+++ b/dmr/internal/context.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from collections.abc import Callable
-from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 from typing_extensions import TypedDict
@@ -195,5 +194,5 @@ class SerializerContext:
         except serializer.validation_error as exc:
             raise ValidationError(
                 serializer.serialize_validation_error(exc),
-                status_code=HTTPStatus.BAD_REQUEST,
+                status_code=controller.request_validation_error_status,
             ) from None

--- a/docs/examples/error_handling/request_validation_status.py
+++ b/docs/examples/error_handling/request_validation_status.py
@@ -1,0 +1,19 @@
+from http import HTTPStatus
+
+import pydantic
+
+from dmr import Body, Controller
+from dmr.plugins.pydantic import PydanticSerializer
+
+
+class UserSignup(pydantic.BaseModel):
+    age: int
+
+
+class SignupController(Controller[PydanticSerializer]):
+    # Return `422 Unprocessable Entity` instead of the default `400`
+    # when the incoming request fails validation:
+    request_validation_error_status = HTTPStatus.UNPROCESSABLE_ENTITY
+
+    def post(self, parsed_body: Body[UserSignup]) -> int:
+        return parsed_body.age

--- a/docs/pages/error-handling.rst
+++ b/docs/pages/error-handling.rst
@@ -205,6 +205,29 @@ This can also be used to attach ``RateLimit`` headers
 and other :doc:`throttling` information.
 
 
+Customizing request validation status code
+-------------------------------------------
+
+When an incoming request fails validation
+(an invalid body, query, headers, and so on),
+``django-modern-rest`` returns a ``400 Bad Request`` response by default.
+
+Some APIs prefer a different status code for this case,
+for example ``422 Unprocessable Entity``.
+You can change it per-controller
+via the :attr:`~dmr.controller.Controller.request_validation_error_status`
+attribute:
+
+.. literalinclude:: /examples/error_handling/request_validation_status.py
+  :caption: views.py
+  :language: python
+  :linenos:
+  :emphasize-lines: 16
+
+This only affects errors raised while validating the incoming request.
+Response and streaming validation errors are unaffected.
+
+
 Problem Details
 ---------------
 

--- a/tests/test_unit/test_endpoint/test_request_validation.py
+++ b/tests/test_unit/test_endpoint/test_request_validation.py
@@ -48,6 +48,22 @@ class _WrongTypedDictBodyController(
 
 
 @final
+class _CustomStatusBodyController(
+    Controller[PydanticSerializer],
+):
+    """Overrides the status code returned on request validation errors."""
+
+    request_validation_error_status = HTTPStatus.UNPROCESSABLE_ENTITY
+
+    def post(
+        self,
+        parsed_body: Body[_MyPydanticModel],
+    ) -> str:  # pragma: no cover
+        """Does not respect a body type."""
+        return 'done'  # not an exception for a better test clarity
+
+
+@final
 class _WrongPydanticQueryController(
     Controller[PydanticSerializer],
 ):
@@ -112,6 +128,27 @@ def test_validate_typed_dict_request_body(dmr_rf: DMRRequestFactory) -> None:
             {
                 'msg': 'Field required',
                 'loc': ['parsed_body', 'name'],
+                'type': 'value_error',
+            },
+        ],
+    })
+
+
+def test_validate_request_body_custom_status(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures a controller can customize the validation error status code."""
+    request = dmr_rf.post('/whatever/', data={})
+
+    response = _CustomStatusBodyController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert json.loads(response.content) == snapshot({
+        'detail': [
+            {
+                'msg': 'Field required',
+                'loc': ['parsed_body', 'age'],
                 'type': 'value_error',
             },
         ],


### PR DESCRIPTION
Add a `request_validation_error_status` class attribute on `Controller` (default `400`, so existing behavior is unchanged) and read it when raising the request `ValidationError`. Controllers that need a different code, e.g. `422 Unprocessable Entity`, can now set it explicitly.

Adds tests, docs, and a changelog entry.

Closes #1130
