### PR TITLE
Fix jwt extras being unintentionally required

### DIFF
--- a/.github/workflows/test-extras.yml
+++ b/.github/workflows/test-extras.yml
@@ -180,3 +180,32 @@ jobs:
 
     - name: Run checks
       run: just smoke
+
+  build-no-extras:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+    - name: Install just
+      run: uv tool install rust-just
+
+    - name: Install dependencies
+      run: uv sync
+
+    - name: Run checks
+      run: just smoke

--- a/.github/workflows/test-extras.yml
+++ b/.github/workflows/test-extras.yml
@@ -86,7 +86,6 @@ jobs:
 
     - name: Run checks
       run: |
-        just smoke
         just smoke jwt
         just unit --cov-fail-under=98
 
@@ -119,7 +118,6 @@ jobs:
 
     - name: Run checks
       run: |
-        just smoke
         just smoke jwt
         just example
         uv run pytest --cov-fail-under=90
@@ -153,7 +151,6 @@ jobs:
 
     - name: Run checks
       run: |
-        just smoke
         just smoke jwt
         uv run pytest tests/test_unit/test_plugins/test_msgspec --cov-fail-under=50
 
@@ -186,7 +183,6 @@ jobs:
 
     - name: Run checks
       run: |
-        just smoke
         just smoke jwt
 
   build-no-extras:

--- a/.github/workflows/test-extras.yml
+++ b/.github/workflows/test-extras.yml
@@ -182,8 +182,7 @@ jobs:
       run: uv sync --extra jwt
 
     - name: Run checks
-      run: |
-        just smoke jwt
+      run: just smoke jwt
 
   build-no-extras:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-extras.yml
+++ b/.github/workflows/test-extras.yml
@@ -85,7 +85,10 @@ jobs:
         uv pip install "${{ matrix.django-version }}"
 
     - name: Run checks
-      run: just smoke unit --cov-fail-under=98
+      run: |
+        just smoke
+        just smoke jwt
+        just unit --cov-fail-under=98
 
 
   build-no-msgspec:
@@ -116,7 +119,9 @@ jobs:
 
     - name: Run checks
       run: |
-        just smoke example
+        just smoke
+        just smoke jwt
+        just example
         uv run pytest --cov-fail-under=90
 
 
@@ -149,6 +154,7 @@ jobs:
     - name: Run checks
       run: |
         just smoke
+        just smoke jwt
         uv run pytest tests/test_unit/test_plugins/test_msgspec --cov-fail-under=50
 
 
@@ -179,7 +185,9 @@ jobs:
       run: uv sync --extra jwt
 
     - name: Run checks
-      run: just smoke
+      run: |
+        just smoke
+        just smoke jwt
 
   build-no-extras:
     runs-on: ubuntu-latest

--- a/dmr/throttling/cache_keys.py
+++ b/dmr/throttling/cache_keys.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import override
 
-from dmr.security.jwt.auth import request_jwt
-
 if TYPE_CHECKING:
     from dmr.controller import Controller
     from dmr.endpoint import Endpoint
@@ -124,6 +122,10 @@ class JwtToken(BaseThrottleCacheKey):
         controller: 'Controller[BaseSerializer]',
     ) -> str | None:
         """Return a hash of JWT ``jti`` / ``sub`` claims as a cache key."""
+        from dmr.security.jwt.auth import (  # noqa: PLC0415
+            request_jwt,
+        )
+
         jwt_token = request_jwt(controller.request)
         if jwt_token is None:
             return None

--- a/dmr/throttling/cache_keys.py
+++ b/dmr/throttling/cache_keys.py
@@ -102,6 +102,8 @@ class JwtToken(BaseThrottleCacheKey):
     """
     Uses a hash of JWT claims from ``request.__dmr_jwt__`` as a cache key.
 
+    Requires JWT extras to be installed.
+
     1. Never use a full token string for cache key generation.
     2. Prefer ``jti`` claim, fallback to ``sub`` claim.
     3. Store only SHA-256 hash, never raw claim values.

--- a/dmr/throttling/cache_keys.py
+++ b/dmr/throttling/cache_keys.py
@@ -102,7 +102,11 @@ class JwtToken(BaseThrottleCacheKey):
     """
     Uses a hash of JWT claims from ``request.__dmr_jwt__`` as a cache key.
 
-    Requires JWT extras to be installed.
+    Requires JWT extra to be installed with:
+
+    .. code:: bash
+
+        pip install 'django-modern-rest[jwt]'
 
     1. Never use a full token string for cache key generation.
     2. Prefer ``jti`` claim, fallback to ``sub`` claim.

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ lint:
 
 # Run all checks
 [group('dev')]
-test: lint type-check example benchmarks-type-check package smoke translations unit
+test: lint type-check example benchmarks-type-check package smoke (smoke 'jwt') translations unit
 
 # Run all type checkers
 [group('type-check')]
@@ -52,7 +52,7 @@ unit *args='':
 
 # Check package imports without django.setup()
 [group('testing')]
-smoke:
+smoke extras='':
     uv run python -c 'from dmr import Controller'
     # Checks that renderers and parsers can be imported
     # from settings without `.setup()` call:
@@ -61,7 +61,9 @@ smoke:
     # Checks that auth can be imported from settings without `.setup()` call:
     uv run python -c 'from dmr.security import *'
     uv run python -c 'from dmr.security.django_session import *'
-    uv run python -c 'from dmr.security.jwt import *'
+    if [ "{{ extras }}" = "jwt" ]; then \
+      uv run python -c 'from dmr.security.jwt import *'; \
+    fi
     uv run python -c 'from dmr.security.token import *'
     uv run python -c 'from dmr.throttling import *'
     uv run python -c 'from dmr.throttling.backends import *'

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ lint:
 
 # Run all checks
 [group('dev')]
-test: lint type-check example benchmarks-type-check package smoke (smoke 'jwt') translations unit
+test: lint type-check example benchmarks-type-check package (smoke 'jwt') translations unit
 
 # Run all type checkers
 [group('type-check')]

--- a/justfile
+++ b/justfile
@@ -61,11 +61,6 @@ smoke *extras='':
     # Checks that auth can be imported from settings without `.setup()` call:
     uv run python -c 'from dmr.security import *'
     uv run python -c 'from dmr.security.django_session import *'
-    for extra in {{ extras }}; do \
-      case "$extra" in \
-        jwt) uv run python -c 'from dmr.security.jwt import *' ;; \
-      esac; \
-    done
     uv run python -c 'from dmr.security.token import *'
     uv run python -c 'from dmr.throttling import *'
     uv run python -c 'from dmr.throttling.backends import *'
@@ -75,6 +70,11 @@ smoke *extras='':
     uv run python -c 'from dmr.openapi.objects import *'
     # Settings itself can be imported with `.setup()`:
     uv run python -c 'from dmr import settings'
+    for extra in {{ extras }}; do \
+      case "$extra" in \
+        jwt) uv run python -c 'from dmr.security.jwt import *' ;; \
+      esac; \
+    done
 
 # Run QA tools on example code
 [group('testing')]

--- a/justfile
+++ b/justfile
@@ -50,9 +50,9 @@ type-check:
 unit *args='':
     uv run pytest --inline-snapshot=disable {{ args }}
 
-# Check package imports without django.setup()
+# Check package imports without django.setup(); extras are optional, e.g. `just smoke jwt msgspec`
 [group('testing')]
-smoke extras='':
+smoke *extras='':
     uv run python -c 'from dmr import Controller'
     # Checks that renderers and parsers can be imported
     # from settings without `.setup()` call:
@@ -61,9 +61,11 @@ smoke extras='':
     # Checks that auth can be imported from settings without `.setup()` call:
     uv run python -c 'from dmr.security import *'
     uv run python -c 'from dmr.security.django_session import *'
-    if [ "{{ extras }}" = "jwt" ]; then \
-      uv run python -c 'from dmr.security.jwt import *'; \
-    fi
+    for extra in {{ extras }}; do \
+      case "$extra" in \
+        jwt) uv run python -c 'from dmr.security.jwt import *' ;; \
+      esac; \
+    done
     uv run python -c 'from dmr.security.token import *'
     uv run python -c 'from dmr.throttling import *'
     uv run python -c 'from dmr.throttling.backends import *'


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

Fixes a regression made in v0.8.0 when `django-modern-rest` is installed without the `jwt` extra and crashes due to import of jwt-dependent module.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Closes #1177 