### PR TITLE
fix: use Generator return type for contextmanager helpers

### DIFF
--- a/benchmarks/tests/test_compiled/conftest.py
+++ b/benchmarks/tests/test_compiled/conftest.py
@@ -1,5 +1,5 @@
 import sys
-from collections.abc import Callable, Iterator, Set
+from collections.abc import Callable, Generator, Set
 from contextlib import AbstractContextManager, contextmanager
 from types import ModuleType
 from typing import Final, TypeAlias
@@ -25,7 +25,7 @@ def clean_modules() -> CleanModules:
     @contextmanager
     def factory(
         names: Set[str] = _COMPILED_MODULES,
-    ) -> Iterator[dict[str, ModuleType]]:
+    ) -> Generator[dict[str, ModuleType]]:
         orig_modules = {}
         prefixes = tuple(f'{name}.' for name in names)
         for modname in list(sys.modules):

--- a/docs/tools/sphinx_ext/run_examples.py
+++ b/docs/tools/sphinx_ext/run_examples.py
@@ -21,7 +21,7 @@ import socket
 import subprocess  # noqa: S404
 import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager, redirect_stderr, suppress
 from pathlib import Path
 from types import ModuleType
@@ -457,7 +457,7 @@ def _run_app(
     path: Path,
     config: _AppRunArgs,
     builder: type[_BaseBuilder],
-) -> Iterator[int]:
+) -> Generator[int]:
     """Start a Django app on an available port."""
     restart_duration = 0.2
     port = _get_available_port()


### PR DESCRIPTION
## Description

`@contextmanager` helpers annotated with `Iterator[...]` return types are deprecated.
Update them to `Generator[...]` to match typing guidance and the existing pattern in
`tests/test_unit/test_compiled/test_negotiate_compiled.py`.

## Changes

- `benchmarks/tests/test_compiled/conftest.py`
- `docs/tools/sphinx_ext/run_examples.py`

Fixes #1181

## Verification

Scanned the tree for `@contextmanager` + `-> Iterator[` — none remaining.