### PR TITLE
Give schemathesis requests a REMOTE_ADDR

### DIFF
--- a/tests/test_integration/test_openapi/test_schema.py
+++ b/tests/test_integration/test_openapi/test_schema.py
@@ -124,7 +124,13 @@ def test_schemathesis(
 
     from tracecov.schemathesis import helpers  # noqa: PLC0415
 
-    response = case.call_and_validate()
+    # `werkzeug` leaves `REMOTE_ADDR` out of the WSGI environ entirely,
+    # while every real server sets it. Code that looks up the client IP
+    # then behaves differently under test than in production: for example
+    # `django-allauth` rate limiting answers `403` when it cannot find one.
+    response = case.call_and_validate(
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    )
     # Record interaction for `tracecov` report:
     tracecov_map.record_schemathesis_interactions(
         case.method,


### PR DESCRIPTION
# I have made things!
`werkzeug` leaves `REMOTE_ADDR` out of the WSGI environ entirely. PEP 3333 allows that, but every real server sets it, so anything that looks up the client IP behaves differently under this suite than in production.

Found it through `django-allauth`: its rate limiting cannot resolve a client and answers `403`, a status no deployed app would return there. Documenting that `403` would have recorded a harness artifact as if it were API behaviour.

Verified by recording what schemathesis passes to `werkzeug`: every request went out with no `environ_base` before, and every one carries `REMOTE_ADDR` after.
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)