### PR TITLE
Improve Token customization test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,6 @@ on the releases page: https://github.com/wemake-services/django-modern-rest/rele
 ### Misc
 
 - Improved testing docs, #1216
-- Added unit coverage for token obtain controller customizations, #1191
 
 
 ## 0.12.1 (2026-07-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ on the releases page: https://github.com/wemake-services/django-modern-rest/rele
 ### Misc
 
 - Improved testing docs, #1216
+- Added unit coverage for token obtain controller customizations, #1191
 
 
 ## 0.12.1 (2026-07-31)

--- a/tests/test_unit/test_security/test_token/test_token_auth/test_customizations.py
+++ b/tests/test_unit/test_security/test_token/test_token_auth/test_customizations.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import Final
+from typing import Final, TypeAlias
 
 import pytest
 from django.contrib.auth.models import User
@@ -22,12 +22,12 @@ _TOKEN_SALT: Final = 'custom-salt'  # noqa: S105
 _TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
 _SCHEME_NAME: Final = 'customToken'
 
-_SyncAuthType = (
+_SyncAuthType: TypeAlias = (
     type[HeaderTokenSyncAuth]
     | type[CookieTokenSyncAuth]
     | type[QueryTokenSyncAuth]
 )
-_AsyncAuthType = (
+_AsyncAuthType: TypeAlias = (
     type[HeaderTokenAsyncAuth]
     | type[CookieTokenAsyncAuth]
     | type[QueryTokenAsyncAuth]
@@ -75,21 +75,42 @@ def test_sync_auth_custom_hashing(
     'auth_type',
     [HeaderTokenSyncAuth, CookieTokenSyncAuth, QueryTokenSyncAuth],
 )
+@pytest.mark.parametrize(
+    'customize_issue',
+    [
+        pytest.param(True, id='custom-issue-default-auth'),
+        pytest.param(False, id='default-issue-custom-auth'),
+    ],
+)
 def test_sync_auth_rejects_wrong_hashing(
     auth_type: _SyncAuthType,
     admin_user: User,
+    *,
+    customize_issue: bool,
 ) -> None:
-    """Ensures each sync auth class rejects mismatched hash settings."""
-    _, raw_token = Token.issue(
-        user=admin_user,
-        name='sync-invalid',
-        token_secret=_TOKEN_SECRET,
-        token_salt=_TOKEN_SALT,
-        token_algorithm=_TOKEN_ALGORITHM,
-    )
+    """Ensures mismatched sync issue and auth settings are rejected."""
+    if customize_issue:
+        _, raw_token = Token.issue(
+            user=admin_user,
+            name='sync-invalid',
+            token_secret=_TOKEN_SECRET,
+            token_salt=_TOKEN_SALT,
+            token_algorithm=_TOKEN_ALGORITHM,
+        )
+        auth = auth_type()
+    else:
+        _, raw_token = Token.issue(
+            user=admin_user,
+            name='sync-invalid',
+        )
+        auth = auth_type(
+            token_secret=_TOKEN_SECRET,
+            token_salt=_TOKEN_SALT,
+            token_algorithm=_TOKEN_ALGORITHM,
+        )
 
     with pytest.raises(NotAuthenticatedError):
-        auth_type().authenticate(HttpRequest(), raw_token)
+        auth.authenticate(HttpRequest(), raw_token)
 
 
 @pytest.mark.asyncio
@@ -135,18 +156,39 @@ async def test_async_auth_custom_hashing(
     'auth_type',
     [HeaderTokenAsyncAuth, CookieTokenAsyncAuth, QueryTokenAsyncAuth],
 )
+@pytest.mark.parametrize(
+    'customize_issue',
+    [
+        pytest.param(True, id='custom-issue-default-auth'),
+        pytest.param(False, id='default-issue-custom-auth'),
+    ],
+)
 async def test_async_auth_rejects_wrong_hashing(
     auth_type: _AsyncAuthType,
     admin_user: User,
+    *,
+    customize_issue: bool,
 ) -> None:
-    """Ensures each async auth class rejects mismatched hash settings."""
-    _, raw_token = await Token.aissue(
-        user=admin_user,
-        name='async-invalid',
-        token_secret=_TOKEN_SECRET,
-        token_salt=_TOKEN_SALT,
-        token_algorithm=_TOKEN_ALGORITHM,
-    )
+    """Ensures mismatched async issue and auth settings are rejected."""
+    if customize_issue:
+        _, raw_token = await Token.aissue(
+            user=admin_user,
+            name='async-invalid',
+            token_secret=_TOKEN_SECRET,
+            token_salt=_TOKEN_SALT,
+            token_algorithm=_TOKEN_ALGORITHM,
+        )
+        auth = auth_type()
+    else:
+        _, raw_token = await Token.aissue(
+            user=admin_user,
+            name='async-invalid',
+        )
+        auth = auth_type(
+            token_secret=_TOKEN_SECRET,
+            token_salt=_TOKEN_SALT,
+            token_algorithm=_TOKEN_ALGORITHM,
+        )
 
     with pytest.raises(NotAuthenticatedError):
-        await auth_type().authenticate(HttpRequest(), raw_token)
+        await auth.authenticate(HttpRequest(), raw_token)

--- a/tests/test_unit/test_security/test_token/test_token_auth/test_customizations.py
+++ b/tests/test_unit/test_security/test_token/test_token_auth/test_customizations.py
@@ -1,0 +1,152 @@
+import datetime as dt
+from typing import Final
+
+import pytest
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+
+from dmr.exceptions import NotAuthenticatedError
+from dmr.security.token import (
+    CookieTokenAsyncAuth,
+    CookieTokenSyncAuth,
+    HeaderTokenAsyncAuth,
+    HeaderTokenSyncAuth,
+    QueryTokenAsyncAuth,
+    QueryTokenSyncAuth,
+    request_token,
+)
+from dmr.security.token.app.models import Token
+
+_TOKEN_SECRET: Final = 'custom-secret'  # noqa: S105
+_TOKEN_SALT: Final = 'custom-salt'  # noqa: S105
+_TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
+_SCHEME_NAME: Final = 'customToken'
+
+_SyncAuthType = (
+    type[HeaderTokenSyncAuth]
+    | type[CookieTokenSyncAuth]
+    | type[QueryTokenSyncAuth]
+)
+_AsyncAuthType = (
+    type[HeaderTokenAsyncAuth]
+    | type[CookieTokenAsyncAuth]
+    | type[QueryTokenAsyncAuth]
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'auth_type',
+    [HeaderTokenSyncAuth, CookieTokenSyncAuth, QueryTokenSyncAuth],
+)
+def test_sync_auth_custom_hashing(
+    auth_type: _SyncAuthType,
+    admin_user: User,
+) -> None:
+    """Ensures each sync auth class forwards its token customizations."""
+    token, raw_token = Token.issue(
+        user=admin_user,
+        name='sync-custom',
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+    auth = auth_type(
+        security_scheme_name=_SCHEME_NAME,
+        update_last_used=True,
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+    request = HttpRequest()
+
+    user = auth.authenticate(request, raw_token)
+
+    token.refresh_from_db()
+    assert user == admin_user
+    assert request.user == admin_user
+    assert request_token(request) == token
+    assert isinstance(token.last_used_at, dt.datetime)
+    assert auth.security_requirement == {_SCHEME_NAME: []}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'auth_type',
+    [HeaderTokenSyncAuth, CookieTokenSyncAuth, QueryTokenSyncAuth],
+)
+def test_sync_auth_rejects_wrong_hashing(
+    auth_type: _SyncAuthType,
+    admin_user: User,
+) -> None:
+    """Ensures each sync auth class rejects mismatched hash settings."""
+    _, raw_token = Token.issue(
+        user=admin_user,
+        name='sync-invalid',
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        auth_type().authenticate(HttpRequest(), raw_token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    'auth_type',
+    [HeaderTokenAsyncAuth, CookieTokenAsyncAuth, QueryTokenAsyncAuth],
+)
+async def test_async_auth_custom_hashing(
+    auth_type: _AsyncAuthType,
+    admin_user: User,
+) -> None:
+    """Ensures each async auth class forwards its token customizations."""
+    token, raw_token = await Token.aissue(
+        user=admin_user,
+        name='async-custom',
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+    auth = auth_type(
+        security_scheme_name=_SCHEME_NAME,
+        update_last_used=True,
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+    request = HttpRequest()
+
+    user = await auth.authenticate(request, raw_token)
+
+    await token.arefresh_from_db()
+    assert user == admin_user
+    assert await request.auser() == admin_user
+    assert request_token(request) == token
+    assert isinstance(token.last_used_at, dt.datetime)
+    assert auth.security_requirement == {_SCHEME_NAME: []}
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    'auth_type',
+    [HeaderTokenAsyncAuth, CookieTokenAsyncAuth, QueryTokenAsyncAuth],
+)
+async def test_async_auth_rejects_wrong_hashing(
+    auth_type: _AsyncAuthType,
+    admin_user: User,
+) -> None:
+    """Ensures each async auth class rejects mismatched hash settings."""
+    _, raw_token = await Token.aissue(
+        user=admin_user,
+        name='async-invalid',
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        await auth_type().authenticate(HttpRequest(), raw_token)

--- a/tests/test_unit/test_security/test_token/test_token_views.py
+++ b/tests/test_unit/test_security/test_token/test_token_views.py
@@ -1,15 +1,16 @@
 import datetime as dt
+import json
+from http import HTTPStatus
 from typing import Final, final
-from unittest.mock import AsyncMock, Mock
 
 import pytest
 from django.contrib.auth.models import User
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
 from typing_extensions import override
 
 from dmr.exceptions import NotAuthenticatedError
 from dmr.plugins.pydantic import PydanticFastSerializer
-from dmr.security.token import views as token_views
+from dmr.security.token import HeaderTokenAsyncAuth, HeaderTokenSyncAuth
 from dmr.security.token.app.models import Token
 from dmr.security.token.views import (
     ObtainTokenAsyncController,
@@ -17,16 +18,23 @@ from dmr.security.token.views import (
     ObtainTokenResponse,
     ObtainTokenSyncController,
 )
+from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 
-_PASSWORD: Final = 'secret'  # noqa: S105
+_USERNAME: Final = 'admin'
+_PASSWORD: Final = 'password'  # noqa: S105
 _WRONG_PASSWORD: Final = 'wrong'  # noqa: S105
-_TOKEN_SECRET: Final = 'test-secret'  # noqa: S105
-_TOKEN_SALT: Final = 'test-salt'  # noqa: S105
-_TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
+_SYNC_TOKEN_SECRET: Final = 'sync-secret'  # noqa: S105
+_SYNC_TOKEN_SALT: Final = 'sync-salt'  # noqa: S105
+_SYNC_TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
 _SYNC_TOKEN_SIZE: Final = 24
 _SYNC_TOKEN_LENGTH: Final = 32
+_ASYNC_TOKEN_SECRET: Final = 'async-secret'  # noqa: S105
+_ASYNC_TOKEN_SALT: Final = 'async-salt'  # noqa: S105
+_ASYNC_TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
 _ASYNC_TOKEN_SIZE: Final = 20
 _ASYNC_TOKEN_LENGTH: Final = 27
+_WRONG_TOKEN_SECRET: Final = 'wrong-secret'  # noqa: S105
+_WRONG_TOKEN_SALT: Final = 'wrong-salt'  # noqa: S105
 
 
 @final
@@ -39,9 +47,9 @@ class _SyncObtainTokenController(
 ):
     token_cls = Token
     token_size = _SYNC_TOKEN_SIZE
-    token_secret = _TOKEN_SECRET
-    token_salt = _TOKEN_SALT
-    token_algorithm = _TOKEN_ALGORITHM
+    token_secret = _SYNC_TOKEN_SECRET
+    token_salt = _SYNC_TOKEN_SALT
+    token_algorithm = _SYNC_TOKEN_ALGORITHM
     token_expiration = dt.timedelta(minutes=5)
 
     @override
@@ -56,6 +64,43 @@ class _SyncObtainTokenController(
         return {'token': 'sync-response'}
 
 
+@pytest.mark.django_db
+def test_sync_obtain_token_login_success(
+    dmr_rf: DMRRequestFactory,
+    admin_user: User,
+) -> None:
+    """Ensures sync login accepts valid credentials."""
+    request = dmr_rf.post(
+        '/whatever/',
+        data={'username': _USERNAME, 'password': _PASSWORD},
+    )
+
+    response = _SyncObtainTokenController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK
+    assert json.loads(response.content) == {'token': 'sync-response'}
+    assert request.user == admin_user
+
+
+@pytest.mark.django_db
+def test_sync_obtain_token_login_failure(
+    dmr_rf: DMRRequestFactory,
+    admin_user: User,
+) -> None:
+    """Ensures sync login rejects invalid credentials."""
+    request = dmr_rf.post(
+        '/whatever/',
+        data={'username': _USERNAME, 'password': _WRONG_PASSWORD},
+    )
+
+    response = _SyncObtainTokenController.as_view()(request)
+
+    assert admin_user.is_active
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
 @final
 class _AsyncObtainTokenController(
     ObtainTokenAsyncController[
@@ -65,6 +110,11 @@ class _AsyncObtainTokenController(
     ],
 ):
     token_cls = Token
+    token_size = _ASYNC_TOKEN_SIZE
+    token_secret = _ASYNC_TOKEN_SECRET
+    token_salt = _ASYNC_TOKEN_SALT
+    token_algorithm = _ASYNC_TOKEN_ALGORITHM
+    token_expiration = dt.timedelta(minutes=10)
 
     @override
     async def convert_auth_payload(
@@ -78,87 +128,48 @@ class _AsyncObtainTokenController(
         return {'token': 'async-response'}
 
 
-def _setup_controller(
-    controller: _SyncObtainTokenController | _AsyncObtainTokenController,
-) -> HttpRequest:
-    request = HttpRequest()
-    controller.setup(request)
-    return request
-
-
-@pytest.mark.django_db
-def test_sync_obtain_token_login_success(
-    monkeypatch: pytest.MonkeyPatch,
-    admin_user: User,
-) -> None:
-    """Ensures sync login forwards credentials and authenticates the request."""
-    controller = _SyncObtainTokenController()
-    request = _setup_controller(controller)
-    authenticate = Mock(return_value=admin_user)
-    monkeypatch.setattr(token_views, 'authenticate', authenticate)
-    payload = ObtainTokenPayload(username='admin', password=_PASSWORD)
-
-    response = controller.post(payload)
-
-    assert response == {'token': 'sync-response'}
-    authenticate.assert_called_once_with(request, **payload)
-    assert request.user is admin_user
-
-
-@pytest.mark.django_db
-def test_sync_obtain_token_login_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Ensures sync login rejects invalid credentials."""
-    controller = _SyncObtainTokenController()
-    _setup_controller(controller)
-    monkeypatch.setattr(token_views, 'authenticate', Mock(return_value=None))
-
-    with pytest.raises(NotAuthenticatedError):
-        controller.login(
-            ObtainTokenPayload(username='admin', password=_WRONG_PASSWORD),
-        )
-
-
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_async_obtain_token_login_success(
-    monkeypatch: pytest.MonkeyPatch,
+    dmr_async_rf: DMRAsyncRequestFactory,
     admin_user: User,
 ) -> None:
-    """Ensures async login forwards credentials and authenticates request."""
-    controller = _AsyncObtainTokenController()
-    request = _setup_controller(controller)
-    authenticate = AsyncMock(return_value=admin_user)
-    monkeypatch.setattr(token_views, 'aauthenticate', authenticate)
-    payload = ObtainTokenPayload(username='admin', password=_PASSWORD)
+    """Ensures async login accepts valid credentials."""
+    request = dmr_async_rf.post(
+        '/whatever/',
+        data={'username': _USERNAME, 'password': _PASSWORD},
+    )
 
-    response = await controller.post(payload)
+    response = await dmr_async_rf.wrap(
+        _AsyncObtainTokenController.as_view()(request),
+    )
 
-    assert response == {'token': 'async-response'}
-    authenticate.assert_awaited_once_with(request, **payload)
-    assert request.user is admin_user
-    assert await request.auser() is admin_user
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK
+    assert json.loads(response.content) == {'token': 'async-response'}
+    assert request.user == admin_user
+    assert await request.auser() == admin_user
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_async_obtain_token_login_failure(
-    monkeypatch: pytest.MonkeyPatch,
+    dmr_async_rf: DMRAsyncRequestFactory,
+    admin_user: User,
 ) -> None:
     """Ensures async login rejects invalid credentials."""
-    controller = _AsyncObtainTokenController()
-    _setup_controller(controller)
-    monkeypatch.setattr(
-        token_views,
-        'aauthenticate',
-        AsyncMock(return_value=None),
+    request = dmr_async_rf.post(
+        '/whatever/',
+        data={'username': _USERNAME, 'password': _WRONG_PASSWORD},
     )
 
-    with pytest.raises(NotAuthenticatedError):
-        await controller.login(
-            ObtainTokenPayload(username='admin', password=_WRONG_PASSWORD),
-        )
+    response = await dmr_async_rf.wrap(
+        _AsyncObtainTokenController.as_view()(request),
+    )
+
+    assert admin_user.is_active
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @pytest.mark.django_db
@@ -175,6 +186,7 @@ def test_sync_issue_token_class_settings(admin_user: User) -> None:
         token_algorithm=_SyncObtainTokenController.token_algorithm,
     )
     assert token is not None
+    assert Token.find_raw(raw_token) is None
     assert len(raw_token) == _SYNC_TOKEN_LENGTH
     assert token.user == admin_user
     assert len(token.name) == _SYNC_TOKEN_LENGTH
@@ -184,27 +196,83 @@ def test_sync_issue_token_class_settings(admin_user: User) -> None:
     )
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('token_secret', 'token_salt', 'token_algorithm'),
+    [
+        (_WRONG_TOKEN_SECRET, _SYNC_TOKEN_SALT, _SYNC_TOKEN_ALGORITHM),
+        (_SYNC_TOKEN_SECRET, _WRONG_TOKEN_SALT, _SYNC_TOKEN_ALGORITHM),
+        (_SYNC_TOKEN_SECRET, _SYNC_TOKEN_SALT, 'sha256'),
+    ],
+)
+def test_sync_token_rejects_single_mismatch(
+    admin_user: User,
+    *,
+    token_secret: str,
+    token_salt: str,
+    token_algorithm: str,
+) -> None:
+    """Ensures each mismatched sync hash setting prevents auth."""
+    raw_token = _SyncObtainTokenController().issue_token(user=admin_user)
+    auth = HeaderTokenSyncAuth(
+        token_secret=token_secret,
+        token_salt=token_salt,
+        token_algorithm=token_algorithm,
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        auth.authenticate(HttpRequest(), raw_token)
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-async def test_async_issue_token_uses_call_settings(admin_user: User) -> None:
-    """Ensures async token issue forwards call-level customizations."""
+async def test_async_issue_token_class_settings(admin_user: User) -> None:
+    """Ensures async token issue forwards controller-level customizations."""
     raw_token = await _AsyncObtainTokenController().issue_token(
         user=admin_user,
         name='async-token',
         expires_at=None,
-        token_size=_ASYNC_TOKEN_SIZE,
-        token_secret=_TOKEN_SECRET,
-        token_salt=_TOKEN_SALT,
-        token_algorithm=_TOKEN_ALGORITHM,
     )
 
     token = await Token.afind_raw(
         raw_token,
-        token_secret=_TOKEN_SECRET,
-        token_salt=_TOKEN_SALT,
-        token_algorithm=_TOKEN_ALGORITHM,
+        token_secret=_AsyncObtainTokenController.token_secret,
+        token_salt=_AsyncObtainTokenController.token_salt,
+        token_algorithm=_AsyncObtainTokenController.token_algorithm,
     )
     assert token is not None
+    assert await Token.afind_raw(raw_token) is None
     assert len(raw_token) == _ASYNC_TOKEN_LENGTH
     assert token.name == 'async-token'
     assert token.expires_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    ('token_secret', 'token_salt', 'token_algorithm'),
+    [
+        (_WRONG_TOKEN_SECRET, _ASYNC_TOKEN_SALT, _ASYNC_TOKEN_ALGORITHM),
+        (_ASYNC_TOKEN_SECRET, _WRONG_TOKEN_SALT, _ASYNC_TOKEN_ALGORITHM),
+        (_ASYNC_TOKEN_SECRET, _ASYNC_TOKEN_SALT, 'sha256'),
+    ],
+)
+async def test_async_token_rejects_single_mismatch(
+    admin_user: User,
+    *,
+    token_secret: str,
+    token_salt: str,
+    token_algorithm: str,
+) -> None:
+    """Ensures each mismatched async hash setting prevents auth."""
+    raw_token = await _AsyncObtainTokenController().issue_token(
+        user=admin_user,
+    )
+    auth = HeaderTokenAsyncAuth(
+        token_secret=token_secret,
+        token_salt=token_salt,
+        token_algorithm=token_algorithm,
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        await auth.authenticate(HttpRequest(), raw_token)

--- a/tests/test_unit/test_security/test_token/test_token_views.py
+++ b/tests/test_unit/test_security/test_token/test_token_views.py
@@ -6,6 +6,7 @@ from typing import Final, final
 import pytest
 from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
+from faker import Faker
 from typing_extensions import override
 
 from dmr.exceptions import NotAuthenticatedError
@@ -20,9 +21,6 @@ from dmr.security.token.views import (
 )
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 
-_USERNAME: Final = 'admin'
-_PASSWORD: Final = 'password'  # noqa: S105
-_WRONG_PASSWORD: Final = 'wrong'  # noqa: S105
 _SYNC_TOKEN_SECRET: Final = 'sync-secret'  # noqa: S105
 _SYNC_TOKEN_SALT: Final = 'sync-salt'  # noqa: S105
 _SYNC_TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
@@ -35,6 +33,22 @@ _ASYNC_TOKEN_SIZE: Final = 20
 _ASYNC_TOKEN_LENGTH: Final = 27
 _WRONG_TOKEN_SECRET: Final = 'wrong-secret'  # noqa: S105
 _WRONG_TOKEN_SALT: Final = 'wrong-salt'  # noqa: S105
+
+
+@pytest.fixture
+def user_password(faker: Faker) -> str:
+    """Create a password for the test user."""
+    return faker.password()
+
+
+@pytest.fixture
+def user(faker: Faker, user_password: str) -> User:
+    """Create a user with explicit authentication details."""
+    return User.objects.create_user(
+        username=faker.unique.user_name(),
+        email=faker.unique.email(),
+        password=user_password,
+    )
 
 
 @final
@@ -67,12 +81,13 @@ class _SyncObtainTokenController(
 @pytest.mark.django_db
 def test_sync_obtain_token_login_success(
     dmr_rf: DMRRequestFactory,
-    admin_user: User,
+    user: User,
+    user_password: str,
 ) -> None:
     """Ensures sync login accepts valid credentials."""
     request = dmr_rf.post(
         '/whatever/',
-        data={'username': _USERNAME, 'password': _PASSWORD},
+        data={'username': user.username, 'password': user_password},
     )
 
     response = _SyncObtainTokenController.as_view()(request)
@@ -80,23 +95,27 @@ def test_sync_obtain_token_login_success(
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.OK
     assert json.loads(response.content) == {'token': 'sync-response'}
-    assert request.user == admin_user
+    assert request.user == user
 
 
 @pytest.mark.django_db
 def test_sync_obtain_token_login_failure(
     dmr_rf: DMRRequestFactory,
-    admin_user: User,
+    user: User,
+    user_password: str,
 ) -> None:
     """Ensures sync login rejects invalid credentials."""
     request = dmr_rf.post(
         '/whatever/',
-        data={'username': _USERNAME, 'password': _WRONG_PASSWORD},
+        data={
+            'username': user.username,
+            'password': f'invalid-{user_password}',
+        },
     )
 
     response = _SyncObtainTokenController.as_view()(request)
 
-    assert admin_user.is_active
+    assert user.is_active
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.UNAUTHORIZED
 
@@ -132,12 +151,13 @@ class _AsyncObtainTokenController(
 @pytest.mark.django_db(transaction=True)
 async def test_async_obtain_token_login_success(
     dmr_async_rf: DMRAsyncRequestFactory,
-    admin_user: User,
+    user: User,
+    user_password: str,
 ) -> None:
     """Ensures async login accepts valid credentials."""
     request = dmr_async_rf.post(
         '/whatever/',
-        data={'username': _USERNAME, 'password': _PASSWORD},
+        data={'username': user.username, 'password': user_password},
     )
 
     response = await dmr_async_rf.wrap(
@@ -147,27 +167,31 @@ async def test_async_obtain_token_login_success(
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.OK
     assert json.loads(response.content) == {'token': 'async-response'}
-    assert request.user == admin_user
-    assert await request.auser() == admin_user
+    assert request.user == user
+    assert await request.auser() == user
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_async_obtain_token_login_failure(
     dmr_async_rf: DMRAsyncRequestFactory,
-    admin_user: User,
+    user: User,
+    user_password: str,
 ) -> None:
     """Ensures async login rejects invalid credentials."""
     request = dmr_async_rf.post(
         '/whatever/',
-        data={'username': _USERNAME, 'password': _WRONG_PASSWORD},
+        data={
+            'username': user.username,
+            'password': f'invalid-{user_password}',
+        },
     )
 
     response = await dmr_async_rf.wrap(
         _AsyncObtainTokenController.as_view()(request),
     )
 
-    assert admin_user.is_active
+    assert user.is_active
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.UNAUTHORIZED
 

--- a/tests/test_unit/test_security/test_token/test_token_views.py
+++ b/tests/test_unit/test_security/test_token/test_token_views.py
@@ -1,0 +1,210 @@
+import datetime as dt
+from typing import Final, final
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from typing_extensions import override
+
+from dmr.exceptions import NotAuthenticatedError
+from dmr.plugins.pydantic import PydanticFastSerializer
+from dmr.security.token import views as token_views
+from dmr.security.token.app.models import Token
+from dmr.security.token.views import (
+    ObtainTokenAsyncController,
+    ObtainTokenPayload,
+    ObtainTokenResponse,
+    ObtainTokenSyncController,
+)
+
+_PASSWORD: Final = 'secret'  # noqa: S105
+_WRONG_PASSWORD: Final = 'wrong'  # noqa: S105
+_TOKEN_SECRET: Final = 'test-secret'  # noqa: S105
+_TOKEN_SALT: Final = 'test-salt'  # noqa: S105
+_TOKEN_ALGORITHM: Final = 'sha512'  # noqa: S105
+_SYNC_TOKEN_SIZE: Final = 24
+_SYNC_TOKEN_LENGTH: Final = 32
+_ASYNC_TOKEN_SIZE: Final = 20
+_ASYNC_TOKEN_LENGTH: Final = 27
+
+
+@final
+class _SyncObtainTokenController(
+    ObtainTokenSyncController[
+        PydanticFastSerializer,
+        ObtainTokenPayload,
+        ObtainTokenResponse,
+    ],
+):
+    token_cls = Token
+    token_size = _SYNC_TOKEN_SIZE
+    token_secret = _TOKEN_SECRET
+    token_salt = _TOKEN_SALT
+    token_algorithm = _TOKEN_ALGORITHM
+    token_expiration = dt.timedelta(minutes=5)
+
+    @override
+    def convert_auth_payload(
+        self,
+        payload: ObtainTokenPayload,
+    ) -> ObtainTokenPayload:
+        return payload
+
+    @override
+    def make_api_response(self) -> ObtainTokenResponse:
+        return {'token': 'sync-response'}
+
+
+@final
+class _AsyncObtainTokenController(
+    ObtainTokenAsyncController[
+        PydanticFastSerializer,
+        ObtainTokenPayload,
+        ObtainTokenResponse,
+    ],
+):
+    token_cls = Token
+
+    @override
+    async def convert_auth_payload(
+        self,
+        payload: ObtainTokenPayload,
+    ) -> ObtainTokenPayload:
+        return payload
+
+    @override
+    async def make_api_response(self) -> ObtainTokenResponse:
+        return {'token': 'async-response'}
+
+
+def _setup_controller(
+    controller: _SyncObtainTokenController | _AsyncObtainTokenController,
+) -> HttpRequest:
+    request = HttpRequest()
+    controller.setup(request)
+    return request
+
+
+@pytest.mark.django_db
+def test_sync_obtain_token_login_success(
+    monkeypatch: pytest.MonkeyPatch,
+    admin_user: User,
+) -> None:
+    """Ensures sync login forwards credentials and authenticates the request."""
+    controller = _SyncObtainTokenController()
+    request = _setup_controller(controller)
+    authenticate = Mock(return_value=admin_user)
+    monkeypatch.setattr(token_views, 'authenticate', authenticate)
+    payload = ObtainTokenPayload(username='admin', password=_PASSWORD)
+
+    response = controller.post(payload)
+
+    assert response == {'token': 'sync-response'}
+    authenticate.assert_called_once_with(request, **payload)
+    assert request.user is admin_user
+
+
+@pytest.mark.django_db
+def test_sync_obtain_token_login_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensures sync login rejects invalid credentials."""
+    controller = _SyncObtainTokenController()
+    _setup_controller(controller)
+    monkeypatch.setattr(token_views, 'authenticate', Mock(return_value=None))
+
+    with pytest.raises(NotAuthenticatedError):
+        controller.login(
+            ObtainTokenPayload(username='admin', password=_WRONG_PASSWORD),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_obtain_token_login_success(
+    monkeypatch: pytest.MonkeyPatch,
+    admin_user: User,
+) -> None:
+    """Ensures async login forwards credentials and authenticates request."""
+    controller = _AsyncObtainTokenController()
+    request = _setup_controller(controller)
+    authenticate = AsyncMock(return_value=admin_user)
+    monkeypatch.setattr(token_views, 'aauthenticate', authenticate)
+    payload = ObtainTokenPayload(username='admin', password=_PASSWORD)
+
+    response = await controller.post(payload)
+
+    assert response == {'token': 'async-response'}
+    authenticate.assert_awaited_once_with(request, **payload)
+    assert request.user is admin_user
+    assert await request.auser() is admin_user
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_obtain_token_login_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensures async login rejects invalid credentials."""
+    controller = _AsyncObtainTokenController()
+    _setup_controller(controller)
+    monkeypatch.setattr(
+        token_views,
+        'aauthenticate',
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(NotAuthenticatedError):
+        await controller.login(
+            ObtainTokenPayload(username='admin', password=_WRONG_PASSWORD),
+        )
+
+
+@pytest.mark.django_db
+def test_sync_issue_token_class_settings(admin_user: User) -> None:
+    """Ensures sync token issue forwards controller-level customizations."""
+    before = dt.datetime.now(dt.UTC)
+
+    raw_token = _SyncObtainTokenController().issue_token(user=admin_user)
+
+    token = Token.find_raw(
+        raw_token,
+        token_secret=_SyncObtainTokenController.token_secret,
+        token_salt=_SyncObtainTokenController.token_salt,
+        token_algorithm=_SyncObtainTokenController.token_algorithm,
+    )
+    assert token is not None
+    assert len(raw_token) == _SYNC_TOKEN_LENGTH
+    assert token.user == admin_user
+    assert len(token.name) == _SYNC_TOKEN_LENGTH
+    assert token.expires_at is not None
+    assert (
+        before + _SyncObtainTokenController.token_expiration <= token.expires_at
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_issue_token_uses_call_settings(admin_user: User) -> None:
+    """Ensures async token issue forwards call-level customizations."""
+    raw_token = await _AsyncObtainTokenController().issue_token(
+        user=admin_user,
+        name='async-token',
+        expires_at=None,
+        token_size=_ASYNC_TOKEN_SIZE,
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+
+    token = await Token.afind_raw(
+        raw_token,
+        token_secret=_TOKEN_SECRET,
+        token_salt=_TOKEN_SALT,
+        token_algorithm=_TOKEN_ALGORITHM,
+    )
+    assert token is not None
+    assert len(raw_token) == _ASYNC_TOKEN_LENGTH
+    assert token.name == 'async-token'
+    assert token.expires_at is None


### PR DESCRIPTION
# I have made things!

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

Closes #1191

## What I changed

I added focused unit tests for the sync and async token authentication workflows. The tests cover the token-obtain views and the header, cookie, and query authentication classes.

I also covered customization options such as token secrets, salts, hashing algorithms, token sizes, expiration, generated names, security scheme names, and last-used tracking. Both successful authentication and rejection cases are tested.

## Why

These customization options were already available, but they did not have enough focused unit coverage. The additional tests verify that each authentication class forwards the customized token settings correctly and rejects tokens created with incompatible hashing settings.

This should help prevent future changes from silently breaking customized token authentication.

## Testing

I ran the focused token test suite:

- 129 tests passed
- 100% branch coverage for the relevant token modules
- Flake8 and Ruff passed
- mypy, Pyright, and Pyrefly passed
- slotscheck and import-linter passed

I also ran the complete test suite:

- 2,829 tests passed
- 10 tests skipped
- 100% total coverage
