### PR TITLE
Document plain Django views in the OpenAPI specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ of requirements for an API to count as public.
 - Added `dmr.adapters.adapt_django_view` to document plain Django views
   in the generated OpenAPI schema without rewriting them
   as controllers, #1193
+- Added the `components` argument to `dmr.adapters.adapt_django_view`,
+  so an adapted view can contribute the reusable `schemas`, `responses`,
+  `parameters`, `examples` and `requestBodies` its path item
+  references, #1193
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ of requirements for an API to count as public.
   so an adapted view can contribute the reusable `schemas`, `responses`,
   `parameters`, `examples` and `requestBodies` its path item
   references, #1193
+- Added the `component_prefix` argument to `dmr.adapters.adapt_django_view`,
+  which namespaces the components a view contributes and every reference
+  to them, so names imported from a foreign specification cannot displace
+  the project's own, #1193
+- Contributing two different definitions of one component name now raises,
+  instead of silently keeping one of them, #1193
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Later on we will make the API more stable and decrease the amount
 of requirements for an API to count as public.
 
 
+## WIP
+
+### Features
+
+- Added `dmr.adapters.adapt_django_view` to document plain Django views
+  in the generated OpenAPI schema without rewriting them
+  as controllers, #1193
+
+### Bugfixes
+
+- Fixed `TokenLikeSync` and `TokenLikeAsync` doc examples
+  registering real models in the app registry, #1196
+
+
 ## 0.12.1 (2026-07-31)
 
 ### Bugfixes

--- a/dmr/adapters.py
+++ b/dmr/adapters.py
@@ -6,6 +6,7 @@ as it would under plain ``django.urls.path``. See :func:`adapt_django_view`.
 """
 
 import dataclasses
+import re
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import (
@@ -22,10 +23,16 @@ from typing import (
 from django.views import View
 
 from dmr.openapi.core.registry import ComponentRegistry
-from dmr.openapi.objects import Components, PathItem
+from dmr.openapi.objects import (
+    Components,
+    Discriminator,
+    PathItem,
+    Reference,
+)
 from dmr.openapi.objects.openapi import normalize_key
 
 if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
     from django.urls import URLPattern
 
     from dmr.openapi.core.context import OpenAPIContext
@@ -54,11 +61,23 @@ Maps a component category, such as ``responses``, to the components in it.
 #: The only path item key that is not a valid python identifier.
 _REF_KEY: Final = '$ref'
 
+#: Discriminator keys, the one place a reference has no ``$ref`` key.
+_DISCRIMINATOR_KEY: Final = 'discriminator'
+_MAPPING_KEY: Final = 'mapping'
+
 #: Contributable component categories, keyed by their document spelling.
 _COMPONENT_FIELDS: Final = MappingProxyType({
     normalize_key(category): category
     for category in ComponentRegistry.categories
 })
+
+#: Reference targets a prefix applies to, one per contributable category.
+_REF_BASES: Final = tuple(
+    f'#/components/{category}/' for category in _COMPONENT_FIELDS
+)
+
+#: The characters an OpenAPI component name is allowed to be spelled with.
+_COMPONENT_NAME_PATTERN: Final = re.compile(r'[a-zA-Z0-9._-]*')
 
 
 class _AdaptedView:
@@ -88,6 +107,7 @@ def adapt_django_view(
     *,
     openapi: 'PathItem | RawPathItem',
     components: 'Components | RawComponents | None' = None,
+    component_prefix: str = '',
 ) -> type[_ViewT]:
     """
     Document a plain Django view in the generated OpenAPI specification.
@@ -161,8 +181,39 @@ def adapt_django_view(
     Any other category is rejected rather than dropped, in either spelling.
 
     Contributed components share one document with the schemas the framework
-    generates from controllers, and a generated schema always wins a name
-    clash, so give them names of your own.
+    generates from controllers, and names imported from a foreign description
+    are rarely unique enough for that. Pass *component_prefix* to namespace
+    the whole description — the component names and every reference to them,
+    in the path item and nested inside other components alike:
+
+    .. code:: python
+
+        >>> LegacyExport = adapt_django_view(
+        ...     LegacyExportView,
+        ...     openapi={
+        ...         'get': {
+        ...             'responses': {
+        ...                 '200': {'$ref': '#/components/responses/Csv'},
+        ...             },
+        ...         },
+        ...     },
+        ...     components={
+        ...         'responses': {'Csv': {'description': 'CSV payload'}},
+        ...     },
+        ...     component_prefix='Legacy',
+        ... )
+
+    That view is documented under ``#/components/responses/LegacyCsv``,
+    leaving a ``Csv`` of the project's own untouched. The prefix describes
+    the view rather than its contribution, so a view that only references
+    what another view under the same prefix contributes takes it too.
+
+    Because the prefix is applied to every reference, a description that
+    points at a component the framework generates should not carry one.
+
+    Two definitions that end up under the same final name are reported as an
+    error rather than silently merged, whether they come from two adapted
+    views or from a view and the framework's own schemas.
 
     A mapping is used verbatim below its top level, so it must already be
     spelled the way OpenAPI spells it: ``operationId``, not ``operation_id``.
@@ -186,6 +237,9 @@ def adapt_django_view(
         components: Reusable components the path item references, either as
             :class:`~dmr.openapi.objects.components.Components`
             or as a plain mapping.
+        component_prefix: Namespace for the component names of this view and
+            for every reference to them. Empty by default, which documents
+            the view under the names it was given.
 
     Returns:
         A subclass of *view_class* that reports the given path item.
@@ -193,6 +247,7 @@ def adapt_django_view(
     Raises:
         TypeError: If a mapping contains a key that is not a path item field,
             or a component category that cannot be contributed.
+        ValueError: If *component_prefix* cannot spell a component name.
 
     Warning:
         Adapting a view does **not** enrol it into the ``dmr`` request
@@ -204,16 +259,27 @@ def adapt_django_view(
     .. versionadded:: 0.13.0
 
     """
+    _check_prefix(component_prefix)
+    path_item = (
+        openapi if isinstance(openapi, PathItem) else _build_path_item(openapi)
+    )
+    adapted_components = _adapt_components(components)
+    if component_prefix:
+        path_item = cast(
+            'PathItem',
+            _prefix_refs(path_item, component_prefix),
+        )
+        adapted_components = _prefix_components(
+            adapted_components,
+            component_prefix,
+        )
+
     namespace: dict[str, Any] = {
         '__doc__': view_class.__doc__,
         '__module__': view_class.__module__,
         '__qualname__': view_class.__qualname__,
-        '_openapi': (
-            openapi
-            if isinstance(openapi, PathItem)
-            else _build_path_item(openapi)
-        ),
-        '_openapi_components': _adapt_components(components),
+        '_openapi': path_item,
+        '_openapi_components': adapted_components,
     }
     return cast(
         'type[_ViewT]',
@@ -269,6 +335,125 @@ def _check_components(components: Components) -> Components:
             _reject_category(normalize_key(field.name))
 
     return components
+
+
+def _check_prefix(prefix: str) -> None:
+    if _COMPONENT_NAME_PATTERN.fullmatch(prefix) is None:
+        raise ValueError(
+            f'{prefix!r} cannot prefix an OpenAPI component name, which is '
+            'spelled with letters, digits, dots, dashes and underscores only',
+        )
+
+
+def _prefix_components(
+    components: Components | None,
+    prefix: str,
+) -> Components | None:
+    if components is None:
+        return None
+
+    namespaced: dict[str, Any] = {}
+    for category in ComponentRegistry.categories:
+        entries = getattr(components, category)
+        if entries is not None:
+            namespaced[category] = {
+                f'{prefix}{name}': _prefix_refs(component, prefix)
+                for name, component in entries.items()
+            }
+
+    return dataclasses.replace(components, **namespaced)
+
+
+def _prefix_refs(node: Any, prefix: str) -> Any:
+    if isinstance(node, Mapping):
+        return _prefix_mapping_refs(node, prefix)  # pyright: ignore[reportUnknownArgumentType]
+    if isinstance(node, list):
+        return _prefix_list_refs(node, prefix)  # pyright: ignore[reportUnknownArgumentType]
+    if dataclasses.is_dataclass(node) and not isinstance(node, type):
+        return _prefix_object_refs(node, prefix)
+    return node
+
+
+def _prefix_mapping_refs(
+    node: Mapping[str, Any],
+    prefix: str,
+) -> dict[str, Any]:
+    return {
+        key: _prefix_keyed_value(key, node_value, prefix)
+        for key, node_value in node.items()
+    }
+
+
+def _prefix_keyed_value(key: str, node_value: Any, prefix: str) -> Any:
+    if key == _REF_KEY and isinstance(node_value, str):
+        return _prefix_ref(node_value, prefix)
+    if key == _DISCRIMINATOR_KEY and isinstance(node_value, Mapping):
+        return _prefix_raw_discriminator(node_value, prefix)  # pyright: ignore[reportUnknownArgumentType]
+    return _prefix_refs(node_value, prefix)
+
+
+def _prefix_raw_discriminator(
+    node: Mapping[str, Any],
+    prefix: str,
+) -> dict[str, Any]:
+    return {
+        key: (
+            _prefix_discriminator_targets(node_value, prefix)
+            if key == _MAPPING_KEY
+            else node_value
+        )
+        for key, node_value in node.items()
+    }
+
+
+def _prefix_discriminator_targets(
+    mapping: Mapping[str, str] | None,
+    prefix: str,
+) -> dict[str, str] | None:
+    if mapping is None:
+        return None
+    return {
+        payload: _prefix_schema_target(target, prefix)
+        for payload, target in mapping.items()
+    }
+
+
+def _prefix_schema_target(target: str, prefix: str) -> str:
+    if '/' in target:
+        return _prefix_ref(target, prefix)
+    # A discriminator may also name a schema outright, which the
+    # specification resolves against `#/components/schemas/` for us:
+    return f'{prefix}{target}'
+
+
+def _prefix_list_refs(node: list[Any], prefix: str) -> list[Any]:
+    return [_prefix_refs(list_item, prefix) for list_item in node]
+
+
+def _prefix_object_refs(node: 'DataclassInstance', prefix: str) -> Any:
+    if isinstance(node, Reference):
+        return dataclasses.replace(node, ref=_prefix_ref(node.ref, prefix))
+    if isinstance(node, Discriminator):
+        return dataclasses.replace(
+            node,
+            mapping=_prefix_discriminator_targets(node.mapping, prefix),
+        )
+
+    return dataclasses.replace(
+        node,
+        **{
+            field.name: _prefix_refs(getattr(node, field.name), prefix)
+            for field in dataclasses.fields(node)
+            if field.init
+        },
+    )
+
+
+def _prefix_ref(ref: str, prefix: str) -> str:
+    for base in _REF_BASES:
+        if ref.startswith(base):
+            return f'{base}{prefix}{ref.removeprefix(base)}'
+    return ref
 
 
 def _reject_category(key: str) -> NoReturn:

--- a/dmr/adapters.py
+++ b/dmr/adapters.py
@@ -7,11 +7,23 @@ as it would under plain ``django.urls.path``. See :func:`adapt_django_view`.
 
 import dataclasses
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias, TypeVar, cast
+from types import MappingProxyType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Final,
+    NoReturn,
+    TypeAlias,
+    TypeVar,
+    cast,
+)
 
 from django.views import View
 
-from dmr.openapi.objects import PathItem
+from dmr.openapi.core.registry import ComponentRegistry
+from dmr.openapi.objects import Components, PathItem
+from dmr.openapi.objects.openapi import normalize_key
 
 if TYPE_CHECKING:
     from django.urls import URLPattern
@@ -29,16 +41,33 @@ Path item spelled the way it appears in an OpenAPI document.
 
 """
 
+RawComponents: TypeAlias = Mapping[str, Any]
+"""
+Reusable components spelled the way they appear in an OpenAPI document.
+
+Maps a component category, such as ``responses``, to the components in it.
+
+.. versionadded:: 0.13.0
+
+"""
+
 #: The only path item key that is not a valid python identifier.
 _REF_KEY: Final = '$ref'
 
+#: Contributable component categories, keyed by their document spelling.
+_COMPONENT_FIELDS: Final = MappingProxyType({
+    normalize_key(category): category
+    for category in ComponentRegistry.categories
+})
+
 
 class _AdaptedView:
-    """Reports a statically supplied path item to the schema collector."""
+    """Reports a statically supplied description to the schema collector."""
 
     __slots__ = ()
 
     _openapi: ClassVar[PathItem]
+    _openapi_components: ClassVar[Components | None]
 
     @classmethod
     def get_path_item(
@@ -48,7 +77,9 @@ class _AdaptedView:
         context: 'OpenAPIContext',
         router: 'Router',
     ) -> PathItem:
-        """Report the path item supplied at adaptation time."""
+        """Contribute the components, then report the path item."""
+        if cls._openapi_components is not None:
+            context.registries.component.contribute(cls._openapi_components)
         return cls._openapi
 
 
@@ -56,6 +87,7 @@ def adapt_django_view(
     view_class: type[_ViewT],
     *,
     openapi: 'PathItem | RawPathItem',
+    components: 'Components | RawComponents | None' = None,
 ) -> type[_ViewT]:
     """
     Document a plain Django view in the generated OpenAPI specification.
@@ -104,6 +136,34 @@ def adapt_django_view(
         ...     },
         ... )
 
+    A path item that references reusable components carries them in
+    *components*, in the same two spellings. Only the categories a description
+    can reference are accepted — ``schemas``, ``responses``, ``parameters``,
+    ``examples`` and ``requestBodies``:
+
+    .. code:: python
+
+        >>> LegacyExport = adapt_django_view(
+        ...     LegacyExportView,
+        ...     openapi={
+        ...         'get': {
+        ...             'summary': 'Export report as CSV',
+        ...             'responses': {
+        ...                 '200': {'$ref': '#/components/responses/Csv'},
+        ...             },
+        ...         },
+        ...     },
+        ...     components={
+        ...         'responses': {'Csv': {'description': 'CSV payload'}},
+        ...     },
+        ... )
+
+    Any other category is rejected rather than dropped, in either spelling.
+
+    Contributed components share one document with the schemas the framework
+    generates from controllers, and a generated schema always wins a name
+    clash, so give them names of your own.
+
     A mapping is used verbatim below its top level, so it must already be
     spelled the way OpenAPI spells it: ``operationId``, not ``operation_id``.
     Two consequences are worth knowing:
@@ -123,12 +183,16 @@ def adapt_django_view(
         openapi: Path item describing the view, either as
             :class:`~dmr.openapi.objects.path_item.PathItem`
             or as a plain mapping.
+        components: Reusable components the path item references, either as
+            :class:`~dmr.openapi.objects.components.Components`
+            or as a plain mapping.
 
     Returns:
         A subclass of *view_class* that reports the given path item.
 
     Raises:
-        TypeError: If a mapping contains a key that is not a path item field.
+        TypeError: If a mapping contains a key that is not a path item field,
+            or a component category that cannot be contributed.
 
     Warning:
         Adapting a view does **not** enrol it into the ``dmr`` request
@@ -149,6 +213,7 @@ def adapt_django_view(
             if isinstance(openapi, PathItem)
             else _build_path_item(openapi)
         ),
+        '_openapi_components': _adapt_components(components),
     }
     return cast(
         'type[_ViewT]',
@@ -171,3 +236,43 @@ def _build_path_item(raw: RawPathItem) -> PathItem:
         fields[name] = field_value
 
     return PathItem(**fields)
+
+
+def _adapt_components(
+    components: 'Components | RawComponents | None',
+) -> Components | None:
+    if components is None:
+        return None
+    if isinstance(components, Components):
+        return _check_components(components)
+    return _build_components(components)
+
+
+def _build_components(raw: RawComponents) -> Components:
+    fields: dict[str, Any] = {}
+
+    for key, category in raw.items():
+        name = _COMPONENT_FIELDS.get(key)
+        if name is None:
+            _reject_category(key)
+        fields[name] = dict(category)
+
+    return Components(**fields)
+
+
+def _check_components(components: Components) -> Components:
+    for field in dataclasses.fields(components):
+        if (
+            field.name not in ComponentRegistry.categories
+            and getattr(components, field.name) is not None
+        ):
+            _reject_category(normalize_key(field.name))
+
+    return components
+
+
+def _reject_category(key: str) -> NoReturn:
+    raise TypeError(
+        f'{key!r} is not a component category an adapted view can '
+        f'contribute, expected one of {sorted(_COMPONENT_FIELDS)}',
+    )

--- a/dmr/adapters.py
+++ b/dmr/adapters.py
@@ -1,0 +1,173 @@
+"""
+Adapters that make plain Django views visible in the OpenAPI specification.
+
+An adapted view is documented, not adopted: it keeps dispatching exactly
+as it would under plain ``django.urls.path``. See :func:`adapt_django_view`.
+"""
+
+import dataclasses
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias, TypeVar, cast
+
+from django.views import View
+
+from dmr.openapi.objects import PathItem
+
+if TYPE_CHECKING:
+    from django.urls import URLPattern
+
+    from dmr.openapi.core.context import OpenAPIContext
+    from dmr.routing import Router
+
+_ViewT = TypeVar('_ViewT', bound=View)
+
+RawPathItem: TypeAlias = Mapping[str, Any]
+"""
+Path item spelled the way it appears in an OpenAPI document.
+
+.. versionadded:: 0.13.0
+
+"""
+
+#: The only path item key that is not a valid python identifier.
+_REF_KEY: Final = '$ref'
+
+
+class _AdaptedView:
+    """Reports a statically supplied path item to the schema collector."""
+
+    __slots__ = ()
+
+    _openapi: ClassVar[PathItem]
+
+    @classmethod
+    def get_path_item(
+        cls,
+        path: str,
+        pattern: 'URLPattern',
+        context: 'OpenAPIContext',
+        router: 'Router',
+    ) -> PathItem:
+        """Report the path item supplied at adaptation time."""
+        return cls._openapi
+
+
+def adapt_django_view(
+    view_class: type[_ViewT],
+    *,
+    openapi: 'PathItem | RawPathItem',
+) -> type[_ViewT]:
+    """
+    Document a plain Django view in the generated OpenAPI specification.
+
+    Returns a subclass of *view_class* that the schema collector can consume.
+    Mount it in a :class:`~dmr.routing.Router` like any other view:
+
+    .. code:: python
+
+        >>> from django.http import HttpResponse
+        >>> from django.urls import path
+        >>> from django.views import View
+
+        >>> from dmr.adapters import adapt_django_view
+        >>> from dmr.openapi.objects import Operation, PathItem, Response
+        >>> from dmr.routing import Router
+
+        >>> class LegacyExportView(View):
+        ...     def get(self, request):
+        ...         return HttpResponse('id,name', content_type='text/csv')
+
+        >>> LegacyExport = adapt_django_view(
+        ...     LegacyExportView,
+        ...     openapi=PathItem(
+        ...         get=Operation(
+        ...             summary='Export report as CSV',
+        ...             responses={'200': Response(description='CSV payload')},
+        ...         ),
+        ...     ),
+        ... )
+
+        >>> router = Router('api/', [path('export/', LegacyExport.as_view())])
+
+    The path item can also be a plain mapping, so a fragment of an existing
+    specification can be pasted in without translating it into typed objects:
+
+    .. code:: python
+
+        >>> LegacyExport = adapt_django_view(
+        ...     LegacyExportView,
+        ...     openapi={
+        ...         'get': {
+        ...             'summary': 'Export report as CSV',
+        ...             'responses': {'200': {'description': 'CSV payload'}},
+        ...         },
+        ...     },
+        ... )
+
+    A mapping is used verbatim below its top level, so it must already be
+    spelled the way OpenAPI spells it: ``operationId``, not ``operation_id``.
+    Two consequences are worth knowing:
+
+    - Typed objects always emit their defaults, so the typed form of an
+      operation carries ``"deprecated": false`` where the mapping form
+      carries nothing. The documents mean the same thing, but they are not
+      byte-identical.
+    - Specification extensions (``x-`` keys) are not supported at the top
+      level of the path item, because a
+      :class:`~dmr.openapi.objects.path_item.PathItem` has nowhere to keep
+      them. They are rejected rather than dropped. Inside an operation they
+      pass through untouched.
+
+    Args:
+        view_class: Any Django view class. It is not modified.
+        openapi: Path item describing the view, either as
+            :class:`~dmr.openapi.objects.path_item.PathItem`
+            or as a plain mapping.
+
+    Returns:
+        A subclass of *view_class* that reports the given path item.
+
+    Raises:
+        TypeError: If a mapping contains a key that is not a path item field.
+
+    Warning:
+        Adapting a view does **not** enrol it into the ``dmr`` request
+        pipeline. No parsers, renderers, content negotiation, problem details,
+        throttling, response validation or controller-level auth are applied
+        to it, and its errors keep the shape Django gives them. The adapter
+        adds visibility in the specification and nothing else.
+
+    .. versionadded:: 0.13.0
+
+    """
+    namespace: dict[str, Any] = {
+        '__doc__': view_class.__doc__,
+        '__module__': view_class.__module__,
+        '__qualname__': view_class.__qualname__,
+        '_openapi': (
+            openapi
+            if isinstance(openapi, PathItem)
+            else _build_path_item(openapi)
+        ),
+    }
+    return cast(
+        'type[_ViewT]',
+        type(view_class.__name__, (_AdaptedView, view_class), namespace),
+    )
+
+
+def _build_path_item(raw: RawPathItem) -> PathItem:
+    field_names = {field.name for field in dataclasses.fields(PathItem)}
+    fields: dict[str, Any] = {}
+
+    for key, field_value in raw.items():
+        name = 'ref' if key == _REF_KEY else key
+        if name not in field_names:
+            raise TypeError(
+                f'{key!r} is not a supported OpenAPI path item field, '
+                f'expected one of {sorted(field_names)}. '
+                'Specification extensions are not supported here',
+            )
+        fields[name] = field_value
+
+    return PathItem(**fields)

--- a/dmr/openapi/collector.py
+++ b/dmr/openapi/collector.py
@@ -1,20 +1,38 @@
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 from django.contrib.admindocs.views import simplify_regex
 from django.urls import URLPattern, URLResolver
 
 if TYPE_CHECKING:
-    from dmr.controller import Controller
-    from dmr.serializer import BaseSerializer
+    from dmr.openapi.core.context import OpenAPIContext
+    from dmr.openapi.objects import PathItem
+    from dmr.routing import Router
+
+
+class SupportsPathItem(Protocol):
+    """
+    What the collector needs from a view to document it.
+
+    Both a :class:`~dmr.controller.Controller` and a plain Django view
+    adapted by :func:`~dmr.adapters.adapt_django_view` satisfy this.
+    """
+
+    @classmethod
+    def get_path_item(
+        cls,
+        path: str,
+        pattern: URLPattern,
+        context: 'OpenAPIContext',
+        router: 'Router',
+    ) -> 'PathItem':
+        """Describe the view as a single OpenAPI path item."""
+        ...
+
 
 _AnyPattern: TypeAlias = URLPattern | URLResolver
-_PathControllerSpec: TypeAlias = tuple[
-    str,
-    URLPattern,
-    'Controller[BaseSerializer]',
-]
+_PathControllerSpec: TypeAlias = tuple[str, URLPattern, type[SupportsPathItem]]
 
 
 def _process_pattern(

--- a/dmr/openapi/core/context.py
+++ b/dmr/openapi/core/context.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, get_origin
 
 from dmr.openapi.core.merger import ConfigMerger
 from dmr.openapi.core.registry import (
+    ComponentRegistry,
     OperationIdRegistry,
     SchemaCallback,
     SchemaRegistry,
@@ -29,6 +30,7 @@ class RegistryContainer:
     operation_id: OperationIdRegistry
     schema: SchemaRegistry
     security_scheme: SecuritySchemeRegistry
+    component: ComponentRegistry
 
 
 @dataclass(slots=True, frozen=True)
@@ -66,6 +68,7 @@ class OpenAPIContext:
             operation_id=OperationIdRegistry(),
             schema=SchemaRegistry(),
             security_scheme=SecuritySchemeRegistry(),
+            component=ComponentRegistry(),
         )
 
         # Initialize generators

--- a/dmr/openapi/core/registry.py
+++ b/dmr/openapi/core/registry.py
@@ -12,6 +12,7 @@ from dmr.openapi.objects import (
     Schema,
     SecurityScheme,
 )
+from dmr.openapi.objects.openapi import normalize_key
 from dmr.types import EMPTY
 
 
@@ -188,12 +189,14 @@ class ComponentRegistry:
         self.request_bodies: dict[str, RequestBody | Reference] = {}
 
     def contribute(self, components: Components) -> None:
-        """Merge the given components into the registry."""
-        self.schemas.update(components.schemas or {})
-        self.responses.update(components.responses or {})
-        self.parameters.update(components.parameters or {})
-        self.examples.update(components.examples or {})
-        self.request_bodies.update(components.request_bodies or {})
+        """
+        Merge the given components into the registry.
+
+        Contributing the very same definition twice is allowed, because one
+        description is commonly shared by several adapted views.
+        """
+        for category in self.categories:
+            self._merge(category, getattr(components, category) or {})
 
     def build(
         self,
@@ -204,9 +207,17 @@ class ComponentRegistry:
         """
         Build the ``components`` section of the document.
 
-        Generated schemas win over contributed ones of the same name, so a
-        contribution can never replace what the pipeline produced.
+        Contributed schemas share the section with the ones the pipeline
+        generates, so a name carrying both definitions is reported here.
         """
+        for schema_name, generated in schemas.items():
+            _check_conflict(
+                'schemas',
+                schema_name,
+                self.schemas.get(schema_name),
+                generated,
+            )
+
         return Components(
             schemas=dict(sorted((self.schemas | schemas).items())),
             security_schemes=security_schemes,
@@ -214,6 +225,29 @@ class ComponentRegistry:
             parameters=self.parameters or None,
             examples=self.examples or None,
             request_bodies=self.request_bodies or None,
+        )
+
+    def _merge(self, category: str, contributed: dict[str, Any]) -> None:
+        registered: dict[str, Any] = getattr(self, category)
+        for name, component in contributed.items():
+            _check_conflict(category, name, registered.get(name), component)
+            registered[name] = component
+
+
+def _check_conflict(
+    category: str,
+    name: str,
+    existing: Any | None,
+    component: Any,
+) -> None:
+    if existing is not None and existing != component:
+        raise ValueError(
+            f'Component {name!r} is defined twice under '
+            f'{normalize_key(category)!r} in the OpenAPI specification, '
+            'with two different definitions. Components contributed by an '
+            'adapted view share one document with the ones the framework '
+            'generates, so rename the contribution or namespace it with the '
+            '`component_prefix` argument of `adapt_django_view`.',
         )
 
 

--- a/dmr/openapi/core/registry.py
+++ b/dmr/openapi/core/registry.py
@@ -2,7 +2,16 @@ from typing import Any, ClassVar, Protocol
 
 from typing_extensions import Sentinel
 
-from dmr.openapi.objects import Reference, Schema, SecurityScheme
+from dmr.openapi.objects import (
+    Components,
+    Example,
+    Parameter,
+    Reference,
+    RequestBody,
+    Response,
+    Schema,
+    SecurityScheme,
+)
 from dmr.types import EMPTY
 
 
@@ -140,6 +149,72 @@ class SecuritySchemeRegistry:
     ) -> None:
         """Register security scheme in registry."""
         self.schemes[name] = scheme
+
+
+class ComponentRegistry:
+    """
+    Registry for reusable components contributed from outside the pipeline.
+
+    The framework derives schemas and security schemes from controllers on its
+    own. Everything collected here comes from a description supplied by hand,
+    the typical source being an adapted plain Django view whose path item
+    references components the pipeline knows nothing about.
+    """
+
+    __slots__ = (
+        'examples',
+        'parameters',
+        'request_bodies',
+        'responses',
+        'schemas',
+    )
+
+    #: Component categories that can be contributed, as field names.
+    categories: ClassVar[tuple[str, ...]] = (
+        'schemas',
+        'responses',
+        'parameters',
+        'examples',
+        'request_bodies',
+    )
+
+    def __init__(self) -> None:
+        """Initialize empty registers for every contributed category."""
+        self.schemas: dict[str, Schema] = {}
+        self.responses: dict[str, Response | Reference] = {}
+        # An OpenAPI category name, not a variable name we chose:
+        self.parameters: dict[str, Parameter | Reference] = {}  # noqa: WPS110
+        self.examples: dict[str, Example | Reference] = {}
+        self.request_bodies: dict[str, RequestBody | Reference] = {}
+
+    def contribute(self, components: Components) -> None:
+        """Merge the given components into the registry."""
+        self.schemas.update(components.schemas or {})
+        self.responses.update(components.responses or {})
+        self.parameters.update(components.parameters or {})
+        self.examples.update(components.examples or {})
+        self.request_bodies.update(components.request_bodies or {})
+
+    def build(
+        self,
+        *,
+        schemas: dict[str, Schema],
+        security_schemes: dict[str, SecurityScheme | Reference],
+    ) -> Components:
+        """
+        Build the ``components`` section of the document.
+
+        Generated schemas win over contributed ones of the same name, so a
+        contribution can never replace what the pipeline produced.
+        """
+        return Components(
+            schemas=dict(sorted((self.schemas | schemas).items())),
+            security_schemes=security_schemes,
+            responses=self.responses or None,
+            parameters=self.parameters or None,
+            examples=self.examples or None,
+            request_bodies=self.request_bodies or None,
+        )
 
 
 def _check_hashes(

--- a/dmr/routing.py
+++ b/dmr/routing.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 from dmr.errors import ErrorType, format_error
 from dmr.exceptions import InternalServerError, NotAcceptableError
 from dmr.openapi.collector import controller_mapping_collector
-from dmr.openapi.objects import Components, OpenAPI, Paths
+from dmr.openapi.objects import OpenAPI, Paths
 
 if TYPE_CHECKING:
     from django.utils.functional import (
@@ -86,7 +86,7 @@ class Router:
                 router=self,
             )
 
-        components = Components(
+        components = context.registries.component.build(
             schemas=context.registries.schema.schemas,
             security_schemes=context.registries.security_scheme.schemes,
         )

--- a/docs/pages/deep-dive/public-api.rst
+++ b/docs/pages/deep-dive/public-api.rst
@@ -113,6 +113,8 @@ Adapters
 
 .. autodata:: dmr.adapters.RawPathItem
 
+.. autodata:: dmr.adapters.RawComponents
+
 
 Meta mixins
 -----------

--- a/docs/pages/deep-dive/public-api.rst
+++ b/docs/pages/deep-dive/public-api.rst
@@ -106,6 +106,14 @@ Routing
 .. autofunction:: dmr.routing.path
 
 
+Adapters
+--------
+
+.. autofunction:: dmr.adapters.adapt_django_view
+
+.. autodata:: dmr.adapters.RawPathItem
+
+
 Meta mixins
 -----------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,10 @@ per-file-ignores =
   dmr/endpoint.py: WPS201, WPS203, WPS402, WPS404
   dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS402
   dmr/openapi/mappers/schema_loader.py: WPS202
+  # One public function surrounded by its private helpers:
+  dmr/adapters.py: WPS202
+  # A registry per thing the specification registers:
+  dmr/openapi/core/registry.py: WPS202
   dmr/controller.py: WPS201
   dmr/routing.py: WPS201
   dmr/problem_details.py: WPS211, WPS226

--- a/tests/test_unit/test_adapters/__snapshots__/test_component_contribution.ambr
+++ b/tests/test_unit/test_adapters/__snapshots__/test_component_contribution.ambr
@@ -1,0 +1,84 @@
+# serializer version: 1
+# name: test_contributed_components
+  '''
+  {
+    "info": {
+      "title": "Your Awesome Project",
+      "version": "0.1.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {
+      "/api/report/": {
+        "post": {
+          "summary": "Build a report",
+          "parameters": [
+            {
+              "$ref": "#/components/parameters/ReportFormat"
+            }
+          ],
+          "requestBody": {
+            "$ref": "#/components/requestBodies/ReportFilter"
+          },
+          "responses": {
+            "200": {
+              "$ref": "#/components/responses/ReportBuilt"
+            }
+          },
+          "deprecated": false
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "ReportFilter": {
+          "properties": {
+            "since": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "responses": {
+        "ReportBuilt": {
+          "description": "The built report"
+        }
+      },
+      "parameters": {
+        "ReportFormat": {
+          "deprecated": false,
+          "examples": {
+            "csv": {
+              "$ref": "#/components/examples/CsvFormat"
+            }
+          },
+          "name": "format",
+          "in": "query",
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "examples": {
+        "CsvFormat": {
+          "summary": "Comma separated",
+          "value": "csv"
+        }
+      },
+      "requestBodies": {
+        "ReportFilter": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportFilter"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "securitySchemes": {}
+    }
+  }
+  '''
+# ---

--- a/tests/test_unit/test_adapters/__snapshots__/test_component_namespacing.ambr
+++ b/tests/test_unit/test_adapters/__snapshots__/test_component_namespacing.ambr
@@ -1,0 +1,98 @@
+# serializer version: 1
+# name: test_prefixed_and_unprefixed_components
+  '''
+  {
+    "info": {
+      "title": "Your Awesome Project",
+      "version": "0.1.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {
+      "/api/report/": {
+        "get": {
+          "summary": "Build a report",
+          "parameters": [
+            {
+              "$ref": "#/components/parameters/LegacyFormat"
+            }
+          ],
+          "requestBody": {
+            "$ref": "#/components/requestBodies/LegacyFilter"
+          },
+          "responses": {
+            "200": {
+              "$ref": "#/components/responses/LegacyBuilt"
+            }
+          },
+          "deprecated": false
+        }
+      },
+      "/api/export/": {
+        "get": {
+          "summary": "Export a report",
+          "responses": {
+            "200": {
+              "$ref": "#/components/responses/Exported"
+            }
+          },
+          "deprecated": false
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "LegacyErrorModel": {
+          "properties": {
+            "since": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "responses": {
+        "LegacyBuilt": {
+          "description": "The built report"
+        },
+        "Exported": {
+          "description": "The exported report"
+        }
+      },
+      "parameters": {
+        "LegacyFormat": {
+          "deprecated": false,
+          "examples": {
+            "csv": {
+              "$ref": "#/components/examples/LegacyCsv"
+            }
+          },
+          "name": "format",
+          "in": "query",
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "examples": {
+        "LegacyCsv": {
+          "summary": "Comma separated",
+          "value": "csv"
+        }
+      },
+      "requestBodies": {
+        "LegacyFilter": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LegacyErrorModel"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "securitySchemes": {}
+    }
+  }
+  '''
+# ---

--- a/tests/test_unit/test_adapters/__snapshots__/test_django_view_adapter.ambr
+++ b/tests/test_unit/test_adapters/__snapshots__/test_django_view_adapter.ambr
@@ -1,0 +1,30 @@
+# serializer version: 1
+# name: test_adapted_view_schema
+  '''
+  {
+    "info": {
+      "title": "Your Awesome Project",
+      "version": "0.1.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {
+      "/api/legacy/export/": {
+        "summary": "Legacy CSV export",
+        "get": {
+          "summary": "Export report as CSV",
+          "responses": {
+            "200": {
+              "description": "CSV payload"
+            }
+          },
+          "deprecated": false
+        }
+      }
+    },
+    "components": {
+      "schemas": {},
+      "securitySchemes": {}
+    }
+  }
+  '''
+# ---

--- a/tests/test_unit/test_adapters/test_component_contribution.py
+++ b/tests/test_unit/test_adapters/test_component_contribution.py
@@ -1,0 +1,283 @@
+import json
+from http import HTTPStatus
+from types import MappingProxyType
+from typing import Any
+
+import pydantic
+import pytest
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory
+from django.urls import path
+from django.views import View
+from syrupy.assertion import SnapshotAssertion
+
+from dmr import Controller
+from dmr.adapters import adapt_django_view
+from dmr.openapi import build_schema, objects
+from dmr.openapi.objects.enums import OpenAPIType
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.routing import Router
+
+
+class _LegacyReportView(View):
+    """Plain Django view whose description references shared components."""
+
+    def post(self, request: HttpRequest) -> HttpResponse:
+        """Build the report the way plain Django would."""
+        return HttpResponse(b'{}', content_type='application/json')
+
+
+class _LegacyAuditView(View):
+    """Second legacy view, contributing components of its own."""
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        """Render the audit trail the way plain Django would."""
+        return HttpResponse(b'[]', content_type='application/json')
+
+
+_REPORT_PATH_ITEM = objects.PathItem(
+    post=objects.Operation(
+        summary='Build a report',
+        parameters=[
+            objects.Reference(ref='#/components/parameters/ReportFormat'),
+        ],
+        request_body=objects.Reference(
+            ref='#/components/requestBodies/ReportFilter',
+        ),
+        responses={
+            '200': objects.Reference(ref='#/components/responses/ReportBuilt'),
+        },
+    ),
+)
+
+_REPORT_COMPONENTS = objects.Components(
+    schemas={
+        'ReportFilter': objects.Schema(
+            type=OpenAPIType.OBJECT,
+            properties={'since': objects.Schema(type=OpenAPIType.STRING)},
+        ),
+    },
+    parameters={
+        'ReportFormat': objects.Parameter(
+            name='format',
+            param_in='query',
+            schema=objects.Schema(type=OpenAPIType.STRING),
+            examples={
+                'csv': objects.Reference(ref='#/components/examples/CsvFormat'),
+            },
+        ),
+    },
+    examples={
+        'CsvFormat': objects.Example(summary='Comma separated', value='csv'),
+    },
+    request_bodies={
+        'ReportFilter': objects.RequestBody(
+            content={
+                'application/json': objects.MediaType(
+                    schema=objects.Reference(
+                        ref='#/components/schemas/ReportFilter',
+                    ),
+                ),
+            },
+        ),
+    },
+    responses={'ReportBuilt': objects.Response(description='The built report')},
+)
+
+# The very same components, spelled the way an OpenAPI document spells them.
+# Defaults are explicit here because typed objects always emit them.
+_RAW_REPORT_COMPONENTS = MappingProxyType({
+    'schemas': {
+        'ReportFilter': {
+            'type': 'object',
+            'properties': {'since': {'type': 'string'}},
+        },
+    },
+    'parameters': {
+        'ReportFormat': {
+            'name': 'format',
+            'in': 'query',
+            'schema': {'type': 'string'},
+            'examples': {'csv': {'$ref': '#/components/examples/CsvFormat'}},
+            'deprecated': False,
+        },
+    },
+    'examples': {'CsvFormat': {'summary': 'Comma separated', 'value': 'csv'}},
+    'requestBodies': {
+        'ReportFilter': {
+            'content': {
+                'application/json': {
+                    'schema': {'$ref': '#/components/schemas/ReportFilter'},
+                },
+            },
+            'required': True,
+        },
+    },
+    'responses': {'ReportBuilt': {'description': 'The built report'}},
+})
+
+_AUDIT_PATH_ITEM = objects.PathItem(
+    get=objects.Operation(
+        summary='Read the audit trail',
+        responses={
+            '200': objects.Reference(ref='#/components/responses/AuditListed'),
+        },
+    ),
+)
+
+_AUDIT_COMPONENTS = objects.Components(
+    schemas={'AuditEntry': objects.Schema(type=OpenAPIType.OBJECT)},
+    responses={
+        'AuditListed': objects.Response(
+            description='The audit trail',
+            content={
+                'application/json': objects.MediaType(
+                    schema=objects.Reference(
+                        ref='#/components/schemas/AuditEntry',
+                    ),
+                ),
+            },
+        ),
+    },
+)
+
+_TypedReport = adapt_django_view(
+    _LegacyReportView,
+    openapi=_REPORT_PATH_ITEM,
+    components=_REPORT_COMPONENTS,
+)
+_RawReport = adapt_django_view(
+    _LegacyReportView,
+    openapi=_REPORT_PATH_ITEM,
+    components=_RAW_REPORT_COMPONENTS,
+)
+_Audit = adapt_django_view(
+    _LegacyAuditView,
+    openapi=_AUDIT_PATH_ITEM,
+    components=_AUDIT_COMPONENTS,
+)
+
+
+class _UserModel(pydantic.BaseModel):
+    username: str
+
+
+class _UserController(Controller[PydanticSerializer]):
+    def get(self) -> _UserModel:
+        raise NotImplementedError
+
+
+def _build_schema(*urls: Any) -> dict[str, Any]:
+    return build_schema(Router('api/', list(urls))).convert()
+
+
+def test_contributed_components(snapshot: SnapshotAssertion) -> None:
+    """Ensure that all five component categories reach the document."""
+    schema = _build_schema(path('report/', _TypedReport.as_view()))
+
+    assert json.dumps(schema, indent=2) == snapshot
+
+
+def test_raw_components_match_typed_objects() -> None:
+    """Ensure that a mapping and typed objects describe the same components."""
+    assert _build_schema(
+        path('report/', _RawReport.as_view()),
+    ) == _build_schema(path('report/', _TypedReport.as_view()))
+
+
+def test_contributed_document_is_valid() -> None:
+    """Ensure that the document with contributed components validates."""
+    router = Router('api/', [path('report/', _TypedReport.as_view())])
+
+    # Raises when `django-modern-rest[openapi]` is installed and the
+    # document is invalid — a dangling reference is what would break here:
+    assert build_schema(router).convert(skip_validation=False)
+
+
+def test_components_from_two_views() -> None:
+    """Ensure that two adapted views can both contribute components."""
+    schema = _build_schema(
+        path('report/', _TypedReport.as_view()),
+        path('audit/', _Audit.as_view()),
+    )
+    components = schema['components']
+
+    assert sorted(schema['paths']) == ['/api/audit/', '/api/report/']
+    assert sorted(components['schemas']) == ['AuditEntry', 'ReportFilter']
+    assert sorted(components['responses']) == ['AuditListed', 'ReportBuilt']
+    assert sorted(components['parameters']) == ['ReportFormat']
+    assert sorted(components['examples']) == ['CsvFormat']
+    assert sorted(components['requestBodies']) == ['ReportFilter']
+
+
+def test_generated_schemas_are_untouched() -> None:
+    """Ensure that contributions do not disturb the framework's own schemas."""
+    with_adapter = _build_schema(
+        path('user/', _UserController.as_view()),
+        path('report/', _TypedReport.as_view()),
+    )
+    without_adapter = _build_schema(path('user/', _UserController.as_view()))
+
+    generated = without_adapter['components']['schemas']
+    assert generated
+    assert {
+        name: schema
+        for name, schema in with_adapter['components']['schemas'].items()
+        if name in generated
+    } == generated
+
+
+def test_no_components_without_contributions() -> None:
+    """Ensure that a view without components leaves the document alone."""
+    plain = adapt_django_view(
+        _LegacyAuditView,
+        openapi=objects.PathItem(
+            get=objects.Operation(
+                responses={'200': objects.Response(description='Ok')},
+            ),
+        ),
+    )
+
+    components = _build_schema(
+        path('audit/', plain.as_view()),
+    )['components']
+
+    assert 'responses' not in components
+    assert 'parameters' not in components
+    assert 'examples' not in components
+    assert 'requestBodies' not in components
+
+
+def test_contribution_does_not_change_dispatch(rf: RequestFactory) -> None:
+    """Ensure that contributing components stays a documentation-only act."""
+    report = _TypedReport.as_view()(rf.post('/api/report/'))
+    audit = _Audit.as_view()(rf.get('/api/audit/'))
+
+    assert isinstance(report, HttpResponse)
+    assert isinstance(audit, HttpResponse)
+    assert report.status_code == HTTPStatus.OK
+    assert report.content == b'{}'
+    assert audit.status_code == HTTPStatus.OK
+    assert audit.content == b'[]'
+
+
+def test_unsupported_raw_category() -> None:
+    """Ensure that an unsupported category is reported, not silently dropped."""
+    with pytest.raises(TypeError, match='securitySchemes'):
+        adapt_django_view(
+            _LegacyAuditView,
+            openapi=_AUDIT_PATH_ITEM,
+            components={'securitySchemes': {'apiKey': {'type': 'apiKey'}}},
+        )
+
+
+def test_unsupported_typed_category() -> None:
+    """Ensure that both spellings reject an unsupported category alike."""
+    with pytest.raises(TypeError, match='headers'):
+        adapt_django_view(
+            _LegacyAuditView,
+            openapi=_AUDIT_PATH_ITEM,
+            components=objects.Components(
+                headers={'X-Total-Count': objects.Header()},
+            ),
+        )

--- a/tests/test_unit/test_adapters/test_component_namespacing.py
+++ b/tests/test_unit/test_adapters/test_component_namespacing.py
@@ -1,0 +1,457 @@
+import json
+from http import HTTPStatus
+from types import MappingProxyType
+from typing import Any
+
+import pydantic
+import pytest
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory
+from django.urls import path
+from django.views import View
+from syrupy.assertion import SnapshotAssertion
+
+from dmr import Controller
+from dmr.adapters import adapt_django_view
+from dmr.openapi import build_schema, objects
+from dmr.openapi.objects.enums import OpenAPIType
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.routing import Router
+
+
+class _LegacyReportView(View):
+    """Plain Django view imported from a foreign specification."""
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        """Build the report the way plain Django would."""
+        return HttpResponse(b'{}', content_type='application/json')
+
+
+class _ProjectExportView(View):
+    """Plain Django view of our own, described without a prefix."""
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        """Export the report the way plain Django would."""
+        return HttpResponse(b'id,name', content_type='text/csv')
+
+
+_REPORT_PATH_ITEM = objects.PathItem(
+    get=objects.Operation(
+        summary='Build a report',
+        parameters=[objects.Reference(ref='#/components/parameters/Format')],
+        request_body=objects.Reference(
+            ref='#/components/requestBodies/Filter',
+        ),
+        responses={
+            '200': objects.Reference(ref='#/components/responses/Built'),
+        },
+    ),
+)
+
+# `ErrorModel` is also the name of a schema the framework generates,
+# so it only survives here because the contribution is namespaced.
+_REPORT_COMPONENTS = objects.Components(
+    schemas={
+        'ErrorModel': objects.Schema(
+            type=OpenAPIType.OBJECT,
+            properties={'since': objects.Schema(type=OpenAPIType.STRING)},
+        ),
+    },
+    parameters={
+        'Format': objects.Parameter(
+            name='format',
+            param_in='query',
+            schema=objects.Schema(type=OpenAPIType.STRING),
+            examples={
+                'csv': objects.Reference(ref='#/components/examples/Csv'),
+            },
+        ),
+    },
+    examples={'Csv': objects.Example(summary='Comma separated', value='csv')},
+    request_bodies={
+        'Filter': objects.RequestBody(
+            content={
+                'application/json': objects.MediaType(
+                    schema=objects.Reference(
+                        ref='#/components/schemas/ErrorModel',
+                    ),
+                ),
+            },
+        ),
+    },
+    responses={'Built': objects.Response(description='The built report')},
+)
+
+# The very same components, spelled the way an OpenAPI document spells them.
+# Defaults are explicit here because typed objects always emit them.
+_RAW_REPORT_COMPONENTS = MappingProxyType({
+    'schemas': {
+        'ErrorModel': {
+            'type': 'object',
+            'properties': {'since': {'type': 'string'}},
+        },
+    },
+    'parameters': {
+        'Format': {
+            'name': 'format',
+            'in': 'query',
+            'schema': {'type': 'string'},
+            'examples': {'csv': {'$ref': '#/components/examples/Csv'}},
+            'deprecated': False,
+        },
+    },
+    'examples': {'Csv': {'summary': 'Comma separated', 'value': 'csv'}},
+    'requestBodies': {
+        'Filter': {
+            'content': {
+                'application/json': {
+                    'schema': {'$ref': '#/components/schemas/ErrorModel'},
+                },
+            },
+            'required': True,
+        },
+    },
+    'responses': {'Built': {'description': 'The built report'}},
+})
+
+_EXPORT_PATH_ITEM = objects.PathItem(
+    get=objects.Operation(
+        summary='Export a report',
+        responses={
+            '200': objects.Reference(ref='#/components/responses/Exported'),
+        },
+    ),
+)
+
+_EXPORT_COMPONENTS = objects.Components(
+    responses={'Exported': objects.Response(description='The exported report')},
+)
+
+_TypedReport = adapt_django_view(
+    _LegacyReportView,
+    openapi=_REPORT_PATH_ITEM,
+    components=_REPORT_COMPONENTS,
+    component_prefix='Legacy',
+)
+_RawReport = adapt_django_view(
+    _LegacyReportView,
+    openapi=_REPORT_PATH_ITEM,
+    components=_RAW_REPORT_COMPONENTS,
+    component_prefix='Legacy',
+)
+_OtherReport = adapt_django_view(
+    _LegacyReportView,
+    openapi=_REPORT_PATH_ITEM,
+    components=_REPORT_COMPONENTS,
+    component_prefix='Vendor',
+)
+_Export = adapt_django_view(
+    _ProjectExportView,
+    openapi=_EXPORT_PATH_ITEM,
+    components=_EXPORT_COMPONENTS,
+)
+
+
+class _UserModel(pydantic.BaseModel):
+    username: str
+
+
+class _UserController(Controller[PydanticSerializer]):
+    def get(self) -> _UserModel:
+        raise NotImplementedError
+
+
+def _build_schema(*urls: Any) -> dict[str, Any]:
+    return build_schema(Router('api/', list(urls))).convert()
+
+
+def test_prefixed_and_unprefixed_components(
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Ensure that namespaced and plain contributions share one document."""
+    schema = _build_schema(
+        path('report/', _TypedReport.as_view()),
+        path('export/', _Export.as_view()),
+    )
+
+    assert json.dumps(schema, indent=2) == snapshot
+
+
+def test_prefixed_document_is_valid() -> None:
+    """Ensure that every rewritten reference still resolves."""
+    router = Router('api/', [path('report/', _TypedReport.as_view())])
+
+    # Raises when `django-modern-rest[openapi]` is installed and the
+    # document is invalid — a dangling reference is what would break here:
+    assert build_schema(router).convert(skip_validation=False)
+
+
+def test_top_level_references_are_prefixed() -> None:
+    """Ensure that the path item points at the namespaced components."""
+    operation = _build_schema(
+        path('report/', _TypedReport.as_view()),
+    )['paths']['/api/report/']['get']
+
+    assert operation['parameters'] == [
+        {'$ref': '#/components/parameters/LegacyFormat'},
+    ]
+    assert operation['requestBody'] == {
+        '$ref': '#/components/requestBodies/LegacyFilter',
+    }
+    assert operation['responses'] == {
+        '200': {'$ref': '#/components/responses/LegacyBuilt'},
+    }
+
+
+def test_nested_references_are_prefixed() -> None:
+    """Ensure that a reference inside another component is rewritten too."""
+    components = _build_schema(
+        path('report/', _TypedReport.as_view()),
+    )['components']
+
+    assert components['parameters']['LegacyFormat']['examples'] == {
+        'csv': {'$ref': '#/components/examples/LegacyCsv'},
+    }
+    assert components['requestBodies']['LegacyFilter']['content'] == {
+        'application/json': {
+            'schema': {'$ref': '#/components/schemas/LegacyErrorModel'},
+        },
+    }
+
+
+def test_raw_components_are_prefixed_alike() -> None:
+    """Ensure that both spellings pass through the same namespacing."""
+    assert _build_schema(
+        path('report/', _RawReport.as_view()),
+    ) == _build_schema(path('report/', _TypedReport.as_view()))
+
+
+def test_prefix_is_caller_supplied() -> None:
+    """Ensure that the namespace comes from the caller, not from the adapter."""
+    components = _build_schema(
+        path('report/', _OtherReport.as_view()),
+    )['components']
+
+    assert sorted(components['schemas']) == ['VendorErrorModel']
+    assert sorted(components['responses']) == ['VendorBuilt']
+
+
+def test_project_and_foreign_components_coexist() -> None:
+    """Ensure that a shared base name leaves both definitions reachable."""
+    schema = _build_schema(
+        path('user/', _UserController.as_view()),
+        path('report/', _TypedReport.as_view()),
+    )
+    schemas = schema['components']['schemas']
+    generated = _build_schema(
+        path('user/', _UserController.as_view()),
+    )['components']['schemas']
+
+    assert schemas['ErrorModel'] == generated['ErrorModel']
+    assert schemas['LegacyErrorModel'] != generated['ErrorModel']
+    assert schemas['LegacyErrorModel']['properties'].keys() == {'since'}
+
+
+def test_same_view_mounted_twice() -> None:
+    """Ensure that re-contributing the same definitions is not a conflict."""
+    components = _build_schema(
+        path('report/', _TypedReport.as_view()),
+        path('legacy/report/', _TypedReport.as_view()),
+    )['components']
+
+    assert sorted(components['responses']) == ['LegacyBuilt']
+
+
+def test_namespacing_does_not_change_dispatch(rf: RequestFactory) -> None:
+    """Ensure that namespacing components stays a documentation-only act."""
+    report = _TypedReport.as_view()(rf.get('/api/report/'))
+    export = _Export.as_view()(rf.get('/api/export/'))
+
+    assert isinstance(report, HttpResponse)
+    assert isinstance(export, HttpResponse)
+    assert report.status_code == HTTPStatus.OK
+    assert report.content == b'{}'
+    assert export.status_code == HTTPStatus.OK
+    assert export.content == b'id,name'
+
+
+def test_conflicting_contributions_are_reported() -> None:
+    """Ensure that two definitions under one name raise, not overwrite."""
+    other = adapt_django_view(
+        _ProjectExportView,
+        openapi=_EXPORT_PATH_ITEM,
+        components=objects.Components(
+            responses={'Exported': objects.Response(description='Something')},
+        ),
+    )
+
+    with pytest.raises(ValueError, match='Exported'):
+        _build_schema(
+            path('export/', _Export.as_view()),
+            path('other/', other.as_view()),
+        )
+
+
+def test_conflict_with_a_generated_schema() -> None:
+    """Ensure that a contribution cannot be displaced by a generated schema."""
+    unprefixed = adapt_django_view(
+        _LegacyReportView,
+        openapi=_REPORT_PATH_ITEM,
+        components=_REPORT_COMPONENTS,
+    )
+
+    with pytest.raises(ValueError, match='ErrorModel'):
+        _build_schema(
+            path('user/', _UserController.as_view()),
+            path('report/', unprefixed.as_view()),
+        )
+
+
+def test_invalid_prefix_is_rejected() -> None:
+    """Ensure that a prefix that cannot spell a component name is refused."""
+    with pytest.raises(ValueError, match='Legacy/'):
+        adapt_django_view(
+            _LegacyReportView,
+            openapi=_REPORT_PATH_ITEM,
+            components=_REPORT_COMPONENTS,
+            component_prefix='Legacy/',
+        )
+
+
+def _discriminator_schemas(view: Any) -> Any:
+    schema = build_schema(
+        Router('api/', [path('pet/', view.as_view())]),
+    ).convert(skip_validation=True)
+    return schema['components']['schemas']
+
+
+def test_typed_discriminator_targets_are_prefixed() -> None:
+    """Ensure that a discriminator points at the namespaced schemas."""
+    pet = adapt_django_view(
+        _ProjectExportView,
+        openapi=_EXPORT_PATH_ITEM,
+        components=objects.Components(
+            schemas={
+                'Dog': objects.Schema(type=OpenAPIType.OBJECT),
+                'Pet': objects.Schema(
+                    discriminator=objects.Discriminator(
+                        property_name='kind',
+                        # Both spellings the specification allows:
+                        mapping={
+                            'dog': '#/components/schemas/Dog',
+                            'puppy': 'Dog',
+                        },
+                    ),
+                ),
+            },
+            responses=_EXPORT_COMPONENTS.responses,
+        ),
+        component_prefix='Legacy',
+    )
+
+    assert _discriminator_schemas(pet)['LegacyPet']['discriminator'] == {
+        'propertyName': 'kind',
+        'mapping': {
+            'dog': '#/components/schemas/LegacyDog',
+            'puppy': 'LegacyDog',
+        },
+    }
+
+
+def test_raw_discriminator_targets_are_prefixed() -> None:
+    """Ensure that both spellings namespace a discriminator alike."""
+    pet = adapt_django_view(
+        _ProjectExportView,
+        openapi=_EXPORT_PATH_ITEM,
+        components={
+            'schemas': {
+                'Dog': {'type': 'object'},
+                'Pet': {
+                    'discriminator': {
+                        'propertyName': 'kind',
+                        'mapping': {'dog': '#/components/schemas/Dog'},
+                    },
+                },
+            },
+            'responses': {'Exported': {'description': 'The exported report'}},
+        },
+        component_prefix='Legacy',
+    )
+
+    assert _discriminator_schemas(pet)['LegacyPet']['discriminator'] == {
+        'propertyName': 'kind',
+        'mapping': {'dog': '#/components/schemas/LegacyDog'},
+    }
+
+
+def test_discriminator_without_a_mapping() -> None:
+    """Ensure that a discriminator naming no schema is left alone."""
+    pet = adapt_django_view(
+        _ProjectExportView,
+        openapi=_EXPORT_PATH_ITEM,
+        components=objects.Components(
+            schemas={
+                'Pet': objects.Schema(
+                    discriminator=objects.Discriminator(property_name='kind'),
+                ),
+            },
+        ),
+        component_prefix='Legacy',
+    )
+
+    assert _discriminator_schemas(pet)['LegacyPet']['discriminator'] == {
+        'propertyName': 'kind',
+    }
+
+
+def test_reference_outside_the_categories() -> None:
+    """Ensure that the prefix only owns what an adapted view can contribute."""
+    header_ref = {'$ref': '#/components/headers/Total'}
+    referencing = adapt_django_view(
+        _ProjectExportView,
+        openapi={
+            'get': {
+                'responses': {
+                    '200': {
+                        'description': 'The exported report',
+                        'headers': {'X-Total': header_ref},
+                    },
+                },
+            },
+        },
+        component_prefix='Legacy',
+    )
+
+    # A `headers` component cannot be contributed, so the reference is
+    # left for the project itself to define, prefix or no prefix:
+    schema = build_schema(
+        Router('api/', [path('export/', referencing.as_view())]),
+    ).convert(skip_validation=True)
+    operation = schema['paths']['/api/export/']['get']
+
+    assert operation['responses']['200']['headers'] == {'X-Total': header_ref}
+
+
+def test_prefix_without_components() -> None:
+    """Ensure that the prefix describes the view, not only its components."""
+    referencing = adapt_django_view(
+        _ProjectExportView,
+        openapi=_EXPORT_PATH_ITEM,
+        component_prefix='Legacy',
+    )
+    contributing = adapt_django_view(
+        _LegacyReportView,
+        openapi=objects.PathItem(),
+        components=_EXPORT_COMPONENTS,
+        component_prefix='Legacy',
+    )
+
+    schema = _build_schema(
+        path('export/', referencing.as_view()),
+        path('report/', contributing.as_view()),
+    )
+
+    assert schema['paths']['/api/export/']['get']['responses'] == {
+        '200': {'$ref': '#/components/responses/LegacyExported'},
+    }
+    assert sorted(schema['components']['responses']) == ['LegacyExported']

--- a/tests/test_unit/test_adapters/test_django_view_adapter.py
+++ b/tests/test_unit/test_adapters/test_django_view_adapter.py
@@ -1,0 +1,175 @@
+import functools
+import json
+from collections.abc import Awaitable, Callable
+from http import HTTPStatus
+from types import MappingProxyType
+from typing import Any, cast
+
+import pytest
+from django.http import HttpRequest, HttpResponse, HttpResponseBase
+from django.test import AsyncRequestFactory, RequestFactory
+from django.urls import path
+from django.views import View
+from syrupy.assertion import SnapshotAssertion
+
+from dmr.adapters import adapt_django_view
+from dmr.openapi import build_schema
+from dmr.openapi.objects import Operation, PathItem, Response
+from dmr.routing import Router
+
+_CSV_PAYLOAD = b'id,name\n'
+_AnyView = Callable[..., HttpResponseBase]
+_AnyAsyncView = Callable[..., Awaitable[HttpResponseBase]]
+
+
+class _LegacyExportView(View):
+    """Plain Django view that was never rewritten as a controller."""
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        """Render the report the way plain Django would."""
+        return HttpResponse(_CSV_PAYLOAD, content_type='text/csv')
+
+
+class _LegacyAsyncExportView(View):
+    """Async flavour of the very same legacy view."""
+
+    async def get(self, request: HttpRequest) -> HttpResponse:
+        """Render the report the way plain Django would."""
+        return HttpResponse(_CSV_PAYLOAD, content_type='text/csv')
+
+
+_TYPED_PATH_ITEM = PathItem(
+    summary='Legacy CSV export',
+    get=Operation(
+        summary='Export report as CSV',
+        responses={'200': Response(description='CSV payload')},
+    ),
+)
+
+# The same document, written the way it is spelled in an OpenAPI file.
+# `deprecated` is explicit here because a typed `Operation` always emits it.
+_RAW_PATH_ITEM = MappingProxyType({
+    'summary': 'Legacy CSV export',
+    'get': {
+        'summary': 'Export report as CSV',
+        'responses': {'200': {'description': 'CSV payload'}},
+        'deprecated': False,
+    },
+})
+
+_TypedExport = adapt_django_view(
+    _LegacyExportView,
+    openapi=_TYPED_PATH_ITEM,
+)
+_RawExport = adapt_django_view(
+    _LegacyExportView,
+    openapi=_RAW_PATH_ITEM,
+)
+_AsyncExport = adapt_django_view(
+    _LegacyAsyncExportView,
+    openapi=_TYPED_PATH_ITEM,
+)
+
+
+def _build_schema(
+    view: _AnyView,
+    *,
+    skip_validation: bool = False,
+) -> dict[str, Any]:
+    return build_schema(
+        Router('api/', [path('legacy/export/', view)]),
+    ).convert(skip_validation=skip_validation)
+
+
+def _wrap_view(view: _AnyView) -> _AnyView:
+    @functools.wraps(view)
+    def wrapper(
+        request: HttpRequest,
+        *args: Any,
+        **kwargs: Any,
+    ) -> HttpResponseBase:
+        return view(request, *args, **kwargs)
+
+    return wrapper
+
+
+def test_adapted_view_schema(snapshot: SnapshotAssertion) -> None:
+    """Ensure that a plain Django view appears in the specification."""
+    assert (
+        json.dumps(_build_schema(_TypedExport.as_view()), indent=2) == snapshot
+    )
+
+
+def test_raw_mapping_matches_typed_objects() -> None:
+    """Ensure that a mapping and typed objects describe the same path."""
+    assert _build_schema(_RawExport.as_view()) == _build_schema(
+        _TypedExport.as_view(),
+    )
+
+
+def test_path_item_reference() -> None:
+    """Ensure that a ``$ref`` path item is passed through untranslated."""
+    referenced = adapt_django_view(
+        _LegacyExportView,
+        openapi={'$ref': '#/components/pathItems/LegacyExport'},
+    )
+
+    schema = _build_schema(referenced.as_view(), skip_validation=True)
+
+    assert schema['paths']['/api/legacy/export/'] == {
+        '$ref': '#/components/pathItems/LegacyExport',
+    }
+
+
+def test_unknown_path_item_key() -> None:
+    """Ensure that an unsupported key is reported, not silently dropped."""
+    with pytest.raises(TypeError, match='x-vendor'):
+        adapt_django_view(_LegacyExportView, openapi={'x-vendor': 'nope'})
+
+
+def test_adapted_view_dispatches_as_plain_django(rf: RequestFactory) -> None:
+    """Ensure that the adapter does not enrol the view into the pipeline."""
+    request = rf.get(
+        '/api/legacy/export/',
+        headers={'accept': 'application/xml'},
+    )
+
+    response = _TypedExport.as_view()(request)
+
+    # A `dmr` controller would fail the content negotiation with a `406`:
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers['Content-Type'] == 'text/csv'
+    assert response.content == _CSV_PAYLOAD
+
+
+def test_adapted_view_errors_stay_django_shaped(rf: RequestFactory) -> None:
+    """Ensure that errors keep the shape plain Django gives them."""
+    response = _TypedExport.as_view()(rf.post('/api/legacy/export/'))
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED
+    assert not response.content
+
+
+async def test_adapted_async_view(async_rf: AsyncRequestFactory) -> None:
+    """Ensure that async views can be adapted as well."""
+    view = cast('_AnyAsyncView', _AsyncExport.as_view())
+
+    response = await view(async_rf.get('/api/legacy/export/'))
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK
+    assert response.content == _CSV_PAYLOAD
+
+
+def test_decorated_view_is_still_collected(rf: RequestFactory) -> None:
+    """Ensure that ``functools.wraps`` chains stay discoverable."""
+    decorated = _wrap_view(_TypedExport.as_view())
+
+    schema = _build_schema(decorated)
+
+    assert schema['paths']['/api/legacy/export/']['summary'] == (
+        'Legacy CSV export'
+    )
+    assert decorated(rf.get('/api/legacy/export/')).status_code == HTTPStatus.OK


### PR DESCRIPTION
# I have made things!

A plain Django view can now be documented in the generated OpenAPI
specification without being rewritten as a controller. This is the piece
needed to describe endpoints the framework does not own — the immediate
motivation being allauth's headless endpoints, but it stands on its own for
anyone migrating to `dmr` incrementally.

Three commits, each one leaving the tree green:

1. **`adapt_django_view`** returns a subclass of any Django view that the
   schema collector can consume. The path item is supplied statically, either
   as a `PathItem` or as a plain mapping, so a fragment of an existing
   document can be pasted in without translating it to typed objects.

2. **A component contribution channel.** Any imported third-party description
   references shared components, and a path item referencing them produced
   dangling references before this. An adapted view can now contribute
   `schemas`, `responses`, `parameters`, `examples` and `requestBodies`
   through the `OpenAPIContext` during `get_path_item` — the same channel
   controllers already use to register schemas.

3. **Namespacing and collision reporting.** `component_prefix` namespaces the
   whole description: the component names and every reference to them, in the
   path item and nested inside other components, in both spellings. Names
   imported from a foreign document are rarely unique enough to share a
   document with the schemas the framework generates.

Two collisions were resolved silently before and now raise: a second,
*different* definition of a name already contributed, and a contributed schema
clashing with a generated one (previously the generated schema won, leaving the
adapted view's `$ref` pointing at a different definition than intended).
Re-contributing an *identical* definition stays legal, because one description
is commonly shared by several adapted views.

A discriminator's `mapping` is handled specially — it is the one place a
reference is not spelled as a `$ref`, so a rename would otherwise leave it
pointing at a name that no longer exists, without tripping schema validation.

Adapting a view is deliberately documentation-only: it does **not** enrol the
view into the request pipeline. No parsers, renderers, negotiation, problem
details, throttling, response validation or controller-level auth apply, and
its errors keep the shape Django gives them. That is the design, not an
omission, and it is called out in a `Warning::` block on the function.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

Tests live in `tests/test_unit/test_adapters/`, following the existing
schema-snapshot suite: the views and the router are declared in the test
module and the assertions are on the document that comes out, not on the
adapter's shape or on registry internals. `docs/pages/deep-dive/public-api.rst`
picks the new API up through autodoc.

## Related issues

- Refs #1193

Two pre-existing defects were found while building this and are **not**
addressed here; they deserve their own issues:

- `SchemaRegistry` silently discards a newly registered schema on a name
  collision when no annotation is supplied. Contributed components never pass
  through it, so this work sidesteps rather than fixes it.
- The demo project's URL configuration builds the specification before
  assigning url patterns, so any URL reversing during the build fails.
  Harmless today, but it constrains what the build is allowed to do.
