### PR TITLE
fix: correct OpenAPIFormat.IRI value; enforce unique enum members

### DIFF
--- a/dmr/openapi/objects/enums.py
+++ b/dmr/openapi/objects/enums.py
@@ -3,6 +3,7 @@ from typing import final
 
 
 @final
+@enum.unique
 class OpenAPIFormat(enum.StrEnum):
     """
     OpenAPI format.
@@ -30,7 +31,7 @@ class OpenAPIFormat(enum.StrEnum):
     URI_TEMPLATE = 'uri-template'
     JSON_POINTER = 'json-pointer'
     RELATIVE_JSON_POINTER = 'relative-json-pointer'
-    IRI = 'iri-reference'
+    IRI = 'iri'
     IRI_REFERENCE = 'iri-reference'
     UUID = 'uuid'
     REGEX = 'regex'
@@ -44,6 +45,7 @@ class OpenAPIFormat(enum.StrEnum):
 
 
 @final
+@enum.unique
 class OpenAPIType(enum.StrEnum):
     """OpenAPI types."""
 


### PR DESCRIPTION
Per the JSON Schema core/validation spec (draft-bhutton-json-schema-validation-00, section 7.3.5), the "Iri" format value is `'iri'`, not `'iri-reference'`. `IRI_REFERENCE = 'iri-reference'` remains correct and is untouched.

Changes:
- `OpenAPIFormat.IRI` value: `'iri-reference'` -> `'iri'`
- Marked `OpenAPIFormat` and `OpenAPIType` with `@enum.unique` to catch duplicate values at class creation time

Closes #1226
