### PR TITLE
Add missing JSON Schema keywords to Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ of requirements for an API to count as public.
 
 - Fixed a bug that `OpenAPIConfig.components` were silently
   ignored when defined with custom user's data, #1229
+- Fixed missing `$ref`, `$anchor`, `$comment`, and `$schema` fields in `Schema`, #1232
 - Fixed `OpenAPIFormat.IRI` value, #1228
 
 

--- a/dmr/files.py
+++ b/dmr/files.py
@@ -48,7 +48,7 @@ class FileBody:
     @classmethod
     def media_type(
         cls,
-        schema: Schema | Reference,
+        schema: Reference | Schema,
         model: Any,
         model_meta: tuple[Any, ...],
         parser: Parser,
@@ -84,7 +84,7 @@ class FileBody:
     @classmethod
     def get_schema(
         cls,
-        schema: Schema | Reference,
+        schema: Reference | Schema,
         context: 'OpenAPIContext',
     ) -> Schema:
         """Returns the openapi schema that this object represents."""

--- a/dmr/openapi/core/context.py
+++ b/dmr/openapi/core/context.py
@@ -100,7 +100,7 @@ class OpenAPIContext:
     def register_schema(
         self,
         annotation: Any,
-        schema: Schema | Reference | SchemaCallback,
+        schema: Reference | Schema | SchemaCallback,
         *,
         override: bool = False,
     ) -> None:

--- a/dmr/openapi/core/registry.py
+++ b/dmr/openapi/core/registry.py
@@ -17,7 +17,7 @@ class SchemaCallback(Protocol):
         *,
         used_for_response: bool,
         skip_registration: bool,
-    ) -> Schema | Reference | None:
+    ) -> Reference | Schema | None:
         """
         Resolve the annotation into schema or into a reference.
 
@@ -57,7 +57,7 @@ class SchemaRegistry:
     def __init__(self) -> None:
         """Initialize empty schema and type registers."""
         self._schemas: dict[str, tuple[Schema, int | None]] = {}
-        self.overrides: dict[Any, Schema | Reference | SchemaCallback] = {}
+        self.overrides: dict[Any, Reference | Schema | SchemaCallback] = {}
 
     @property
     def schemas(self) -> dict[str, Schema]:

--- a/dmr/openapi/generators/component_parsers.py
+++ b/dmr/openapi/generators/component_parsers.py
@@ -177,7 +177,7 @@ class ComponentParserGenerator:
     ) -> dict[str, 'MediaType']:
         new_content: dict[str, MediaType] = {}
         for media_name, media_type in new_schema.content.items():
-            media_items: list[Schema | Reference] = []
+            media_items: list[Reference | Schema] = []
             if media_type.schema:  # pragma: no cover:
                 media_items.append(media_type.schema)
             existing_content = schema.content.get(media_name)

--- a/dmr/openapi/generators/parameter.py
+++ b/dmr/openapi/generators/parameter.py
@@ -63,7 +63,7 @@ class ParameterGenerator:
         self,
         metadata: ParameterMetadata | None,
         property_name: str,
-        property_schema: Schema | Reference,
+        property_schema: Reference | Schema,
         schema: Schema,
         context: 'OpenAPIContext',
     ) -> dict[str, Any]:

--- a/dmr/openapi/generators/schema.py
+++ b/dmr/openapi/generators/schema.py
@@ -38,7 +38,7 @@ class SchemaGenerator:
         used_for_response: bool = False,
         skip_registration: bool = False,
         register_referenced_components: bool = False,
-    ) -> Schema | Reference: ...
+    ) -> Reference | Schema: ...
 
     def __call__(
         self,
@@ -48,7 +48,7 @@ class SchemaGenerator:
         used_for_response: bool = False,
         skip_registration: bool = False,
         register_referenced_components: bool = False,
-    ) -> Schema | Reference:
+    ) -> Reference | Schema:
         """
         Get schema for an annotation.
 
@@ -111,7 +111,7 @@ class SchemaGenerator:
         *,
         used_for_response: bool = False,
         skip_registration: bool = False,
-    ) -> Schema | Reference | None:
+    ) -> Reference | Schema | None:
         origin = get_origin(annotation) or annotation
         type_args = get_args(annotation)
 
@@ -138,7 +138,7 @@ class SchemaGenerator:
         *,
         skip_registration: bool = False,
         register_referenced_components: bool = False,
-    ) -> Schema | Reference:
+    ) -> Reference | Schema:
         if not skip_registration:
             for component_name, component in components.items():
                 self._context.registries.schema.register(
@@ -183,7 +183,7 @@ class SchemaGenerator:
         *,
         skip_registration: bool,
         register_referenced_components: bool,
-    ) -> Schema | Reference:
+    ) -> Reference | Schema:
         if skip_registration and register_referenced_components:
             for component_name, component in components.items():
                 self._context.registries.schema.register(

--- a/dmr/openapi/objects/header.py
+++ b/dmr/openapi/objects/header.py
@@ -19,7 +19,7 @@ class Header:
     a location of header (for example, style).
     """
 
-    schema: 'Schema | Reference | None' = None
+    schema: 'Reference | Schema | None' = None
     description: str | None = None
     required: bool | None = None
     deprecated: bool | None = None

--- a/dmr/openapi/objects/parameter.py
+++ b/dmr/openapi/objects/parameter.py
@@ -30,6 +30,6 @@ class Parameter(ParameterMetadata):
 
     name: str
     param_in: Annotated[str, Field(alias='in')]
-    schema: 'Schema | Reference | None' = None
+    schema: 'Reference | Schema | None' = None
     content: dict[str, 'MediaType'] | None = None
     required: bool = False

--- a/dmr/openapi/objects/schema.py
+++ b/dmr/openapi/objects/schema.py
@@ -27,6 +27,10 @@ class Schema:
     the OpenAPI document.
     """
 
+    ref: Annotated[str | None, Field(alias='$ref')] = None
+    anchor: Annotated[str | None, Field(alias='$anchor')] = None
+    comment: Annotated[str | None, Field(alias='$comment')] = None
+    schema_uri: Annotated[str | None, Field(alias='$schema')] = None
     all_of: list['Reference | Schema'] | None = None
     any_of: list['Reference | Schema'] | None = None
     one_of: list['Reference | Schema'] | None = None

--- a/dmr/openapi/objects/schema.py
+++ b/dmr/openapi/objects/schema.py
@@ -27,10 +27,6 @@ class Schema:
     the OpenAPI document.
     """
 
-    ref: Annotated[str | None, Field(alias='$ref')] = None
-    anchor: Annotated[str | None, Field(alias='$anchor')] = None
-    comment: Annotated[str | None, Field(alias='$comment')] = None
-    schema_uri: Annotated[str | None, Field(alias='$schema')] = None
     all_of: list['Reference | Schema'] | None = None
     any_of: list['Reference | Schema'] | None = None
     one_of: list['Reference | Schema'] | None = None
@@ -93,6 +89,10 @@ class Schema:
         None
     )
     dynamic_ref: Annotated['str | None', Field(alias='$dynamicRef')] = None
+    ref: Annotated[str | None, Field(alias='$ref')] = None
+    anchor: Annotated[str | None, Field(alias='$anchor')] = None
+    comment: Annotated[str | None, Field(alias='$comment')] = None
+    schema_uri: Annotated[str | None, Field(alias='$schema')] = None
     defs: Annotated[
         dict[str, 'Reference | Schema'] | None,
         Field(alias='$defs'),

--- a/tests/test_unit/test_openapi/test_mappers/test_schema_normalization/__snapshots__/test_schema_load.ambr
+++ b/tests/test_unit/test_openapi/test_mappers/test_schema_normalization/__snapshots__/test_schema_load.ambr
@@ -3227,7 +3227,9 @@
             "code"
           ]
         },
-        "OptionalTimestamp": {},
+        "OptionalTimestamp": {
+          "$ref": "#/components/schemas/Timestamp"
+        },
         "Timestamp": {
           "type": "number",
           "description": "An epoch based timestamp (trivial to parse using: `new Date(value)*1000`)\n",

--- a/tests/test_unit/test_openapi/test_mappers/test_schema_normalization/test_schema_load.py
+++ b/tests/test_unit/test_openapi/test_mappers/test_schema_normalization/test_schema_load.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 from collections.abc import Callable
 
@@ -6,6 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from dmr.openapi import load_schema
 from dmr.openapi.mappers.schema_normalization import dump_schema
+from dmr.openapi.objects import Components
 from dmr.openapi.openapi import OpenAPI
 
 
@@ -17,6 +19,16 @@ def test_load_schema(
     schema = yaml.safe_load(named_text_fixture('django-allauth.yml'))
 
     loaded = load_schema(schema, OpenAPI)
-
     assert isinstance(loaded, OpenAPI)
-    assert json.dumps(dump_schema(loaded), indent=2) == snapshot
+
+    dumped = dump_schema(loaded)
+    assert json.dumps(dumped, indent=2) == snapshot
+    assert dumped['components'].keys() == schema['components'].keys()
+    for field in dataclasses.fields(Components):
+        if field.name not in schema['components']:
+            continue
+
+        assert (
+            dumped['components'][field.name].keys()
+            == schema['components'][field.name].keys()
+        )

--- a/tests/test_unit/test_openapi/test_schema_validation.py
+++ b/tests/test_unit/test_openapi/test_schema_validation.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover
 from dmr import Controller, modify
 from dmr.endpoint import Endpoint
 from dmr.openapi import build_schema
+from dmr.openapi.objects.schema import Schema
 from dmr.openapi.objects import Reference, SecurityRequirement, SecurityScheme
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.routing import Router
@@ -52,6 +53,21 @@ class _UserController(Controller[PydanticSerializer]):
     @modify(auth=[_WrongAuth()])
     def post(self) -> str:
         raise NotImplementedError
+
+
+def test_schema_supports_json_schema_keywords() -> None:
+    """Ensure that Schema exposes the missing JSON Schema keywords."""
+    schema = Schema(
+        ref='#/components/schemas/User',
+        anchor='user',
+        comment='comment',
+        schema_uri='https://json-schema.org/draft/2020-12/schema',
+    )
+
+    assert schema.ref == '#/components/schemas/User'
+    assert schema.anchor == 'user'
+    assert schema.comment == 'comment'
+    assert schema.schema_uri == 'https://json-schema.org/draft/2020-12/schema'
 
 
 def test_schema_validation(snapshot: SnapshotAssertion) -> None:

--- a/tests/test_unit/test_openapi/test_schema_validation.py
+++ b/tests/test_unit/test_openapi/test_schema_validation.py
@@ -1,27 +1,28 @@
 import pytest
 from django.urls import path
+from faker import Faker
+from inline_snapshot import snapshot
 from syrupy.assertion import SnapshotAssertion
 from typing_extensions import override
 
-try:
-    from openapi_spec_validator.validation.exceptions import (
-        OpenAPIValidationError,
-    )
-except ImportError:  # pragma: no cover
-    pytest.skip(
-        reason='openapi_spec_validator is not installed',
-        allow_module_level=True,
-    )
-
 from dmr import Controller, modify
 from dmr.endpoint import Endpoint
-from dmr.openapi import build_schema
-from dmr.openapi.objects import Reference, SecurityRequirement, SecurityScheme
+from dmr.openapi import OpenAPIConfig, build_schema
+from dmr.openapi.objects import (
+    Components,
+    Reference,
+    SecurityRequirement,
+    SecurityScheme,
+)
 from dmr.openapi.objects.schema import Schema
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.routing import Router
 from dmr.security import SyncAuth
 from dmr.serializer import BaseSerializer
+
+OpenAPIValidationError = pytest.importorskip(
+    'openapi_spec_validator.validation.exceptions',
+).OpenAPIValidationError
 
 
 class _WrongAuth(SyncAuth):
@@ -55,19 +56,39 @@ class _UserController(Controller[PydanticSerializer]):
         raise NotImplementedError
 
 
-def test_schema_supports_json_schema_keywords() -> None:
+def test_schema_supports_json_schema_keywords(  # noqa: WPS210
+    faker: Faker,
+) -> None:
     """Ensure that Schema exposes the missing JSON Schema keywords."""
-    schema = Schema(
-        ref='#/components/schemas/User',
-        anchor='user',
-        comment='comment',
-        schema_uri='https://json-schema.org/draft/2020-12/schema',
-    )
+    ref = f'#/components/schemas/{faker.name()}'
+    anchor = faker.name()
+    comment = faker.sentence()
+    schema_uri = faker.url()
 
-    assert schema.ref == '#/components/schemas/User'
-    assert schema.anchor == 'user'
-    assert schema.comment == 'comment'
-    assert schema.schema_uri == 'https://json-schema.org/draft/2020-12/schema'
+    schema = Schema(
+        ref=ref,
+        anchor=anchor,
+        comment=comment,
+        schema_uri=schema_uri,
+    )
+    router = Router('/', [])
+    config = OpenAPIConfig(
+        title='Title',
+        version='0.0.1',
+        components=Components(schemas={'Test': schema}),
+    )
+    openapi = build_schema(router, config=config).convert(skip_validation=True)
+
+    assert openapi['components'] == snapshot({
+        'schemas': {
+            'Test': {
+                '$ref': ref,
+                '$anchor': anchor,
+                '$comment': comment,
+                '$schema': schema_uri,
+            },
+        },
+    })
 
 
 def test_schema_validation(snapshot: SnapshotAssertion) -> None:

--- a/tests/test_unit/test_openapi/test_schema_validation.py
+++ b/tests/test_unit/test_openapi/test_schema_validation.py
@@ -16,8 +16,8 @@ except ImportError:  # pragma: no cover
 from dmr import Controller, modify
 from dmr.endpoint import Endpoint
 from dmr.openapi import build_schema
-from dmr.openapi.objects.schema import Schema
 from dmr.openapi.objects import Reference, SecurityRequirement, SecurityScheme
+from dmr.openapi.objects.schema import Schema
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.routing import Router
 from dmr.security import SyncAuth

--- a/tests/test_unit/test_routing/__snapshots__/test_external_paths.ambr
+++ b/tests/test_unit/test_routing/__snapshots__/test_external_paths.ambr
@@ -1168,7 +1168,9 @@
             "code"
           ]
         },
-        "OptionalTimestamp": {},
+        "OptionalTimestamp": {
+          "$ref": "#/components/schemas/Timestamp"
+        },
         "Timestamp": {
           "type": "number",
           "description": "An epoch based timestamp (trivial to parse using: `new Date(value)*1000`)\n",


### PR DESCRIPTION
Fixes #1232

Add the missing `$ref`, `$anchor`, `$comment`, and `$schema` fields to `Schema`, plus regression coverage and a changelog entry.