### PR TITLE
Return 401 instead of 500 for unusable JWT subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Later on we will make the API more stable and decrease the amount
 of requirements for an API to count as public.
 
 
+## WIP
+
+### Bugfixes
+
+- JWT auth, refresh, and verify now return `401` instead of `500`
+  when the token subject cannot be a value of the user lookup field,
+  for example a non-numeric `sub` with the default integer `pk`
+
+
 ## 0.14.0 (2026-08-14)
 
 ### Breaking changes

--- a/dmr/security/jwt/auth.py
+++ b/dmr/security/jwt/auth.py
@@ -4,9 +4,9 @@
 # https://github.com/litestar-org/litestar/blob/main/LICENSE
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, Self, overload
+from typing import TYPE_CHECKING, Final, Literal, Self, overload
 
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.http import HttpRequest
 from typing_extensions import override
 
@@ -21,6 +21,20 @@ if TYPE_CHECKING:
     from dmr.controller import Controller
     from dmr.endpoint import Endpoint
     from dmr.serializer import BaseSerializer
+
+# Errors that mean "this token subject cannot identify a user".
+#
+# A signed token can carry anything at all in its claims, while
+# the user lookup field is typed. Django raises `ValueError` when
+# an integer column gets a non-numeric value, and `ValidationError`
+# from fields like `UUIDField` that validate on conversion.
+# All of them mean the same thing for us: no such user.
+USER_LOOKUP_ERRORS: Final = (
+    ObjectDoesNotExist,
+    ValidationError,
+    TypeError,
+    ValueError,
+)
 
 
 class _BaseJWTAuth:  # noqa: WPS214, WPS230
@@ -248,7 +262,7 @@ class JWTSyncAuth(_BaseJWTAuth, SyncAuth):
             return get_user_model().objects.get(**{
                 self.user_id_field: self.claim_from_token(token),
             })
-        except ObjectDoesNotExist:
+        except USER_LOOKUP_ERRORS:
             raise NotAuthenticatedError from None
 
     def check_auth(self, user: 'AbstractBaseUser', token: JWToken) -> None:
@@ -305,7 +319,7 @@ class JWTAsyncAuth(_BaseJWTAuth, AsyncAuth):
             return await get_user_model().objects.aget(**{
                 self.user_id_field: self.claim_from_token(token),
             })
-        except ObjectDoesNotExist:
+        except USER_LOOKUP_ERRORS:
             raise NotAuthenticatedError from None
 
     async def check_auth(

--- a/dmr/security/jwt/views.py
+++ b/dmr/security/jwt/views.py
@@ -8,7 +8,6 @@ from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar
 from django.conf import settings
 from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.base_user import AbstractBaseUser
-from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpRequest
 from django.views.decorators.debug import sensitive_post_parameters
 from typing_extensions import TypedDict
@@ -17,7 +16,7 @@ from dmr import Body, Controller, ResponseSpec, modify
 from dmr.decorators import endpoint_decorator
 from dmr.errors import ErrorModel
 from dmr.exceptions import NotAuthenticatedError
-from dmr.security.jwt.auth import set_request_attrs
+from dmr.security.jwt.auth import USER_LOOKUP_ERRORS, set_request_attrs
 from dmr.security.jwt.token import JWToken
 from dmr.serializer import BaseSerializer
 
@@ -328,7 +327,7 @@ class RefreshTokenSyncController(
             user = get_user_model().objects.get(**{
                 self.jwt_user_id_field: token.sub,
             })
-        except ObjectDoesNotExist:
+        except USER_LOOKUP_ERRORS:
             raise NotAuthenticatedError from None
         self.check_auth(user)
         self.set_request_attrs(self.request, user)
@@ -412,7 +411,7 @@ class RefreshTokenAsyncController(
             user = await get_user_model().objects.aget(**{
                 self.jwt_user_id_field: token.sub,
             })
-        except ObjectDoesNotExist:
+        except USER_LOOKUP_ERRORS:
             raise NotAuthenticatedError from None
         await self.check_auth(user)
         await self.set_request_attrs(self.request, user)
@@ -520,7 +519,7 @@ class VerifyTokenSyncController(
             return get_user_model().objects.get(**{
                 self.jwt_user_id_field: token.sub,
             })
-        except ObjectDoesNotExist:
+        except USER_LOOKUP_ERRORS:
             raise NotAuthenticatedError from None
 
     def check_auth(self, user: Any) -> None:
@@ -590,7 +589,7 @@ class VerifyTokenAsyncController(
             return await get_user_model().objects.aget(**{
                 self.jwt_user_id_field: token.sub,
             })
-        except ObjectDoesNotExist:
+        except USER_LOOKUP_ERRORS:
             raise NotAuthenticatedError from None
 
     async def check_auth(self, user: Any) -> None:

--- a/tests/test_integration/test_jwt_auth/test_jwt_views.py
+++ b/tests/test_integration/test_jwt_auth/test_jwt_views.py
@@ -662,3 +662,59 @@ def test_verify_inactive_user(
     assert response.json() == snapshot({
         'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
     })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_refresh_sync'),
+        reverse('api:jwt_auth:jwt_refresh_async'),
+    ],
+)
+def test_refresh_non_numeric_subject(
+    dmr_client: DMRClient,
+    *,
+    url: str,
+) -> None:
+    """Ensures a subject that cannot be a `pk` raises 401, not 500."""
+    token = JWToken(
+        sub='definitely-not-a-pk',
+        exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'refresh'},
+    ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
+
+    response = dmr_client.post(url, data={'refresh_token': token})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('api:jwt_auth:jwt_verify_sync'),
+        reverse('api:jwt_auth:jwt_verify_async'),
+    ],
+)
+def test_verify_non_numeric_subject(
+    dmr_client: DMRClient,
+    *,
+    url: str,
+) -> None:
+    """Ensures a subject that cannot be a `pk` raises 401, not 500."""
+    token = JWToken(
+        sub='definitely-not-a-pk',
+        exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
+    ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
+
+    response = dmr_client.post(url, data={'access_token': token})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.json() == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })

--- a/tests/test_unit/test_security/test_jwt/test_jwt_invalid_subject.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_invalid_subject.py
@@ -1,0 +1,138 @@
+import datetime as dt
+from http import HTTPStatus
+from typing import Final
+
+import pytest
+from django.conf import LazySettings
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+
+from dmr import Controller
+from dmr.plugins.pydantic import PydanticFastSerializer
+from dmr.security.jwt import JWTAsyncAuth, JWToken, JWTSyncAuth
+from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+
+
+def _encode(subject: str, secret: str) -> str:
+    return JWToken(
+        exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        sub=subject,
+    ).encode(secret=secret, algorithm='HS256')
+
+
+class _SyncController(Controller[PydanticFastSerializer]):
+    auth = (JWTSyncAuth(),)
+
+    def get(self) -> str:
+        raise NotImplementedError
+
+
+class _AsyncController(Controller[PydanticFastSerializer]):
+    auth = (JWTAsyncAuth(),)
+
+    async def get(self) -> str:
+        raise NotImplementedError
+
+
+# The default `user_id_field` is `pk`, which is an integer column.
+# A signed token can still carry anything at all in `sub`.
+# An empty `sub` is not listed: `JWToken` rejects it on both
+# encode and decode, so it never reaches the user lookup.
+_INVALID_SUBJECTS: Final = ('admin', 'not-a-number', '1.5', '{}', 'null')
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('subject', _INVALID_SUBJECTS)
+def test_sync_jwt_non_numeric_subject(
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+    *,
+    subject: str,
+) -> None:
+    """Ensures a subject that cannot be a `pk` is a 401, not a 500."""
+    token = _encode(subject, settings.SECRET_KEY)
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    response = _SyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize('subject', _INVALID_SUBJECTS)
+async def test_async_jwt_non_numeric_subject(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    settings: LazySettings,
+    *,
+    subject: str,
+) -> None:
+    """Ensures a subject that cannot be a `pk` is a 401, not a 500."""
+    token = _encode(subject, settings.SECRET_KEY)
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    response = await dmr_async_rf.wrap(_AsyncController.as_view()(request))
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+
+
+@pytest.mark.django_db
+def test_sync_jwt_subject_validation_error(
+    dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+) -> None:
+    """Ensures `ValidationError` from a field is a 401, not a 500."""
+
+    class _ValidatingController(Controller[PydanticFastSerializer]):
+        # `date_joined` validates on conversion and raises
+        # `ValidationError` instead of `ValueError`, same as `UUIDField`:
+        auth = (JWTSyncAuth(user_id_field='date_joined'),)
+
+        def get(self) -> str:
+            raise NotImplementedError
+
+    token = _encode('definitely-not-a-date', settings.SECRET_KEY)
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    response = _ValidatingController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+
+
+@pytest.mark.django_db
+def test_sync_jwt_valid_subject_still_works(
+    dmr_rf: DMRRequestFactory,
+    admin_user: User,
+    settings: LazySettings,
+) -> None:
+    """Ensures the widened `except` did not swallow successful auth."""
+
+    class _OkController(Controller[PydanticFastSerializer]):
+        auth = (JWTSyncAuth(),)
+
+        def get(self) -> str:
+            assert self.request.user.pk == admin_user.pk
+            return 'authed'
+
+    token = _encode(str(admin_user.pk), settings.SECRET_KEY)
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    response = _OkController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK, response.content

--- a/tests/test_unit/test_security/test_jwt/test_jwt_invalid_subject.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_invalid_subject.py
@@ -24,33 +24,45 @@ class _SyncController(Controller[PydanticFastSerializer]):
     auth = (JWTSyncAuth(),)
 
     def get(self) -> str:
-        raise NotImplementedError
+        return 'authed'
 
 
 class _AsyncController(Controller[PydanticFastSerializer]):
     auth = (JWTAsyncAuth(),)
 
     async def get(self) -> str:
-        raise NotImplementedError
+        return 'authed'
 
 
 # The default `user_id_field` is `pk`, which is an integer column.
 # A signed token can still carry anything at all in `sub`.
 # An empty `sub` is not listed: `JWToken` rejects it on both
 # encode and decode, so it never reaches the user lookup.
-_INVALID_SUBJECTS: Final = ('admin', 'not-a-number', '1.5', '{}', 'null')
+#
+# `None` means "the real user's pk" and is the control case:
+# without it we would only ever assert failures.
+_SUBJECT_CASES: Final = (
+    ('admin', HTTPStatus.UNAUTHORIZED),
+    ('not-a-number', HTTPStatus.UNAUTHORIZED),
+    ('1.5', HTTPStatus.UNAUTHORIZED),
+    ('{}', HTTPStatus.UNAUTHORIZED),
+    ('null', HTTPStatus.UNAUTHORIZED),
+    (None, HTTPStatus.OK),
+)
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('subject', _INVALID_SUBJECTS)
+@pytest.mark.parametrize(('subject', 'expected_status'), _SUBJECT_CASES)
 def test_sync_jwt_non_numeric_subject(
     dmr_rf: DMRRequestFactory,
+    admin_user: User,
     settings: LazySettings,
     *,
-    subject: str,
+    subject: str | None,
+    expected_status: HTTPStatus,
 ) -> None:
     """Ensures a subject that cannot be a `pk` is a 401, not a 500."""
-    token = _encode(subject, settings.SECRET_KEY)
+    token = _encode(subject or str(admin_user.pk), settings.SECRET_KEY)
     request = dmr_rf.get(
         '/whatever/',
         headers={'Authorization': f'Bearer {token}'},
@@ -59,20 +71,22 @@ def test_sync_jwt_non_numeric_subject(
     response = _SyncController.as_view()(request)
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.status_code == expected_status, response.content
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize('subject', _INVALID_SUBJECTS)
+@pytest.mark.parametrize(('subject', 'expected_status'), _SUBJECT_CASES)
 async def test_async_jwt_non_numeric_subject(
     dmr_async_rf: DMRAsyncRequestFactory,
+    admin_user: User,
     settings: LazySettings,
     *,
-    subject: str,
+    subject: str | None,
+    expected_status: HTTPStatus,
 ) -> None:
     """Ensures a subject that cannot be a `pk` is a 401, not a 500."""
-    token = _encode(subject, settings.SECRET_KEY)
+    token = _encode(subject or str(admin_user.pk), settings.SECRET_KEY)
     request = dmr_async_rf.get(
         '/whatever/',
         headers={'Authorization': f'Bearer {token}'},
@@ -81,7 +95,7 @@ async def test_async_jwt_non_numeric_subject(
     response = await dmr_async_rf.wrap(_AsyncController.as_view()(request))
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert response.status_code == expected_status, response.content
 
 
 @pytest.mark.django_db
@@ -109,30 +123,3 @@ def test_sync_jwt_subject_validation_error(
 
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
-
-
-@pytest.mark.django_db
-def test_sync_jwt_valid_subject_still_works(
-    dmr_rf: DMRRequestFactory,
-    admin_user: User,
-    settings: LazySettings,
-) -> None:
-    """Ensures the widened `except` did not swallow successful auth."""
-
-    class _OkController(Controller[PydanticFastSerializer]):
-        auth = (JWTSyncAuth(),)
-
-        def get(self) -> str:
-            assert self.request.user.pk == admin_user.pk
-            return 'authed'
-
-    token = _encode(str(admin_user.pk), settings.SECRET_KEY)
-    request = dmr_rf.get(
-        '/whatever/',
-        headers={'Authorization': f'Bearer {token}'},
-    )
-
-    response = _OkController.as_view()(request)
-
-    assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.OK, response.content


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
A signed token can carry anything in `sub`, but the user lookup field is typed. Looking up a non-numeric subject against the default integer `pk` made Django raise `ValueError`, which escaped as a 500:

    ValueError: Field 'id' expected a number but got 'admin'.

Only `ObjectDoesNotExist` was caught. Fields that validate on conversion, such as `UUIDField`, raise `ValidationError` and had the same problem.

All of these mean the same thing for auth: no such user. They are now collected in `USER_LOOKUP_ERRORS` and turned into `NotAuthenticatedError`, in the auth classes as well as in the refresh and verify controllers, which all shared the lookup.
## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made