### PR TITLE
Validate `exp` and `iat` in a single place, #1324

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ of requirements for an API to count as public.
   use `FileResponseSpec.return_type` instead, #1278
 - Removed `FileMetadataComponent.schema_metadata`,
   now we use `SupportsFileParsing.schema_metadata` instead, #1278
+- Removed init-only `leeway` argument of `JWToken`,
+  it is only used by `JWToken.decode` now, #1324
+- `JWToken` does not validate `exp` and `iat` on creation anymore,
+  they are validated in `JWToken.encode` instead, #1324
 
 ### Features
 
@@ -66,6 +70,9 @@ of requirements for an API to count as public.
   for file responses, #1278
 - Fixed `SimpleRate` throttling reports with redis backends,
   it used to error on missing throttling stats, #1333
+- Fixed `JWToken.decode` validating `exp` and `iat` twice,
+  now `leeway`, `verify_exp`, and `verify_iat` are respected
+  and invalid tokens return `401` instead of `500`, #1324
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ of requirements for an API to count as public.
 - Removed init-only `leeway` argument of `JWToken`,
   it is only used by `JWToken.decode` now, #1324
 - `JWToken` does not validate `exp` and `iat` on creation anymore,
-  they are validated in `JWToken.encode` instead, #1324
+  now `JWToken.encode` validates them instead, #1324
 
 ### Features
 
@@ -51,6 +51,8 @@ of requirements for an API to count as public.
 - Added `FileMetadata` conditional types, #1278
 - Added `SupportsFileParsing.schema_metadata` method to customize
   file schema from the parser, #1278
+- Added `JWToken.validate_issued_claims` method to customize
+  the checks we run before signing a token, #1324
 - Added `security.NO_STORE_HEADERS`, all auth views we ship now
   return the `Cache-Control: no-store` header
   and document it in the OpenAPI schema, #1335

--- a/dmr/security/jwt/token.py
+++ b/dmr/security/jwt/token.py
@@ -29,7 +29,7 @@
 
 import datetime as dt
 from collections.abc import Sequence
-from dataclasses import InitVar, asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Self
 
 import jwt
@@ -53,6 +53,14 @@ class JWToken:
         jti: JWT ID - a unique identifier of the JWT between different issuers.
         extras: Extra fields that were found on the JWT token.
 
+    .. versionchanged:: 0.15.0
+
+        Init-only ``leeway`` argument was removed.
+        Time-based claims are now validated in a single place
+        for each direction: :meth:`encode` checks that a token
+        can be issued, while :meth:`decode` fully relies
+        on ``pyjwt`` and its options.
+
     """
 
     sub: str
@@ -71,37 +79,15 @@ class JWToken:
         default_factory=dict,
     )
 
-    # Options for validation:
-    leeway: InitVar[int] = 0
-
-    def __post_init__(self, leeway: int) -> None:
-        """Runs extra validation."""
+    def __post_init__(self) -> None:
+        """Normalizes datetime claims and runs extra validation."""
         if len(self.sub) < 1:
             raise ValueError(
                 'sub must be a string with a length greater than 0',
             )
 
-        exp = _normalize_datetime(self.exp)
-        if (
-            exp + dt.timedelta(seconds=leeway)
-        ).timestamp() >= _normalize_datetime(
-            dt.datetime.now(dt.UTC),
-        ).timestamp():
-            object.__setattr__(self, 'exp', exp)
-        else:
-            raise ValueError(
-                'exp value must be a datetime in the future, '
-                f'leeway is {leeway}',
-            )
-
-        iat = _normalize_datetime(self.iat)
-        if (
-            iat.timestamp()
-            <= _normalize_datetime(dt.datetime.now(dt.UTC)).timestamp()
-        ):
-            object.__setattr__(self, 'iat', iat)
-        else:
-            raise ValueError('iat must be a current or past time')
+        object.__setattr__(self, 'exp', _normalize_datetime(self.exp))
+        object.__setattr__(self, 'iat', _normalize_datetime(self.iat))
 
     def encode(
         self,
@@ -122,8 +108,16 @@ class JWToken:
             An encoded token string.
 
         Raises:
+            ValueError: If this token cannot be issued right now.
             InternalServerError: If encoding fails.
+
+        .. versionchanged:: 0.15.0
+
+            ``exp`` and ``iat`` are validated here,
+            previously it was done during the instance creation.
+
         """
+        _validate_issued_claims(self)
         try:
             return jwt.encode(
                 payload={
@@ -218,6 +212,14 @@ class JWToken:
         See also:
             https://pyjwt.readthedocs.io/en/stable/api.html#jwt.types.Options
 
+        .. versionchanged:: 0.15.0
+
+            Time-based claims are only validated by ``pyjwt``,
+            we don't validate them a second time anymore.
+            This means that ``leeway``, ``verify_exp``, and ``verify_iat``
+            are now respected, and that invalid tokens always
+            raise :exc:`dmr.exceptions.NotAuthenticatedError`.
+
         """
         options = cls._build_options(
             audience=accepted_audiences,
@@ -254,7 +256,13 @@ class JWToken:
         extras = payload.setdefault('extras', {})
         for key in extra_fields:
             extras[key] = payload.pop(key)
-        return cls(**payload, leeway=leeway)
+
+        try:
+            return cls(**payload)
+        except ValueError:
+            # Time-based claims are already checked by `pyjwt` above,
+            # everything else that is invalid here is still a bad token.
+            raise NotAuthenticatedError from None
 
     @classmethod
     def _build_options(  # noqa: WPS211
@@ -316,6 +324,15 @@ class JWToken:
             )
         except (TypeError, ValueError, OSError):
             raise NotAuthenticatedError from None
+
+
+def _validate_issued_claims(token: JWToken) -> None:
+    """Ensures that this token makes sense to be issued right now."""
+    now = _normalize_datetime(dt.datetime.now(dt.UTC)).timestamp()
+    if token.exp.timestamp() < now:
+        raise ValueError('exp value must be a datetime in the future')
+    if token.iat.timestamp() > now:
+        raise ValueError('iat must be a current or past time')
 
 
 def _normalize_datetime(datetime: dt.datetime) -> dt.datetime:

--- a/dmr/security/jwt/token.py
+++ b/dmr/security/jwt/token.py
@@ -39,7 +39,7 @@ from dmr.exceptions import InternalServerError, NotAuthenticatedError
 
 
 @dataclass(frozen=True, slots=True)
-class JWToken:
+class JWToken:  # noqa: WPS214
     """
     JWT Token DTO.
 
@@ -89,6 +89,25 @@ class JWToken:
         object.__setattr__(self, 'exp', _normalize_datetime(self.exp))
         object.__setattr__(self, 'iat', _normalize_datetime(self.iat))
 
+    def validate_issued_claims(self) -> None:
+        """
+        Ensure that this token makes sense to be issued right now.
+
+        Is called by :meth:`encode`, override it to change or to extend
+        the checks that we run before signing a token.
+
+        Raises:
+            ValueError: If this token cannot be issued right now.
+
+        .. versionadded:: 0.15.0
+
+        """
+        now = _normalize_datetime(dt.datetime.now(dt.UTC)).timestamp()
+        if self.exp.timestamp() < now:
+            raise ValueError('exp value must be a datetime in the future')
+        if self.iat.timestamp() > now:
+            raise ValueError('iat must be a current or past time')
+
     def encode(
         self,
         secret: str | bytes,
@@ -113,11 +132,12 @@ class JWToken:
 
         .. versionchanged:: 0.15.0
 
-            ``exp`` and ``iat`` are validated here,
+            ``exp`` and ``iat`` are validated here
+            via :meth:`validate_issued_claims`,
             previously it was done during the instance creation.
 
         """
-        _validate_issued_claims(self)
+        self.validate_issued_claims()
         try:
             return jwt.encode(
                 payload={
@@ -324,15 +344,6 @@ class JWToken:
             )
         except (TypeError, ValueError, OSError):
             raise NotAuthenticatedError from None
-
-
-def _validate_issued_claims(token: JWToken) -> None:
-    """Ensures that this token makes sense to be issued right now."""
-    now = _normalize_datetime(dt.datetime.now(dt.UTC)).timestamp()
-    if token.exp.timestamp() < now:
-        raise ValueError('exp value must be a datetime in the future')
-    if token.iat.timestamp() > now:
-        raise ValueError('iat must be a current or past time')
 
 
 def _normalize_datetime(datetime: dt.datetime) -> dt.datetime:

--- a/tests/test_unit/test_security/test_jwt/test_blocklist/test_blocklist_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_blocklist/test_blocklist_auth.py
@@ -35,7 +35,6 @@ class _JWTokenKwargs(TypedDict, total=False):
     aud: str | Sequence[str]
     jti: str
     extras: dict[str, Any]
-    leeway: int
 
 
 def test_is_installed() -> None:

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -6,7 +6,7 @@
 import dataclasses
 import datetime as dt
 import secrets
-from typing import Any
+from typing import Any, Final
 
 import jwt
 import pytest
@@ -15,6 +15,9 @@ from typing_extensions import TypedDict
 
 from dmr.exceptions import InternalServerError, NotAuthenticatedError
 from dmr.security.jwt import JWToken
+
+#: Clock error in seconds that we allow in tests below.
+_LEEWAY: Final = 30
 
 
 class _DecodeKwargs(TypedDict, total=False):
@@ -80,16 +83,16 @@ def test_empty_token() -> None:
     ],
 )
 def test_exp_in_the_past(exp: dt.datetime) -> None:
-    """Ensures that we can't create an exp date in the past."""
+    """Ensures that we can't issue a token with an exp date in the past."""
     with pytest.raises(ValueError, match='datetime in the future'):
-        JWToken('a', exp)
+        JWToken('a', exp).encode(secrets.token_hex(), 'HS256')
 
 
 def test_iat_in_the_past() -> None:
-    """Ensures that we can't create an iat date in the future."""
+    """Ensures that we can't issue a token with an iat date in the future."""
     exp = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
     with pytest.raises(ValueError, match='current or past time'):
-        JWToken('a', exp, iat=exp)
+        JWToken('a', exp, iat=exp).encode(secrets.token_hex(), 'HS256')
 
 
 def test_extra_fields(faker: Faker) -> None:
@@ -336,4 +339,122 @@ def test_invalid_datetime_claim_raises_auth_error() -> None:
             secret=secret,
             algorithm='HS256',
             verify_exp=False,
+        )
+
+
+def test_expired_token_can_skip_exp_verification() -> None:
+    """Ensure `verify_exp=False` is not overridden by our own validation."""
+    secret = secrets.token_hex()
+    expires_at = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+    encoded = jwt.encode(
+        {
+            'sub': 'foo',
+            'iat': dt.datetime.now(dt.UTC) - dt.timedelta(days=2),
+            'exp': expires_at,
+        },
+        key=secret,
+        algorithm='HS256',
+    )
+
+    token = JWToken.decode(
+        encoded,
+        secret=secret,
+        algorithm='HS256',
+        verify_exp=False,
+    )
+
+    assert token.exp == expires_at.replace(microsecond=0)
+
+
+def test_future_iat_can_skip_iat_verification() -> None:
+    """Ensure `verify_iat=False` is not overridden by our own validation."""
+    secret = secrets.token_hex()
+    issued_at = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
+    encoded = jwt.encode(
+        {
+            'sub': 'foo',
+            'iat': issued_at,
+            'exp': issued_at + dt.timedelta(days=1),
+        },
+        key=secret,
+        algorithm='HS256',
+    )
+
+    token = JWToken.decode(
+        encoded,
+        secret=secret,
+        algorithm='HS256',
+        verify_iat=False,
+    )
+
+    assert token.iat == issued_at.replace(microsecond=0)
+
+
+@pytest.mark.parametrize('seconds', [_LEEWAY - 1, _LEEWAY])
+def test_leeway_applies_to_iat(seconds: int) -> None:
+    """Ensure `leeway` tolerates an `iat` from the near future."""
+    secret = secrets.token_hex()
+    issued_at = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=seconds)
+    encoded = jwt.encode(
+        {
+            'sub': 'foo',
+            'iat': issued_at,
+            'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        },
+        key=secret,
+        algorithm='HS256',
+    )
+
+    token = JWToken.decode(
+        encoded,
+        secret=secret,
+        algorithm='HS256',
+        leeway=_LEEWAY,
+    )
+
+    assert token.iat == issued_at.replace(microsecond=0)
+
+
+@pytest.mark.parametrize(
+    'raw_token_data',
+    [
+        pytest.param(
+            {
+                'sub': 'foo',
+                'iat': dt.datetime.now(dt.UTC) - dt.timedelta(days=1),
+                'exp': dt.datetime.now(dt.UTC) - dt.timedelta(seconds=_LEEWAY),
+            },
+            id='expired-exp',
+        ),
+        pytest.param(
+            {
+                'sub': 'foo',
+                'iat': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+                'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=2),
+            },
+            id='immature-iat',
+        ),
+        pytest.param(
+            {
+                'sub': '',
+                'iat': dt.datetime.now(dt.UTC),
+                'exp': dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+            },
+            id='empty-sub',
+        ),
+    ],
+)
+def test_invalid_claims_raise_auth_error(
+    raw_token_data: dict[str, Any],
+) -> None:
+    """Ensure invalid claims are auth errors and not server errors."""
+    secret = secrets.token_hex()
+    encoded = jwt.encode(raw_token_data, key=secret, algorithm='HS256')
+
+    with pytest.raises(NotAuthenticatedError):
+        JWToken.decode(
+            encoded,
+            secret=secret,
+            algorithm='HS256',
+            leeway=_LEEWAY,
         )

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -11,7 +11,7 @@ from typing import Any, Final
 import jwt
 import pytest
 from faker import Faker
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, override
 
 from dmr.exceptions import InternalServerError, NotAuthenticatedError
 from dmr.security.jwt import JWToken
@@ -93,6 +93,22 @@ def test_iat_in_the_past() -> None:
     exp = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
     with pytest.raises(ValueError, match='current or past time'):
         JWToken('a', exp, iat=exp).encode(secrets.token_hex(), 'HS256')
+
+
+class _AnyTimeToken(JWToken):
+    """Token that can be issued with any `exp` and `iat` values."""
+
+    @override
+    def validate_issued_claims(self) -> None:
+        """Allows to issue tokens that are already expired."""
+
+
+def test_custom_issued_claims_validation() -> None:
+    """Ensures that `validate_issued_claims` can be customized."""
+    expired_at = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+    token = _AnyTimeToken('a', expired_at)
+
+    assert token.encode(secrets.token_hex(), 'HS256')
 
 
 def test_extra_fields(faker: Faker) -> None:

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -445,6 +445,7 @@ def test_leeway_applies_to_iat(seconds: int) -> None:
     ],
 )
 def test_invalid_claims_raise_auth_error(
+    *,
     raw_token_data: dict[str, Any],
 ) -> None:
     """Ensure invalid claims are auth errors and not server errors."""


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
The double validation mentioned in #1324  did not merely duplicate work — it **overrode** the pyjwt settings. Verified against the live code:

| Case | Before | After |
|---|---|---|
| `verify_exp=False` + expired token | `ValueError` → **500** | token is decoded |
| `verify_iat=False` + `iat` in the future | `ValueError` → **500** | token is decoded |
| `iat` in the future, within `leeway` | `ValueError` → **500** | token is decoded |
| `sub: ''` in a signed token | `ValueError` → **500** | `NotAuthenticatedError` → 401 |

The cause: `__post_init__` checked `exp` / `iat` by its own rules (`leeway` was not applied to `iat`, the `verify_*` flags were not taken into account), and it was called at the end of `decode()` — after pyjwt had already checked everything.

**Solution:** a single source of truth **per direction**, instead of a "skip validation" flag:

- **issuing a token** → our own checks, now in `encode()` (`dmr/security/jwt/token.py:92`): `exp` not in the past, `iat` not in the future, `ValueError`;
- **parsing a token** → entirely pyjwt with its `options` / `leeway`, no second check.

In `__post_init__` I kept only what does not depend on time: a non-empty `sub` and datetime normalization. The init-only `leeway` argument of `JWToken` was removed — it existed solely for the sake of that repeated check (breakage is allowed by the issue). In `decode`, the constructor is wrapped in `except ValueError → NotAuthenticatedError`, so that any remaining field validation yields a 401 rather than a 500.

**A risk worth being aware of:** `verify_exp=False` now genuinely disables the expiry check. Previously an expired token was rejected anyway — accidentally, by the second check. This is the declared behaviour of the flag, but the semantics have changed.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1324 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
