### PR TITLE
Add Renderer.validate method for import-time validation, #1306

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ of requirements for an API to count as public.
   to authenticate `django-allauth` headless session tokens,
   available via the new `django-modern-rest[allauth]` extra, #1193
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
-- Added ``Parser.validate`` method for import-time validation of parser
+- Added `Parser.validate` method for import-time validation of parser
   configuration, #1304
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,9 @@ of requirements for an API to count as public.
   to authenticate `django-allauth` headless session tokens,
   available via the new `django-modern-rest[allauth]` extra, #1193
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
-- Added ``Parser.validate`` method for import-time validation of parser
-  configuration, #1304
-- Added ``Renderer.validate`` method for import-time validation of renderer
+- Added `Parser.validate` method for import-time validation of parser
+configuration, #1304
+- Added `Renderer.validate` method for import-time validation of renderer
   configuration, #1306
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ of requirements for an API to count as public.
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
 - Added ``Parser.validate`` method for import-time validation of parser
   configuration, #1304
+- Added ``Renderer.validate`` method for import-time validation of renderer
+  configuration, #1306
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ of requirements for an API to count as public.
   to authenticate `django-allauth` headless session tokens,
   available via the new `django-modern-rest[allauth]` extra, #1193
 - Added `query` method support for `PathItem` OpenAPI 3.2.0 spec, #1300
-- Added `Parser.validate` method for import-time validation of parser
+- Added ``Parser.validate`` method for import-time validation of parser
   configuration, #1304
 
 ### Bugfixes

--- a/dmr/renderers.py
+++ b/dmr/renderers.py
@@ -59,6 +59,19 @@ class Renderer(ResponseSpecProvider):
         """
         raise NotImplementedError
 
+    def validate(
+        self,
+        controller_cls: type['Controller[BaseSerializer]'],
+        metadata: EndpointMetadata,
+    ) -> None:
+        """
+        Validate renderer configuration at import time.
+
+        Override this method to enforce renderer-specific constraints.
+        Raise :class:`dmr.exceptions.EndpointMetadataError`
+        if the renderer is used incorrectly.
+        """
+
     @override
     def provide_response_specs(
         self,

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -893,6 +893,7 @@ class EndpointMetadataValidator:  # noqa: WPS214
         self._validate_request_http_spec()
         self._validate_components(controller_cls)
         self._validate_parsers(controller_cls)
+        self._validate_renderers(controller_cls)
 
     def _resolve_all_responses(
         self,
@@ -977,6 +978,13 @@ class EndpointMetadataValidator:  # noqa: WPS214
     ) -> None:
         for parser in self.metadata.parsers.values():
             parser.validate(controller_cls, self.metadata)
+
+    def _validate_renderers(
+        self,
+        controller_cls: type['Controller[BaseSerializer]'],
+    ) -> None:
+        for renderer in self.metadata.renderers.values():
+            renderer.validate(controller_cls, self.metadata)
 
     def _validate_request_http_spec(self) -> None:
         """Validate HTTP spec rules for request."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ per-file-ignores =
   dmr/openapi/objects/*.py: WPS201, WPS110
   # We have complex modules with a lot of quircks:
   dmr/endpoint.py: WPS201, WPS203, WPS402, WPS404
-  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS214, WPS402
+  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS402
   dmr/openapi/mappers/schema_loader.py: WPS202
   dmr/controller.py: WPS201, WPS203
   dmr/routing.py: WPS114, WPS201

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ per-file-ignores =
   dmr/openapi/objects/*.py: WPS201, WPS110
   # We have complex modules with a lot of quircks:
   dmr/endpoint.py: WPS201, WPS203, WPS402, WPS404
-  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS402
+  dmr/validation/endpoint_metadata.py: WPS201, WPS203, WPS214, WPS402
   dmr/openapi/mappers/schema_loader.py: WPS202
   dmr/controller.py: WPS201, WPS203
   dmr/routing.py: WPS114, WPS201

--- a/tests/test_unit/test_parsers/test_parser_validate.py
+++ b/tests/test_unit/test_parsers/test_parser_validate.py
@@ -48,6 +48,8 @@ def test_custom_parser_validate_pass() -> None:
         def get(self) -> list[dict[str, str]]:
             raise NotImplementedError
 
+    # Controller is created successfully at import time.
+
 
 def test_custom_parser_validate_fail() -> None:
     """Parser.validate raises on invalid usage."""

--- a/tests/test_unit/test_renderers/test_renderer_validate.py
+++ b/tests/test_unit/test_renderers/test_renderer_validate.py
@@ -1,0 +1,61 @@
+import pytest
+from typing_extensions import override
+
+from dmr import Controller
+from dmr.exceptions import EndpointMetadataError
+from dmr.metadata import EndpointMetadata
+from dmr.parsers import Parser
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.renderers import Renderer
+from dmr.serializer import BaseSerializer
+
+
+class _StrictRenderer(Renderer):
+    """Renderer that only works with GET endpoints."""
+
+    content_type = 'application/strict'
+
+    @override
+    def render(self, to_serialize, serializer_hook):
+        raise NotImplementedError
+
+    @property
+    @override
+    def validation_parser(self) -> Parser:
+        raise NotImplementedError
+
+    @override
+    def validate(
+        self,
+        controller_cls: type['Controller[BaseSerializer]'],
+        metadata: EndpointMetadata,
+    ) -> None:
+        """Only allow this renderer on GET endpoints."""
+        if metadata.method != 'get':
+            raise EndpointMetadataError(
+                f'{type(self).__name__} only works on get endpoints, '
+                f'found: {metadata.method}',
+            )
+
+
+def test_custom_renderer_validate_pass() -> None:
+    """Renderer.validate passes when constraints are met."""
+
+    class _Controller(Controller[PydanticSerializer]):
+        renderers = (_StrictRenderer(),)
+
+        def get(self) -> list[dict[str, str]]:
+            raise NotImplementedError
+
+    # Controller is created successfully at import time.
+
+
+def test_custom_renderer_validate_fail() -> None:
+    """Renderer.validate raises on invalid usage."""
+    with pytest.raises(EndpointMetadataError, match='only works on get'):
+
+        class _Controller(Controller[PydanticSerializer]):
+            renderers = (_StrictRenderer(),)
+
+            def post(self, parsed_body: dict[str, str]) -> dict[str, str]:
+                raise NotImplementedError

--- a/tests/test_unit/test_renderers/test_renderer_validate.py
+++ b/tests/test_unit/test_renderers/test_renderer_validate.py
@@ -16,7 +16,7 @@ class _StrictRenderer(Renderer):
     content_type = 'application/strict'
 
     @override
-    def render(self, to_serialize, serializer_hook):
+    def render(self, to_serialize, serializer_hook) -> None:
         raise NotImplementedError
 
     @property

--- a/tests/test_unit/test_renderers/test_renderer_validate.py
+++ b/tests/test_unit/test_renderers/test_renderer_validate.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 from typing_extensions import override
 
@@ -16,7 +19,11 @@ class _StrictRenderer(Renderer):
     content_type = 'application/strict'
 
     @override
-    def render(self, to_serialize, serializer_hook) -> None:
+    def render(
+        self,
+        to_serialize: Any,
+        serializer_hook: Callable[[Any], Any],
+    ) -> bytes:
         raise NotImplementedError
 
     @property


### PR DESCRIPTION
Closes #1306

Adds a Renderer.validate() method (empty by default) and wires it into the existing import-time validation flow via _validate_renderers().

Same pattern as Parser.validate() from #1304 — renderers can now override alidate() to enforce constraints at import time.