### PR TITLE
feat: add --skip-validation to schema export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ of requirements for an API to count as public.
 ### Features
 
 - Django 6.1 official support, #1214
+- Added `--skip-validation` to the `dmr_export_schema` management command, #1225
 - Added `extra_namespace` parameter to `BaseSerializer.from_python`
   and all its existing subclasses, #1222
 - Added an ability to load external OpenAPI schemas

--- a/dmr/management/commands/dmr_export_schema.py
+++ b/dmr/management/commands/dmr_export_schema.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
 
     @override
     def add_arguments(self, parser: CommandParser) -> None:
-        """Add schema, format, indent, and sort-keys arguments."""
+        """Add schema, format, validation, indent, and sort-keys arguments."""
         parser.add_argument(
             'schema',
             help='Import path to the OpenAPI schema.',
@@ -58,6 +58,13 @@ class Command(BaseCommand):
             dest='no_ensure_ascii',
             help='Should we properly escape all non-ascii symbols.',
         )
+        parser.add_argument(
+            '--skip-validation',
+            action='store_true',
+            default=False,
+            dest='skip_validation',
+            help='Skip schema validation before exporting.',
+        )
 
     @override
     def handle(self, *args: Any, **options: Any) -> None:  # noqa: WPS110
@@ -66,7 +73,7 @@ class Command(BaseCommand):
 
         converted_schema = import_string(
             schema_path.replace(':', '.'),
-        ).convert()
+        ).convert(skip_validation=options['skip_validation'])
 
         if options['format'] == 'yaml':
             try:

--- a/tests/test_integration/test_management/test_dmr_export_schema.py
+++ b/tests/test_integration/test_management/test_dmr_export_schema.py
@@ -117,7 +117,7 @@ def test_export_schema_invalid_input(
         ({'skip_validation': True}, True),
     ],
 )
-def test_export_schema_passes_skip_validation_to_schema_converter(
+def test_skip_validation_to_schema_converter(
     monkeypatch: pytest.MonkeyPatch,
     *,
     kwargs: dict[str, Any],

--- a/tests/test_integration/test_management/test_dmr_export_schema.py
+++ b/tests/test_integration/test_management/test_dmr_export_schema.py
@@ -118,8 +118,8 @@ def test_export_schema_invalid_input(
     ],
 )
 def test_export_schema_passes_skip_validation_to_schema_converter(
-    *,
     monkeypatch: pytest.MonkeyPatch,
+    *,
     kwargs: dict[str, Any],
     expected_skip_validation: bool,
 ) -> None:

--- a/tests/test_integration/test_management/test_dmr_export_schema.py
+++ b/tests/test_integration/test_management/test_dmr_export_schema.py
@@ -5,6 +5,8 @@ from typing import Any, Final
 import pytest
 from django.core.management import call_command
 
+from dmr.management.commands import dmr_export_schema
+
 # From the OpenAPI description:
 _NON_ASCII_TEXT: Final = 'Не АСКИИ текст'  # noqa: RUF001
 
@@ -106,3 +108,47 @@ def test_export_schema_invalid_input(
     """Invalid schema inputs raise the expected exception."""
     with pytest.raises(expected_exception):
         call_command('dmr_export_schema', schema_path)
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'expected_skip_validation'),
+    [
+        ({}, False),
+        ({'skip_validation': True}, True),
+    ],
+)
+def test_export_schema_passes_skip_validation_to_schema_converter(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs: dict[str, Any],
+    expected_skip_validation: bool,
+) -> None:
+    """Pass the skip-validation flag to the schema converter.
+
+    This also verifies that the default remains false.
+    """
+    observed: list[bool] = []
+
+    class FakeSchema:
+        def convert(self, *, skip_validation: bool) -> dict[str, bool]:
+            observed.append(skip_validation)
+            return {'skip_validation': skip_validation}
+
+    monkeypatch.setattr(
+        dmr_export_schema,
+        'import_string',
+        lambda _: FakeSchema(),
+    )
+
+    out = StringIO()
+    call_command(
+        'dmr_export_schema',
+        'server.urls:schema',
+        stdout=out,
+        **kwargs,
+    )
+
+    assert observed == [expected_skip_validation]
+    assert json.loads(out.getvalue()) == {
+        'skip_validation': expected_skip_validation,
+    }


### PR DESCRIPTION
## Summary

- Add `--skip-validation` to the `dmr_export_schema` management command.
- Forward the flag to `schema.convert`, preserving validation by default.
- Add a parametrized regression test and changelog entry.

Closes #1225

## Validation

- `uv run --extra pydantic --extra jwt pytest tests/test_integration/test_management/test_dmr_export_schema.py -o addopts=""` (58 passed)
- `uv run --extra pydantic --extra jwt ruff check dmr/management/commands/dmr_export_schema.py tests/test_integration/test_management/test_dmr_export_schema.py`
- `git diff --check`
