### PR TITLE
Fix `OpenAPIConfig.openapi_version` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Later on we will make the API more stable and decrease the amount
 of requirements for an API to count as public.
 
 
+## WIP
+
+### Bugfixes
+
+- `OpenAPIConfig.openapi_version` now support any `str` argument
+
+
 ## 0.13.0 (2026-08-10)
 
 This release was focused on better routing and better OpenAPI support.

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal, TypeAlias, cast
+from typing import TypeAlias, cast
 
 from dmr.openapi.objects import (  # noqa: WPS235
     Components,
@@ -12,8 +12,6 @@ from dmr.openapi.objects import (  # noqa: WPS235
     Server,
     Tag,
 )
-
-_SupportedOpenAPIVersions: TypeAlias = Literal['3.0.0', '3.1.0', '3.2.0']
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -51,7 +49,7 @@ class OpenAPIConfig:
 
     title: str
     version: str
-    openapi_version: _SupportedOpenAPIVersions = '3.1.0'
+    openapi_version: str = '3.1.0'
 
     summary: str | None = None
     description: str | None = None

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TypeAlias, cast
+from typing import cast
 
 from dmr.openapi.objects import (  # noqa: WPS235
     Components,

--- a/tests/test_unit/test_openapi/test_views.py
+++ b/tests/test_unit/test_openapi/test_views.py
@@ -100,7 +100,7 @@ def test_skip_validation(
         config=OpenAPIConfig(
             title='A',
             version='B',
-            openapi_version='wrong',  # type: ignore[arg-type]
+            license='wrong',  # type: ignore[arg-type]
         ),
     )
     request = dmr_rf.get('/whatever/')


### PR DESCRIPTION
It can also be `3.0.3` or whatever.