### PR TITLE
Fix typo in external-views.rst

### DIFF
--- a/docs/pages/external-views.rst
+++ b/docs/pages/external-views.rst
@@ -37,7 +37,7 @@ without any logic or modifications.
   However, if you define top-level error handlers with
   :func:`~dmr.routing.build_404_handler`
   and :func:`~dmr.routing.build_500_handler`,
-  it would still affect the view, when these error happen.
+  it would still affect the view, when these errors happen.
 
 OpenAPI
 ~~~~~~~
@@ -55,7 +55,7 @@ Here's its spec:
   :linenos:
 
 Next, let's show how we can adapt existing
-pure-Django API views, attach this existing schemaas:
+pure-Django API views, attach this to existing schema as:
 
 - both functional,
 - and class-based.
@@ -144,7 +144,7 @@ Real world use-cases
 For example, one can reuse:
 
 - ``django-allauth``
-  `headles views <https://github.com/pennersr/django-allauth/tree/main/allauth/headless>`_
+  `headless views <https://github.com/pennersr/django-allauth/tree/main/allauth/headless>`_
   that are built to be used by the pure Django framework
 - Any ``APIView`` or ``GenericAPIView`` objects from ``django-rest-framework``
 - Any ``ControllerBase`` objects from ``django-ninja-extra``


### PR DESCRIPTION
# Fix typos in external-views.rst

## AI Policy

- [ v] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

- [ v] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues
