### PR TITLE
Document removing expired blocklisted and opaque tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ of requirements for an API to count as public.
 - Fixes AI docs and plugin install instructions, #1311
 - Added `dmr-from-dj-rest-auth` agent skill to migrate `dj-rest-auth`
   installations to `django-modern-rest` and `django-allauth` headless, #1193
+- Documented why and how to remove expired `BlocklistedJWToken`
+  and `Token` rows on a schedule, #1336
 
 
 ## 0.14.0 (2026-08-14)

--- a/docs/examples/auth/jwt/blocklist_cleanup.py
+++ b/docs/examples/auth/jwt/blocklist_cleanup.py
@@ -1,0 +1,25 @@
+import datetime as dt
+from typing import Any, final
+
+from django.core.management.base import BaseCommand
+from typing_extensions import override
+
+from dmr.security.jwt.blocklist.models import BlocklistedJWToken
+
+#: Must be bigger than the `leeway` of all your jwt auth classes.
+GRACE_PERIOD = dt.timedelta(days=1)
+
+
+@final
+class Command(BaseCommand):
+    """Delete blocklist entries of tokens that are already expired."""
+
+    help = 'Delete blocklist entries of tokens that are already expired.'
+
+    @override
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: WPS110
+        """Expired tokens are rejected by `exp` before the blocklist runs."""
+        deleted, _ = BlocklistedJWToken.objects.filter(
+            expires_at__lt=dt.datetime.now(dt.UTC) - GRACE_PERIOD,
+        ).delete()
+        self.stdout.write(f'Removed {deleted} blocklisted tokens')

--- a/docs/examples/auth/token/token_cleanup.py
+++ b/docs/examples/auth/token/token_cleanup.py
@@ -1,0 +1,27 @@
+import datetime as dt
+from typing import Any, final
+
+from django.core.management.base import BaseCommand
+from django.db import models
+from typing_extensions import override
+
+from dmr.security.token.app.models import Token
+
+#: How long dead tokens are kept around for auditing.
+GRACE_PERIOD = dt.timedelta(days=30)
+
+
+@final
+class Command(BaseCommand):
+    """Delete tokens that cannot authenticate anyone anymore."""
+
+    help = 'Delete expired and revoked tokens.'
+
+    @override
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: WPS110
+        """Tokens with `expires_at=None` never expire, `__lt` skips them."""
+        cutoff = dt.datetime.now(dt.UTC) - GRACE_PERIOD
+        deleted, _ = Token.objects.filter(
+            models.Q(expires_at__lt=cutoff) | models.Q(revoked_at__lt=cutoff),
+        ).delete()
+        self.stdout.write(f'Removed {deleted} tokens')

--- a/docs/pages/auth/jwt.rst
+++ b/docs/pages/auth/jwt.rst
@@ -360,16 +360,7 @@ We recommend deleting them with a periodic job:
   :linenos:
   :language: python
 
-And then schedule it, for example with ``cron``:
-
-.. code-block:: bash
-  :caption: crontab
-
-  0 4 * * * /path/to/venv/bin/python /path/to/manage.py cleanup_blocklist
-
-Anything else that runs code on a schedule will do:
-Celery beat, ``django-q``, a ``systemd`` timer,
-or whatever your hosting provides.
+Then run this task as a periodic job.
 
 .. warning::
 

--- a/docs/pages/auth/jwt.rst
+++ b/docs/pages/auth/jwt.rst
@@ -333,6 +333,58 @@ We provide two mixin types:
 
 If this app is installed, we would provide an admin panel by default.
 
+.. _cleaning-up-blocklisted-tokens:
+
+Cleaning up expired tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The blocklist only answers one question:
+is this *otherwise valid* token still allowed?
+When ``exp`` of a token is in the past,
+:meth:`~dmr.security.jwt.token.JWToken.decode` rejects it
+before we even look into the blocklist.
+
+Which means:
+
+- Rows with ``expires_at`` in the future must stay,
+  they are the ones actually blocking tokens
+- Rows with ``expires_at`` in the past can be removed,
+  they cannot change any auth decision anymore
+
+Nothing removes them for us, so the table grows forever
+while storing rows that can never affect auth again.
+We recommend deleting them with a periodic job:
+
+.. literalinclude:: /examples/auth/jwt/blocklist_cleanup.py
+  :caption: myapp/management/commands/cleanup_blocklist.py
+  :linenos:
+  :language: python
+
+And then schedule it, for example with ``cron``:
+
+.. code-block:: bash
+  :caption: crontab
+
+  0 4 * * * /path/to/venv/bin/python /path/to/manage.py cleanup_blocklist
+
+Anything else that runs code on a schedule will do:
+Celery beat, ``django-q``, a ``systemd`` timer,
+or whatever your hosting provides.
+
+.. warning::
+
+  Keep the grace period bigger than the largest ``leeway``
+  you pass to your auth classes.
+  With a non-zero ``leeway`` a token is still accepted
+  for that many seconds after ``exp``,
+  and its blocklist row is still doing real work for that long.
+
+.. tip::
+
+  The same reasoning applies to the opaque
+  :class:`~dmr.security.token.app.models.Token` model,
+  see :ref:`cleaning-up-old-tokens`.
+
 
 API Reference
 -------------
@@ -404,6 +456,9 @@ Pre-defined views to fetch JWT tokens
 
 Blocklist app
 ~~~~~~~~~~~~~
+
+.. autoclass:: dmr.security.jwt.blocklist.models.BlocklistedJWToken
+  :members:
 
 .. autoclass:: dmr.security.jwt.blocklist.auth.JWTokenBlocklistSyncMixin
   :members:

--- a/docs/pages/auth/token.rst
+++ b/docs/pages/auth/token.rst
@@ -175,6 +175,64 @@ Here's an example with the default model:
   :linenos:
   :language: python
 
+.. _cleaning-up-old-tokens:
+
+Cleaning up old tokens
+~~~~~~~~~~~~~~~~~~~~~~
+
+Auth finds a token by its hash and then checks
+:attr:`~dmr.security.token.app.models.Token.is_active`.
+Expired and revoked tokens always fail that check,
+so deleting their rows changes nothing for the client:
+a ``401`` stays a ``401``, it just says "unknown token" now.
+
+Which means:
+
+- Rows that are still active must stay,
+  including the ones with ``expires_at`` set to ``None``,
+  because such tokens never expire
+- Rows with ``expires_at`` in the past
+  and rows with ``revoked_at`` set can be removed,
+  they can never authenticate anyone again
+
+Deleting a token is not a replacement for revoking it,
+:meth:`~dmr.security.token.token.TokenLikeSync.revoke` is what stops
+a token that is still active. Cleanup is just housekeeping afterwards,
+and it is worth doing periodically:
+
+.. literalinclude:: /examples/auth/token/token_cleanup.py
+  :caption: myapp/management/commands/cleanup_tokens.py
+  :linenos:
+  :language: python
+
+Note that ``expires_at__lt`` never matches ``NULL``,
+so tokens without an expiry date are safe from this query by construction.
+
+Then run it on a schedule, for example with ``cron``:
+
+.. code-block:: bash
+  :caption: crontab
+
+  0 4 * * * /path/to/venv/bin/python /path/to/manage.py cleanup_tokens
+
+Celery beat, ``django-q``, or a ``systemd`` timer work just as well.
+
+.. note::
+
+  Keep a grace period that matches your auditing needs.
+  Dead rows still tell you when a token was issued, last used, and revoked,
+  which is the kind of thing you want during an incident.
+  For the same reason you might want to archive them
+  somewhere else instead of just deleting them.
+
+  If you :ref:`swapped the token model <swapping-token-model>`,
+  adjust the query to the fields your own model has.
+
+.. tip::
+
+  Blocklisted JWT tokens have the same problem and the same solution,
+  see :ref:`cleaning-up-blocklisted-tokens`.
+
 
 Django admin
 ------------

--- a/docs/pages/auth/token.rst
+++ b/docs/pages/auth/token.rst
@@ -208,14 +208,7 @@ and it is worth doing periodically:
 Note that ``expires_at__lt`` never matches ``NULL``,
 so tokens without an expiry date are safe from this query by construction.
 
-Then run it on a schedule, for example with ``cron``:
-
-.. code-block:: bash
-  :caption: crontab
-
-  0 4 * * * /path/to/venv/bin/python /path/to/manage.py cleanup_tokens
-
-Celery beat, ``django-q``, or a ``systemd`` timer work just as well.
+Then run this task as a periodic job.
 
 .. note::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,3 +86,5 @@ per-file-ignores =
   docs/tools/sphinx_ext/*.py: WPS201, WPS202, WPS203, WPS204, WPS226, WPS402
   # Tests in doc examples are special:
   docs/examples/testing/*.py: WPS226
+  # A grace period in days is not a magic number:
+  docs/examples/auth/token/token_cleanup.py: WPS432


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
Expired rows in `BlocklistedJWToken` and `Token` cannot change any auth decision anymore, so they are pure dead weight.

Both auth pages now explain what is safe to delete and what must stay, and ship a management command example to schedule with cron.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1336 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
