### PR TITLE
Add pytest-timeout to fail hanging tests fast (#1195)

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,7 +1,9 @@
 import pytest
 
 
-def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config, items: list[pytest.Item]) -> None:
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+) -> None:
     """Automatically disable timeout for all of benchmarks"""
     for item in items:
         item.add_marker(pytest.mark.timeout(0))

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+def pytest_collection_modifyitems(items):
+    """Automatically disable timeout for all of benchmarks"""
+    for item in items:
+        item.add_marker(pytest.mark.timeout(0))

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def pytest_collection_modifyitems(items):
     """Automatically disable timeout for all of benchmarks"""
     for item in items:

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config, items: list[pytest.Item]) -> None:
     """Automatically disable timeout for all of benchmarks"""
     for item in items:
         item.add_marker(pytest.mark.timeout(0))

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -2,7 +2,9 @@ import pytest
 
 
 def pytest_collection_modifyitems(
-    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+    session: pytest.Session,
+    config: pytest.Config,
+    items: list[pytest.Item],
 ) -> None:
     """Automatically disable timeout for all of benchmarks"""
     for item in items:

--- a/benchmarks/tests/test_router/test_path.py
+++ b/benchmarks/tests/test_router/test_path.py
@@ -13,6 +13,7 @@ from dmr.routing import path as dmr_path
 
 pytestmark = pytest.mark.timeout(0)
 
+
 def _a_view(request: HttpRequest) -> HttpResponse:
     return HttpResponse(b'')
 

--- a/benchmarks/tests/test_router/test_path.py
+++ b/benchmarks/tests/test_router/test_path.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from contextlib import suppress
 from typing import Final, Literal, assert_never
 
-import pytest
 from django.http import HttpRequest, HttpResponse
 from django.urls import Resolver404, URLPattern, include
 from django.urls import path as django_path
@@ -10,8 +9,6 @@ from django.urls.resolvers import RegexPattern, URLResolver
 from pytest_codspeed import BenchmarkFixture
 
 from dmr.routing import path as dmr_path
-
-pytestmark = pytest.mark.timeout(0)
 
 
 def _a_view(request: HttpRequest) -> HttpResponse:

--- a/benchmarks/tests/test_router/test_path.py
+++ b/benchmarks/tests/test_router/test_path.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from typing import Final, Literal, assert_never
 
+import pytest
 from django.http import HttpRequest, HttpResponse
 from django.urls import Resolver404, URLPattern, include
 from django.urls import path as django_path
@@ -10,6 +11,7 @@ from pytest_codspeed import BenchmarkFixture
 
 from dmr.routing import path as dmr_path
 
+pytestmark = pytest.mark.timeout(0)
 
 def _a_view(request: HttpRequest) -> HttpResponse:
     return HttpResponse(b'')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,8 +368,12 @@ pythonpath = ["django_test_app"]
 # pytest-asyncio configuration:
 # https://pytest-asyncio.readthedocs.io/en/stable/reference/configuration.html
 asyncio_mode = 'auto'
+
+# pytest-timeout configuration:
+# https://github.com/pytest-dev/pytest-timeout
 timeout = 5
 timeout_method = "thread"
+
 addopts = [
   "--strict-config",
   "--strict-markers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ unit-test = [
   "pytest-django>=4.8,<5",
   "pytest-freezer>=0.4,<0.5",
   "pytest-asyncio>=1.3,<2",
+  "pytest-timeout>=2.4,<3",
   "dirty-equals>=0.11,<0.12",
   "faker>=40.36,<41",
   "inline-snapshot>=0.35,<0.36",
@@ -367,7 +368,8 @@ pythonpath = ["django_test_app"]
 # pytest-asyncio configuration:
 # https://pytest-asyncio.readthedocs.io/en/stable/reference/configuration.html
 asyncio_mode = 'auto'
-
+timeout = 30
+timeout_method = "thread"
 addopts = [
   "--strict-config",
   "--strict-markers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,7 @@ pythonpath = ["django_test_app"]
 # pytest-asyncio configuration:
 # https://pytest-asyncio.readthedocs.io/en/stable/reference/configuration.html
 asyncio_mode = 'auto'
-timeout = 30
+timeout = 5
 timeout_method = "thread"
 addopts = [
   "--strict-config",

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -112,7 +112,7 @@ class _DjangoSessionAuth:
 
 @schema.parametrize()
 @h_settings(max_examples=_MAX_EXAMPLES)
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(0)
 def test_schemathesis(
     tracecov_map: 'tracecov.CoverageMap | None',
     *,

--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -112,6 +112,7 @@ class _DjangoSessionAuth:
 
 @schema.parametrize()
 @h_settings(max_examples=_MAX_EXAMPLES)
+@pytest.mark.timeout(60)
 def test_schemathesis(
     tracecov_map: 'tracecov.CoverageMap | None',
     *,

--- a/uv.lock
+++ b/uv.lock
@@ -732,6 +732,7 @@ dev = [
     { name = "pytest-django" },
     { name = "pytest-freezer" },
     { name = "pytest-randomly" },
+    { name = "pytest-timeout" },
     { name = "redis" },
     { name = "ruff" },
     { name = "schemathesis" },
@@ -794,6 +795,7 @@ unit-test = [
     { name = "pytest-django" },
     { name = "pytest-freezer" },
     { name = "pytest-randomly" },
+    { name = "pytest-timeout" },
     { name = "syrupy" },
     { name = "xmltodict-rs" },
 ]
@@ -843,6 +845,7 @@ dev = [
     { name = "pytest-django", specifier = ">=4.8,<5" },
     { name = "pytest-freezer", specifier = ">=0.4,<0.5" },
     { name = "pytest-randomly", specifier = ">=4.0,<5" },
+    { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "redis", specifier = ">=7.4,<9" },
     { name = "ruff", specifier = ">=0.15,<0.17" },
     { name = "schemathesis", specifier = ">=4.14,<5" },
@@ -903,6 +906,7 @@ unit-test = [
     { name = "pytest-django", specifier = ">=4.8,<5" },
     { name = "pytest-freezer", specifier = ">=0.4,<0.5" },
     { name = "pytest-randomly", specifier = ">=4.0,<5" },
+    { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "syrupy", specifier = ">=5.1,<6" },
     { name = "xmltodict-rs", specifier = ">=0.13,<0.14" },
 ]
@@ -2396,6 +2400,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues
Closes #1195
Added pytest-timeout as a dev dependency and set a global 5s timeout in
the pytest config. Went with the `thread` method since it behaves the
same on Windows and POSIX. Signal-based timeouts don't work the same
way on Windows, and this repo builds Windows wheels, so thread keeps
things consistent.

To pick the 5s number, I ran the full suite locally with `--durations=10`
first to see what "normal" looks like. The slowest regular test was
under 3 seconds, so 5s still leaves some margin, though less than the
30s I originally had. The maintainer suggested 5s directly, which lines
up with what I saw in practice. The one exception is `test_schemathesis`,
which is an aggregate fuzz test and legitimately runs 25-30s, so I gave
that one its own `@pytest.mark.timeout(60)` override instead of letting
it hit the global limit.

Ran `just test` locally (lint, type-check, unit) and everything passes
clean, coverage's still at 100%.

Didn't add a new test for this since it's more of a CI/config change
than new behavior. Also didn't update the docs, since this only affects the internal test suite and not anything a library user would interact with.
<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
