### PR TITLE
Add Parser.validate method for import-time validation, #1304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ of requirements for an API to count as public.
   to authenticate `django-allauth` headless session tokens,
   available via the new `django-modern-rest[allauth]` extra, #1193
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
-- Added ``Parser.validate`` method for import-time validation of parser
+- Added `Parser.validate` method for import-time validation of parser
   configuration, #1304
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ of requirements for an API to count as public.
   to authenticate `django-allauth` headless session tokens,
   available via the new `django-modern-rest[allauth]` extra, #1193
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
+- Added ``Parser.validate`` method for import-time validation of parser
+  configuration, #1304
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ of requirements for an API to count as public.
   to authenticate `django-allauth` headless session tokens,
   available via the new `django-modern-rest[allauth]` extra, #1193
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
-- Added `Parser.validate` method for import-time validation of parser
+- Added ``Parser.validate`` method for import-time validation of parser
   configuration, #1304
 
 ### Bugfixes

--- a/dmr/parsers.py
+++ b/dmr/parsers.py
@@ -41,6 +41,13 @@ class Parser(ResponseSpecProvider):
     Must be defined for all subclasses.
     """
 
+    def validate(
+        self,
+        controller_cls: type['Controller[BaseSerializer]'],
+        metadata: EndpointMetadata,
+    ) -> None:
+        """Validate parser configuration at import time."""
+
     @abc.abstractmethod
     def parse(
         self,

--- a/dmr/parsers.py
+++ b/dmr/parsers.py
@@ -46,7 +46,13 @@ class Parser(ResponseSpecProvider):
         controller_cls: type['Controller[BaseSerializer]'],
         metadata: EndpointMetadata,
     ) -> None:
-        """Validate parser configuration at import time."""
+        """
+        Validate parser configuration at import time.
+
+        Override this method to enforce parser-specific constraints.
+        Raise :class:`dmr.exceptions.EndpointMetadataError`
+        if the parser is used incorrectly.
+        """
 
     @abc.abstractmethod
     def parse(

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -892,6 +892,7 @@ class EndpointMetadataValidator:
         # After that we can do some other validation:
         self._validate_request_http_spec()
         self._validate_components(controller_cls)
+        self._validate_parsers(controller_cls)
 
     def _resolve_all_responses(
         self,
@@ -969,6 +970,13 @@ class EndpointMetadataValidator:
     ) -> None:
         for component, _model, _metadata in self.metadata.component_parsers:
             component.validate(controller_cls, self.metadata)
+
+    def _validate_parsers(
+        self,
+        controller_cls: type['Controller[BaseSerializer]'],
+    ) -> None:
+        for parser in self.metadata.parsers.values():
+            parser.validate(controller_cls, self.metadata)
 
     def _validate_request_http_spec(self) -> None:
         """Validate HTTP spec rules for request."""

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -852,7 +852,7 @@ class EndpointMetadataBuilder:  # noqa: WPS214
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
-class EndpointMetadataValidator:
+class EndpointMetadataValidator:  # noqa: WPS214
     """
     Builds responses for the endpoint metadata.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ per-file-ignores =
   dmr/openapi/objects/*.py: WPS201, WPS110
   # We have complex modules with a lot of quircks:
   dmr/endpoint.py: WPS201, WPS203, WPS402, WPS404
-  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS214, WPS402
+  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS402
   dmr/openapi/mappers/schema_loader.py: WPS202
   dmr/controller.py: WPS201, WPS203
   dmr/routing.py: WPS114, WPS201

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ per-file-ignores =
   dmr/openapi/objects/*.py: WPS201, WPS110
   # We have complex modules with a lot of quircks:
   dmr/endpoint.py: WPS201, WPS203, WPS402, WPS404
-  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS402
+  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS214, WPS402
   dmr/openapi/mappers/schema_loader.py: WPS202
   dmr/controller.py: WPS201, WPS203
   dmr/routing.py: WPS114, WPS201

--- a/tests/test_unit/test_parsers/test_parser_validate.py
+++ b/tests/test_unit/test_parsers/test_parser_validate.py
@@ -6,6 +6,7 @@ from dmr.exceptions import EndpointMetadataError
 from dmr.metadata import EndpointMetadata
 from dmr.parsers import DeserializeFunc, Parser, Raw
 from dmr.plugins.pydantic import PydanticSerializer
+from dmr.serializer import BaseSerializer
 
 
 class _StrictParser(Parser):
@@ -27,7 +28,7 @@ class _StrictParser(Parser):
     @override
     def validate(
         self,
-        controller_cls: type[Controller],
+        controller_cls: type['Controller[BaseSerializer]'],
         metadata: EndpointMetadata,
     ) -> None:
         """Only allow this parser on GET endpoints."""
@@ -47,7 +48,7 @@ def test_custom_parser_validate_pass() -> None:
         def get(self) -> list[dict[str, str]]:
             raise NotImplementedError
 
-    assert _Controller is not None
+    pass
 
 
 def test_custom_parser_validate_fail() -> None:

--- a/tests/test_unit/test_parsers/test_parser_validate.py
+++ b/tests/test_unit/test_parsers/test_parser_validate.py
@@ -19,15 +19,15 @@ class _StrictParser(Parser):
         to_deserialize: Raw,
         deserializer_hook: DeserializeFunc | None = None,
         *,
-        request,
-        model,
+        request: object,
+        model: object,
     ) -> None:
         raise NotImplementedError
 
     @override
     def validate(
         self,
-        controller_cls: type['Controller[PydanticSerializer]'],
+        controller_cls: type[Controller],
         metadata: EndpointMetadata,
     ) -> None:
         """Only allow this parser on GET endpoints."""

--- a/tests/test_unit/test_parsers/test_parser_validate.py
+++ b/tests/test_unit/test_parsers/test_parser_validate.py
@@ -48,8 +48,6 @@ def test_custom_parser_validate_pass() -> None:
         def get(self) -> list[dict[str, str]]:
             raise NotImplementedError
 
-    pass
-
 
 def test_custom_parser_validate_fail() -> None:
     """Parser.validate raises on invalid usage."""

--- a/tests/test_unit/test_parsers/test_parser_validate.py
+++ b/tests/test_unit/test_parsers/test_parser_validate.py
@@ -1,0 +1,61 @@
+import pytest
+from typing_extensions import override
+
+from dmr import Controller
+from dmr.exceptions import EndpointMetadataError
+from dmr.metadata import EndpointMetadata
+from dmr.parsers import DeserializeFunc, Parser, Raw
+from dmr.plugins.pydantic import PydanticSerializer
+
+
+class _StrictParser(Parser):
+    """Parser that only works with GET endpoints."""
+
+    content_type = 'application/strict'
+
+    @override
+    def parse(
+        self,
+        to_deserialize: Raw,
+        deserializer_hook: DeserializeFunc | None = None,
+        *,
+        request,
+        model,
+    ) -> None:
+        raise NotImplementedError
+
+    @override
+    def validate(
+        self,
+        controller_cls: type['Controller[PydanticSerializer]'],
+        metadata: EndpointMetadata,
+    ) -> None:
+        """Only allow this parser on GET endpoints."""
+        if metadata.method != 'get':
+            raise EndpointMetadataError(
+                f'{type(self).__name__} only works on get endpoints, '
+                f'found: {metadata.method}',
+            )
+
+
+def test_custom_parser_validate_pass() -> None:
+    """Parser.validate passes when constraints are met."""
+
+    class _Controller(Controller[PydanticSerializer]):
+        parsers = (_StrictParser(),)
+
+        def get(self) -> list[dict[str, str]]:
+            raise NotImplementedError
+
+    assert _Controller is not None
+
+
+def test_custom_parser_validate_fail() -> None:
+    """Parser.validate raises on invalid usage."""
+    with pytest.raises(EndpointMetadataError, match='only works on get'):
+
+        class _Controller(Controller[PydanticSerializer]):
+            parsers = (_StrictParser(),)
+
+            def post(self, parsed_body: dict[str, str]) -> dict[str, str]:
+                raise NotImplementedError


### PR DESCRIPTION
Closes #1304

Adds a Parser.validate() method (empty by default) and wires it into the existing import-time validation flow via _validate_parsers().

Parsers can now override validate() to enforce constraints at import time, similar to ComponentParser.validate().