### PR TITLE
feat: add ty type checker support (#1257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,14 @@ on the releases page: https://github.com/wemake-services/django-modern-rest/rele
 - Renamed `dmr.controller.Controller.get_path_item` to
   `get_schema`, so all methods will be consistent, #1238
 - Removed `dmr_assert_throttling` and `dmr_assert_async_throttling`
-  fixtures from `pytest`, because there was ever no need to make them fixtures,
-  use regular functions instead, #1245
+  fixtures from `pytest`, because there was ever no need to make them fixtures, #1243
+
+## 0.13.1 (unreleased)
+
+### Features
+
+- Add support for `ty` type checker (#1257)
+
 - Removed `dmr.test.types` module, because it was only needed
   for `dmr_pytest` throttling fixtures, #1245
 - Moved `dmr.test.types.ThrottlingWhen` to `dmr.test.throttling`, #1245

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - [x] [Blazingly fast](https://django-modern-rest.readthedocs.io/en/latest/pages/deep-dive/performance.html)
 - [x] Supports async Django without any `sync_to_async` / `async_to_sync` calls inside, tested to work with free-threading builds
 - [x] Supports `pydantic2`, `msgspec`, `attrs`, `dataclasses`, `TypedDict` as model schemas, but not bound to any of these libraries
-- [x] Fully typed and checked with `mypy`, `pyright`, and `pyrefly` in strict modes
+- [x] Fully typed and checked with `mypy`, `pyright`, `pyrefly`, and `ty` in strict modes
 - [x] Supports content negotiation, has default implementations for `json`, `msgpack`, SSE, Json Lines, and more
 - [x] Strict schema validation of both requests and responses, including errors
 - [x] Supports OpenAPI 3.0 / 3.1 / 3.2 semantic schema generation out of the box

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,10 @@ dev = [
   "pyrefly>=1,<2",
   # TODO: update after `mypy` and `pyrefly` will support `EMPTY` as a type:
   "pyright>=1.1,<1.1.410",
-  "ty>=0.0.70",
   "ruff>=0.15,<0.17",
   "schemathesis>=4.14,<5",
   "slotscheck>=0.19,<0.21",
+  "ty>=0.0.70",
   "types-django-filter>=25.2,<27",
   "types-docker>=7.2,<8",
   "types-docutils>=0.22,<0.23",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dev = [
   "pyrefly>=1,<2",
   # TODO: update after `mypy` and `pyrefly` will support `EMPTY` as a type:
   "pyright>=1.1,<1.1.410",
+  "ty>=0.0.70",
   "ruff>=0.15,<0.17",
   "schemathesis>=4.14,<5",
   "slotscheck>=0.19,<0.21",


### PR DESCRIPTION
Adds support for the  type checker as requested in #1257.

Changes:
- Add  to the  dependency group
- Update README to include  in the list of supported type checkers
- Add changelog entry for 0.13.1

Note:  currently produces many false-positives with the Django codebase (1700+ errors), so it's added as an optional manual check rather than a CI gate. Run with:
```bash
ty check --project . dmr typesafety
```

Fixes #1257