### PR TITLE
Require `auth_scheme` prefix in http basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ of requirements for an API to count as public.
 - `HttpBasicSyncAuth` and `HttpBasicAsyncAuth` now require
   the `auth_scheme` header prefix, it is `Basic` by default
   and is matched exactly, credentials sent without it
-  are not accepted anymore, #1330
+  are not accepted anymore.
+  Pass `auth_scheme=''` to keep reading prefixless
+  credentials like the older versions did, #1330
 - `HttpBasicSyncAuth` and `HttpBasicAsyncAuth` now raise
   `NotAuthenticatedError` when credentials have the right
   `auth_scheme` prefix, but cannot be decoded,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ of requirements for an API to count as public.
 - Throttling cache keys are now hashed to keep their length bounded, #1337
 - HTTP Basic Auth credentials are no longer URL-decoded,
   so percent-encoded characters such as `%40` are preserved as-is, #1363
+- `HttpBasicSyncAuth` and `HttpBasicAsyncAuth` now require
+  the `auth_scheme` header prefix, it is `Basic` by default
+  and is matched exactly, credentials sent without it
+  are not accepted anymore, #1330
+- `HttpBasicSyncAuth` and `HttpBasicAsyncAuth` now raise
+  `NotAuthenticatedError` when credentials have the right
+  `auth_scheme` prefix, but cannot be decoded,
+  previously the next auth in the chain was tried, #1330
 
 ### Features
 

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -154,10 +154,13 @@ class _HttpBasicAuth:  # noqa: WPS214
 
     def _get_custom_security_scheme_description(self) -> str:
         """Describe non-standard basic auth header contracts."""
+        # Empty `auth_scheme` means that the header carries
+        # the credentials alone, without a prefix and a space after it.
+        scheme_prefix = f'{self.auth_scheme} ' if self.auth_scheme else ''
         return (
             'HTTP Basic auth via '
             f'`{self.header}` header using '
-            f'`{self.auth_scheme!r} <base64(username:password)>` format'
+            f'`{scheme_prefix}<base64(username:password)>` format'
         )
 
 

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -132,10 +132,7 @@ class _HttpBasicAuth:  # noqa: WPS214
 
     def _uses_standard_http_basic_auth(self) -> bool:
         """Whether the auth contract matches OpenAPI HTTP basic auth."""
-        return (
-            self.header == 'Authorization'
-            and self.auth_scheme == 'Basic'
-        )
+        return self.header == 'Authorization' and self.auth_scheme == 'Basic'
 
     def _get_custom_security_scheme_description(self) -> str:
         """Describe non-standard basic auth header contracts."""

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Final, Self
 
 from typing_extensions import override
 
+from dmr.exceptions import NotAuthenticatedError
 from dmr.openapi.objects import Reference, SecurityRequirement, SecurityScheme
 from dmr.security.base import AsyncAuth, SyncAuth
 
@@ -16,20 +17,32 @@ if TYPE_CHECKING:
 _DEFAULT_BASIC_REALM: Final = 'api'
 
 
-class _HttpBasicAuth:
-    __slots__ = ('header', 'realm', 'security_scheme_name', 'www_authenticate')
+class _HttpBasicAuth:  # noqa: WPS214
+    __slots__ = (
+        'auth_scheme',
+        'header',
+        'realm',
+        'security_scheme_name',
+        'www_authenticate',
+    )
 
-    def __init__(
+    def __init__(  # noqa: WPS211
         self,
         *,
         security_scheme_name: str = 'http_basic',
         header: str = 'Authorization',
+        auth_scheme: str = 'Basic',
         www_authenticate: bool = True,
         realm: str = _DEFAULT_BASIC_REALM,
     ) -> None:
         """
         Apply possible customizations.
 
+        - *security_scheme_name* is the name
+          used in the OpenAPI security scheme map
+        - *header* selects the header to read the credentials from
+        - *auth_scheme* is the prefix that the header value must start with,
+          it is matched exactly, so ``Basic`` won't accept ``basic``
         - *www_authenticate* controls whether ``401`` responses
           advertise this auth in the ``WWW-Authenticate`` header.
           Turn it off to stop browsers from showing
@@ -40,6 +53,7 @@ class _HttpBasicAuth:
         """
         self.security_scheme_name = security_scheme_name
         self.header = header
+        self.auth_scheme = auth_scheme
         self.www_authenticate = www_authenticate
         self.realm = realm
 
@@ -48,8 +62,9 @@ class _HttpBasicAuth:
         """
         Challenge for the ``Basic`` scheme.
 
-        Returns ``None`` for a custom *header*, because a challenge
-        can only ask the client for the ``Authorization`` header.
+        Returns ``None`` for a custom *header* or *auth_scheme*,
+        because a challenge can only ask the client
+        for the ``Basic`` prefix in the ``Authorization`` header.
         """
         if (
             not self.www_authenticate
@@ -91,35 +106,43 @@ class _HttpBasicAuth:
         self,
         controller: 'Controller[BaseSerializer]',
     ) -> tuple[str, str] | None:
+        # We return `None` here, because it might be some other auth.
+        # We don't want to falsely trigger any errors just yet.
         header = controller.request.headers.get(self.header)
         if not header:
             return None
-
-        parts = header.split(' ')
-        if len(parts) == 1:
-            encoded = parts[0]
-        elif len(parts) == 2 and parts[0].lower() == 'basic':
-            encoded = parts[1]
-        else:
+        encoded = self._split_encoded_credentials(header)
+        if encoded is None:
             return None
 
+        # After this point we are sure that these are basic auth credentials.
+        # So, broken ones are an error and not a reason to try other authes.
         try:
             username, password = b64decode(encoded).decode().split(':', 1)
         except Exception:
-            return None
+            raise NotAuthenticatedError from None
         return username, password
+
+    def _split_encoded_credentials(self, header: str) -> str | None:
+        """Splits string like 'Basic credentials' and returns 'credentials'."""
+        parts = header.split(' ')
+        if len(parts) != 2 or parts[0] != self.auth_scheme:
+            return None
+        return parts[1]
 
     def _uses_standard_http_basic_auth(self) -> bool:
         """Whether the auth contract matches OpenAPI HTTP basic auth."""
-        return self.header == 'Authorization'
+        return (
+            self.header == 'Authorization'
+            and self.auth_scheme.casefold() == 'basic'
+        )
 
     def _get_custom_security_scheme_description(self) -> str:
         """Describe non-standard basic auth header contracts."""
         return (
             'HTTP Basic auth via '
             f'`{self.header}` header using '
-            '`<base64(username:password)>` or '
-            '`Basic <base64(username:password)>` format'
+            f'`{self.auth_scheme} <base64(username:password)>` format'
         )
 
 
@@ -142,6 +165,12 @@ class HttpBasicSyncAuth(_HttpBasicAuth, SyncAuth):
 
     See also:
         https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication#basic_authentication_scheme
+
+    .. versionchanged:: 0.15.0
+
+        The ``auth_scheme`` prefix is now required and configurable,
+        it is ``Basic`` by default. Header values without a prefix
+        are not accepted anymore.
 
     """
 
@@ -191,6 +220,12 @@ class HttpBasicAsyncAuth(_HttpBasicAuth, AsyncAuth):
     See also:
         https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication#basic_authentication_scheme
 
+    .. versionchanged:: 0.15.0
+
+        The ``auth_scheme`` prefix is now required and configurable,
+        it is ``Basic`` by default. Header values without a prefix
+        are not accepted anymore.
+
     """
 
     __slots__ = ()
@@ -223,13 +258,16 @@ def basic_auth(username: str, password: str, *, prefix: str = 'Basic ') -> str:
     """
     Return a header value for basic auth for a given *username* and *password*.
 
+    The *prefix* must match the ``auth_scheme`` of the auth class
+    that will read this header, including the trailing space.
+
     .. code:: python
 
       >>> basic_auth('admin', 'pass')
       'Basic YWRtaW46cGFzcw=='
 
-      >>> basic_auth('admin', 'pass', prefix='')
-      'YWRtaW46cGFzcw=='
+      >>> basic_auth('admin', 'pass', prefix='Custom ')
+      'Custom YWRtaW46cGFzcw=='
 
     """
     token = b64encode(f'{username}:{password}'.encode()).decode('utf8')

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -134,7 +134,7 @@ class _HttpBasicAuth:  # noqa: WPS214
         """Whether the auth contract matches OpenAPI HTTP basic auth."""
         return (
             self.header == 'Authorization'
-            and self.auth_scheme.casefold() == 'basic'
+            and self.auth_scheme == 'Basic'
         )
 
     def _get_custom_security_scheme_description(self) -> str:

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -142,7 +142,7 @@ class _HttpBasicAuth:  # noqa: WPS214
         return (
             'HTTP Basic auth via '
             f'`{self.header}` header using '
-            f'`{self.auth_scheme} <base64(username:password)>` format'
+            f'`{self.auth_scheme!r} <base64(username:password)>` format'
         )
 
 

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -18,6 +18,16 @@ _DEFAULT_BASIC_REALM: Final = 'api'
 
 
 class _HttpBasicAuth:  # noqa: WPS214
+    """
+    Shared parts of the sync and async http basic auth.
+
+    .. versionchanged:: 0.15.0
+
+        Added the ``auth_scheme`` prefix, which is required by default.
+        See :class:`HttpBasicSyncAuth` and :class:`HttpBasicAsyncAuth`.
+
+    """
+
     __slots__ = (
         'auth_scheme',
         'header',
@@ -42,7 +52,8 @@ class _HttpBasicAuth:  # noqa: WPS214
           used in the OpenAPI security scheme map
         - *header* selects the header to read the credentials from
         - *auth_scheme* is the prefix that the header value must start with,
-          it is matched exactly, so ``Basic`` won't accept ``basic``
+          it is matched exactly, so ``Basic`` won't accept ``basic``.
+          Pass an empty string to read the credentials without any prefix
         - *www_authenticate* controls whether ``401`` responses
           advertise this auth in the ``WWW-Authenticate`` header.
           Turn it off to stop browsers from showing
@@ -125,8 +136,15 @@ class _HttpBasicAuth:  # noqa: WPS214
 
     def _split_encoded_credentials(self, header: str) -> str | None:
         """Splits string like 'Basic credentials' and returns 'credentials'."""
+        if not self.auth_scheme:  # Empty scheme means "no prefix at all".
+            return header
+
         parts = header.split(' ')
         if len(parts) != 2 or parts[0] != self.auth_scheme:
+            # This header does not belong to us: it can be a header
+            # of any other auth from the chain. Raising here would fail
+            # the whole request and would not let the others even try.
+            # So, we return `None` and the next auth gets its chance.
             return None
         return parts[1]
 
@@ -167,7 +185,7 @@ class HttpBasicSyncAuth(_HttpBasicAuth, SyncAuth):
 
         The ``auth_scheme`` prefix is now required and configurable,
         it is ``Basic`` by default. Header values without a prefix
-        are not accepted anymore.
+        are only accepted with ``auth_scheme=''``.
 
     """
 
@@ -221,7 +239,7 @@ class HttpBasicAsyncAuth(_HttpBasicAuth, AsyncAuth):
 
         The ``auth_scheme`` prefix is now required and configurable,
         it is ``Basic`` by default. Header values without a prefix
-        are not accepted anymore.
+        are only accepted with ``auth_scheme=''``.
 
     """
 

--- a/docs/pages/auth/http-basic.rst
+++ b/docs/pages/auth/http-basic.rst
@@ -48,6 +48,8 @@ Consider using :doc:`jwt` instead.
 Customization
 -------------
 
+.. versionadded:: 0.15.0
+
 You can customize:
 
 - Security scheme name, default: ``http_basic``

--- a/docs/pages/auth/http-basic.rst
+++ b/docs/pages/auth/http-basic.rst
@@ -62,6 +62,9 @@ which is matched exactly. So, with the default settings only
 while ``Authorization: basic <base64(username:password)>``
 and a bare ``Authorization: <base64(username:password)>`` are not.
 
+Pass ``auth_scheme=''`` if you need to read the credentials
+without any prefix at all, this is how older versions worked.
+
 Headers with a different prefix are left to the next auth in the chain.
 But, when the prefix does match and the credentials still cannot be decoded,
 :exc:`~dmr.exceptions.NotAuthenticatedError` is raised right away

--- a/docs/pages/auth/http-basic.rst
+++ b/docs/pages/auth/http-basic.rst
@@ -45,6 +45,27 @@ Any other authentication method will be better than the one above.
 Consider using :doc:`jwt` instead.
 
 
+Customization
+-------------
+
+You can customize:
+
+- Security scheme name, default: ``http_basic``
+- Header name, default: ``Authorization``
+- Header value prefix (``auth_scheme``), default: ``Basic``
+
+The header value must always start with the ``auth_scheme`` prefix,
+which is matched exactly. So, with the default settings only
+``Authorization: Basic <base64(username:password)>`` is accepted,
+while ``Authorization: basic <base64(username:password)>``
+and a bare ``Authorization: <base64(username:password)>`` are not.
+
+Headers with a different prefix are left to the next auth in the chain.
+But, when the prefix does match and the credentials still cannot be decoded,
+:exc:`~dmr.exceptions.NotAuthenticatedError` is raised right away
+and no other auth classes are tried.
+
+
 API Reference
 -------------
 

--- a/docs/pages/auth/http-basic.rst
+++ b/docs/pages/auth/http-basic.rst
@@ -55,6 +55,8 @@ You can customize:
 - Security scheme name, default: ``http_basic``
 - Header name, default: ``Authorization``
 - Header value prefix (``auth_scheme``), default: ``Basic``
+- The ``WWW-Authenticate`` challenge (``www_authenticate`` and ``realm``),
+  see :doc:`common`
 
 The header value must always start with the ``auth_scheme`` prefix,
 which is matched exactly. So, with the default settings only

--- a/tests/test_integration/test_contollers/test_auth.py
+++ b/tests/test_integration/test_contollers/test_auth.py
@@ -64,6 +64,8 @@ def test_invalid_auth(
         'several different words',
         '12345',
         'Bearer dGVzdDpwYXNz',  # correct `test:pass` encoded, but `Bearer`
+        'basic dGVzdDpwYXNz',  # correct, but the scheme casing is wrong
+        'dGVzdDpwYXNz',  # correct, but there is no `Basic` scheme
         # `test@pass` encoded:
         'dGVzdEBwYXNz',
         'Basic dGVzdEBwYXNz',

--- a/tests/test_integration/test_contollers/test_invalid_requests.py
+++ b/tests/test_integration/test_contollers/test_invalid_requests.py
@@ -106,7 +106,7 @@ async def test_parse_headers_ignored_async_content_type(
         headers={
             'Content-Type': 'application/xml',
             'X-API-Token': '123',
-            'Authorization': basic_auth('test', 'pass', prefix=''),
+            'Authorization': basic_auth('test', 'pass'),
         },
     )
 

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -1,3 +1,4 @@
+import json
 from http import HTTPStatus
 from typing import Final, Self, final
 
@@ -13,6 +14,107 @@ from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth, basic_auth
 from dmr.serializer import BaseSerializer
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+
+
+class _SyncAuth(HttpBasicSyncAuth):
+    @override
+    def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        if username == 'test' and password == 'pass':  # noqa: S105
+            return self
+        return None
+
+
+class _AsyncAuth(HttpBasicAsyncAuth):
+    @override
+    async def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        if username == 'test' and password == 'pass':  # noqa: S105
+            return self
+        return None
+
+
+class _SyncController(Controller[PydanticSerializer]):
+    auth = (_SyncAuth(),)
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _AsyncController(Controller[PydanticSerializer]):
+    auth = (_AsyncAuth(),)
+
+    async def get(self) -> str:
+        return 'authed'
+
+
+class _CustomSchemeSyncController(Controller[PydanticSerializer]):
+    auth = (_SyncAuth(auth_scheme='Custom'),)
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _CustomSchemeAsyncController(Controller[PydanticSerializer]):
+    auth = (_AsyncAuth(auth_scheme='Custom'),)
+
+    async def get(self) -> str:
+        return 'authed'
+
+
+#: Header and value that the fallback auth of chained controllers accepts.
+_FALLBACK_HEADER: Final = 'X-Fallback-Auth'
+_FALLBACK_VALUE: Final = basic_auth('test', 'pass')
+
+
+class _ChainedSyncController(Controller[PydanticSerializer]):
+    auth = (
+        _SyncAuth(),
+        _SyncAuth(header=_FALLBACK_HEADER, security_scheme_name='fallback'),
+    )
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _ChainedAsyncController(Controller[PydanticSerializer]):
+    auth = (
+        _AsyncAuth(),
+        _AsyncAuth(header=_FALLBACK_HEADER, security_scheme_name='fallback'),
+    )
+
+    async def get(self) -> str:
+        return 'authed'
+
+
+#: Values that have the right prefix, but cannot be parsed at all.
+_BROKEN_CREDENTIALS: Final = (
+    'Basic not-a-base64',
+    'Basic dGVzdEBwYXNz',  # `test@pass` encoded, missing the `:` separator
+)
+
+#: Values that must not be treated as basic auth credentials.
+_UNSUPPORTED_SCHEMES: Final = (
+    # Credentials without the `auth_scheme` prefix:
+    basic_auth('test', 'pass', prefix=''),
+    # `auth_scheme` is matched exactly, so casing matters:
+    basic_auth('test', 'pass', prefix='basic '),
+    # Some other auth might handle these:
+    basic_auth('test', 'pass', prefix='Bearer '),
+    # Prefix alone and extra parts are not valid either:
+    'Basic',
+    f'{basic_auth("test", "pass")} extra',
+)
 
 
 @pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
@@ -34,6 +136,25 @@ def test_schema(
 
 
 @pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
+@pytest.mark.parametrize('auth_scheme', ['Basic', 'basic', 'BASIC'])
+def test_standard_auth_scheme_schema(
+    *,
+    typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
+    auth_scheme: str,
+) -> None:
+    """Ensures that any casing of `Basic` is a standard http basic auth."""
+    instance = typ(auth_scheme=auth_scheme)
+
+    assert instance.security_schemes == snapshot({
+        'http_basic': SecurityScheme(
+            type='http',
+            description='Http Basic auth',
+            scheme='basic',
+        ),
+    })
+
+
+@pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
 def test_custom_header_schema(
     typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
 ) -> None:
@@ -45,7 +166,6 @@ def test_custom_header_schema(
             type='apiKey',
             description=(
                 'HTTP Basic auth via `X-Api-Auth` header using '
-                '`<base64(username:password)>` or '
                 '`Basic <base64(username:password)>` format'
             ),
             name='X-Api-Auth',
@@ -153,3 +273,212 @@ async def test_async_percent_credentials(
 
     assert isinstance(response, HttpResponse)
     assert response.status_code == status, response.content
+
+
+@pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
+def test_custom_auth_scheme_schema(
+    typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
+) -> None:
+    """Ensures that custom basic auth is documented with the real scheme."""
+    instance = typ(auth_scheme='Custom')
+
+    assert instance.security_schemes == snapshot({
+        'http_basic': SecurityScheme(
+            type='apiKey',
+            description=(
+                'HTTP Basic auth via `Authorization` header using '
+                '`Custom <base64(username:password)>` format'
+            ),
+            name='Authorization',
+            security_scheme_in='header',
+        ),
+    })
+    assert instance.security_requirement == snapshot({'http_basic': []})
+
+
+@pytest.mark.parametrize(
+    ('auth_header', 'status_code'),
+    [
+        (basic_auth('test', 'pass'), HTTPStatus.OK),
+        *[
+            (auth_header, HTTPStatus.UNAUTHORIZED)
+            for auth_header in _UNSUPPORTED_SCHEMES
+        ],
+    ],
+)
+def test_sync_auth_scheme(
+    dmr_rf: DMRRequestFactory,
+    *,
+    auth_header: str,
+    status_code: HTTPStatus,
+) -> None:
+    """Ensures that sync auth requires the exact `Basic` prefix."""
+    request = dmr_rf.get('/whatever/', headers={'Authorization': auth_header})
+
+    response = _SyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status_code, response.content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('auth_header', 'status_code'),
+    [
+        (basic_auth('test', 'pass'), HTTPStatus.OK),
+        *[
+            (auth_header, HTTPStatus.UNAUTHORIZED)
+            for auth_header in _UNSUPPORTED_SCHEMES
+        ],
+    ],
+)
+async def test_async_auth_scheme(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    *,
+    auth_header: str,
+    status_code: HTTPStatus,
+) -> None:
+    """Ensures that async auth requires the exact `Basic` prefix."""
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={'Authorization': auth_header},
+    )
+
+    response = await dmr_async_rf.wrap(_AsyncController.as_view()(request))
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status_code, response.content
+
+
+@pytest.mark.parametrize(
+    ('auth_header', 'status_code'),
+    [
+        (basic_auth('test', 'pass', prefix='Custom '), HTTPStatus.OK),
+        (basic_auth('test', 'pass'), HTTPStatus.UNAUTHORIZED),
+    ],
+)
+def test_sync_custom_auth_scheme(
+    dmr_rf: DMRRequestFactory,
+    *,
+    auth_header: str,
+    status_code: HTTPStatus,
+) -> None:
+    """Ensures that sync auth can require a custom prefix."""
+    request = dmr_rf.get('/whatever/', headers={'Authorization': auth_header})
+
+    response = _CustomSchemeSyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status_code, response.content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('auth_header', 'status_code'),
+    [
+        (basic_auth('test', 'pass', prefix='Custom '), HTTPStatus.OK),
+        (basic_auth('test', 'pass'), HTTPStatus.UNAUTHORIZED),
+    ],
+)
+async def test_async_custom_auth_scheme(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    *,
+    auth_header: str,
+    status_code: HTTPStatus,
+) -> None:
+    """Ensures that async auth can require a custom prefix."""
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={'Authorization': auth_header},
+    )
+
+    response = await dmr_async_rf.wrap(
+        _CustomSchemeAsyncController.as_view()(request),
+    )
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status_code, response.content
+
+
+def test_sync_missing_header_is_skipped(dmr_rf: DMRRequestFactory) -> None:
+    """Ensures that a missing header lets the next sync auth run."""
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={_FALLBACK_HEADER: _FALLBACK_VALUE},
+    )
+
+    response = _ChainedSyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert json.loads(response.content) == 'authed'
+
+
+@pytest.mark.asyncio
+async def test_async_missing_header_is_skipped(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """Ensures that a missing header lets the next async auth run."""
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={_FALLBACK_HEADER: _FALLBACK_VALUE},
+    )
+
+    response = await dmr_async_rf.wrap(
+        _ChainedAsyncController.as_view()(request),
+    )
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert json.loads(response.content) == 'authed'
+
+
+@pytest.mark.parametrize('auth_header', _BROKEN_CREDENTIALS)
+def test_sync_broken_credentials_raise(
+    dmr_rf: DMRRequestFactory,
+    *,
+    auth_header: str,
+) -> None:
+    """Ensures that broken credentials don't fall back to the next sync auth."""
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={
+            'Authorization': auth_header,
+            _FALLBACK_HEADER: _FALLBACK_VALUE,
+        },
+    )
+
+    response = _ChainedSyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('auth_header', _BROKEN_CREDENTIALS)
+async def test_async_broken_credentials_raise(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    *,
+    auth_header: str,
+) -> None:
+    """Ensures that broken credentials don't fall back to the next auth."""
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={
+            'Authorization': auth_header,
+            _FALLBACK_HEADER: _FALLBACK_VALUE,
+        },
+    )
+
+    response = await dmr_async_rf.wrap(
+        _ChainedAsyncController.as_view()(request),
+    )
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED, response.content
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Not authenticated', 'type': 'security'}],
+    })

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -44,77 +44,7 @@ class _AsyncAuth(HttpBasicAsyncAuth):
         return None
 
 
-class _SyncController(Controller[PydanticSerializer]):
-    auth = (_SyncAuth(),)
-
-    def get(self) -> str:
-        return 'authed'
-
-
-class _AsyncController(Controller[PydanticSerializer]):
-    auth = (_AsyncAuth(),)
-
-    async def get(self) -> str:
-        return 'authed'
-
-
-class _CustomSchemeSyncController(Controller[PydanticSerializer]):
-    auth = (_SyncAuth(auth_scheme='Custom'),)
-
-    def get(self) -> str:
-        return 'authed'
-
-
-class _CustomSchemeAsyncController(Controller[PydanticSerializer]):
-    auth = (_AsyncAuth(auth_scheme='Custom'),)
-
-    async def get(self) -> str:
-        return 'authed'
-
-
-#: Header and value that the fallback auth of chained controllers accepts.
-_FALLBACK_HEADER: Final = 'X-Fallback-Auth'
-_FALLBACK_VALUE: Final = basic_auth('test', 'pass')
-
-
-class _ChainedSyncController(Controller[PydanticSerializer]):
-    auth = (
-        _SyncAuth(),
-        _SyncAuth(header=_FALLBACK_HEADER, security_scheme_name='fallback'),
-    )
-
-    def get(self) -> str:
-        return 'authed'
-
-
-class _ChainedAsyncController(Controller[PydanticSerializer]):
-    auth = (
-        _AsyncAuth(),
-        _AsyncAuth(header=_FALLBACK_HEADER, security_scheme_name='fallback'),
-    )
-
-    async def get(self) -> str:
-        return 'authed'
-
-
-#: Values that have the right prefix, but cannot be parsed at all.
-_BROKEN_CREDENTIALS: Final = (
-    'Basic not-a-base64',
-    'Basic dGVzdEBwYXNz',  # `test@pass` encoded, missing the `:` separator
-)
-
-#: Values that must not be treated as basic auth credentials.
-_UNSUPPORTED_SCHEMES: Final = (
-    # Credentials without the `auth_scheme` prefix:
-    basic_auth('test', 'pass', prefix=''),
-    # `auth_scheme` is matched exactly, so casing matters:
-    basic_auth('test', 'pass', prefix='basic '),
-    # Some other auth might handle these:
-    basic_auth('test', 'pass', prefix='Bearer '),
-    # Prefix alone and extra parts are not valid either:
-    'Basic',
-    f'{basic_auth("test", "pass")} extra',
-)
+# Security schemes:
 
 
 @pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
@@ -136,25 +66,6 @@ def test_schema(
 
 
 @pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
-@pytest.mark.parametrize('auth_scheme', ['Basic', 'basic', 'BASIC'])
-def test_standard_auth_scheme_schema(
-    *,
-    typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
-    auth_scheme: str,
-) -> None:
-    """Ensures that any casing of `Basic` is a standard http basic auth."""
-    instance = typ(auth_scheme=auth_scheme)
-
-    assert instance.security_schemes == snapshot({
-        'http_basic': SecurityScheme(
-            type='http',
-            description='Http Basic auth',
-            scheme='basic',
-        ),
-    })
-
-
-@pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
 def test_custom_header_schema(
     typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
 ) -> None:
@@ -166,7 +77,7 @@ def test_custom_header_schema(
             type='apiKey',
             description=(
                 'HTTP Basic auth via `X-Api-Auth` header using '
-                '`Basic <base64(username:password)>` format'
+                "`'Basic' <base64(username:password)>` format"
             ),
             name='X-Api-Auth',
             security_scheme_in='header',
@@ -276,24 +187,82 @@ async def test_async_percent_credentials(
 
 
 @pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
+@pytest.mark.parametrize(
+    ('auth_scheme', 'description'),
+    [
+        (
+            'Custom',
+            (
+                'HTTP Basic auth via `Authorization` header using '
+                "`'Custom' <base64(username:password)>` format"
+            ),
+        ),
+        # `auth_scheme` is matched exactly, so casing matters:
+        (
+            'basic',
+            (
+                'HTTP Basic auth via `Authorization` header using '
+                "`'basic' <base64(username:password)>` format"
+            ),
+        ),
+        # Empty scheme reads the credentials without any prefix:
+        (
+            '',
+            (
+                'HTTP Basic auth via `Authorization` header using '
+                "`'' <base64(username:password)>` format"
+            ),
+        ),
+    ],
+)
 def test_custom_auth_scheme_schema(
     typ: type[HttpBasicSyncAuth] | type[HttpBasicAsyncAuth],
+    *,
+    auth_scheme: str,
+    description: str,
 ) -> None:
-    """Ensures that custom basic auth is documented with the real scheme."""
-    instance = typ(auth_scheme='Custom')
+    """Ensures that a non-standard scheme is documented with its real value."""
+    instance = typ(auth_scheme=auth_scheme)
 
-    assert instance.security_schemes == snapshot({
+    assert instance.security_schemes == {
         'http_basic': SecurityScheme(
             type='apiKey',
-            description=(
-                'HTTP Basic auth via `Authorization` header using '
-                '`Custom <base64(username:password)>` format'
-            ),
+            description=description,
             name='Authorization',
             security_scheme_in='header',
         ),
-    })
-    assert instance.security_requirement == snapshot({'http_basic': []})
+    }
+    assert instance.security_requirement == {'http_basic': []}
+
+
+# Default `Basic` scheme:
+
+#: Values that must not be treated as basic auth credentials.
+_UNSUPPORTED_SCHEMES: Final = (
+    # Credentials without the `auth_scheme` prefix:
+    basic_auth('test', 'pass', prefix=''),
+    # `auth_scheme` is matched exactly, so casing matters:
+    basic_auth('test', 'pass', prefix='basic '),
+    # Some other auth might handle these:
+    basic_auth('test', 'pass', prefix='Bearer '),
+    # Prefix alone and extra parts are not valid either:
+    'Basic',
+    f'{basic_auth("test", "pass")} extra',
+)
+
+
+class _SyncController(Controller[PydanticSerializer]):
+    auth = (_SyncAuth(),)
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _AsyncController(Controller[PydanticSerializer]):
+    auth = (_AsyncAuth(),)
+
+    async def get(self) -> str:
+        return 'authed'
 
 
 @pytest.mark.parametrize(
@@ -354,6 +323,23 @@ async def test_async_auth_scheme(
     assert response.status_code == status_code, response.content
 
 
+# Custom scheme:
+
+
+class _CustomSchemeSyncController(Controller[PydanticSerializer]):
+    auth = (_SyncAuth(auth_scheme='Custom'),)
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _CustomSchemeAsyncController(Controller[PydanticSerializer]):
+    auth = (_AsyncAuth(auth_scheme='Custom'),)
+
+    async def get(self) -> str:
+        return 'authed'
+
+
 @pytest.mark.parametrize(
     ('auth_header', 'status_code'),
     [
@@ -402,6 +388,108 @@ async def test_async_custom_auth_scheme(
 
     assert isinstance(response, HttpResponse)
     assert response.status_code == status_code, response.content
+
+
+# Empty scheme, the pre-0.15.0 prefixless contract:
+
+
+class _EmptySchemeSyncController(Controller[PydanticSerializer]):
+    auth = (_SyncAuth(auth_scheme=''),)
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _EmptySchemeAsyncController(Controller[PydanticSerializer]):
+    auth = (_AsyncAuth(auth_scheme=''),)
+
+    async def get(self) -> str:
+        return 'authed'
+
+
+@pytest.mark.parametrize(
+    ('auth_header', 'status_code'),
+    [
+        (basic_auth('test', 'pass', prefix=''), HTTPStatus.OK),
+        # The whole value is the credentials now, so a prefix breaks it:
+        (basic_auth('test', 'pass'), HTTPStatus.UNAUTHORIZED),
+    ],
+)
+def test_sync_empty_auth_scheme(
+    dmr_rf: DMRRequestFactory,
+    *,
+    auth_header: str,
+    status_code: HTTPStatus,
+) -> None:
+    """Ensures that sync auth can read credentials without a prefix."""
+    request = dmr_rf.get('/whatever/', headers={'Authorization': auth_header})
+
+    response = _EmptySchemeSyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status_code, response.content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('auth_header', 'status_code'),
+    [
+        (basic_auth('test', 'pass', prefix=''), HTTPStatus.OK),
+        # The whole value is the credentials now, so a prefix breaks it:
+        (basic_auth('test', 'pass'), HTTPStatus.UNAUTHORIZED),
+    ],
+)
+async def test_async_empty_auth_scheme(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    *,
+    auth_header: str,
+    status_code: HTTPStatus,
+) -> None:
+    """Ensures that async auth can read credentials without a prefix."""
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={'Authorization': auth_header},
+    )
+
+    response = await dmr_async_rf.wrap(
+        _EmptySchemeAsyncController.as_view()(request),
+    )
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status_code, response.content
+
+
+# Auth chains:
+
+#: Header and value that the fallback auth of chained controllers accepts.
+_FALLBACK_HEADER: Final = 'X-Fallback-Auth'
+_FALLBACK_VALUE: Final = basic_auth('test', 'pass')
+
+#: Values that have the right prefix, but cannot be parsed at all.
+_BROKEN_CREDENTIALS: Final = (
+    'Basic not-a-base64',
+    'Basic dGVzdEBwYXNz',  # `test@pass` encoded, missing the `:` separator
+)
+
+
+class _ChainedSyncController(Controller[PydanticSerializer]):
+    auth = (
+        _SyncAuth(),
+        _SyncAuth(header=_FALLBACK_HEADER, security_scheme_name='fallback'),
+    )
+
+    def get(self) -> str:
+        return 'authed'
+
+
+class _ChainedAsyncController(Controller[PydanticSerializer]):
+    auth = (
+        _AsyncAuth(),
+        _AsyncAuth(header=_FALLBACK_HEADER, security_scheme_name='fallback'),
+    )
+
+    async def get(self) -> str:
+        return 'authed'
 
 
 def test_sync_missing_header_is_skipped(dmr_rf: DMRRequestFactory) -> None:

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -300,6 +300,8 @@ def test_custom_auth_scheme_schema(
     ('auth_header', 'status_code'),
     [
         (basic_auth('test', 'pass'), HTTPStatus.OK),
+        # Right scheme, but the credentials are wrong:
+        (basic_auth('test', 'wrong'), HTTPStatus.UNAUTHORIZED),
         *[
             (auth_header, HTTPStatus.UNAUTHORIZED)
             for auth_header in _UNSUPPORTED_SCHEMES
@@ -312,7 +314,7 @@ def test_sync_auth_scheme(
     auth_header: str,
     status_code: HTTPStatus,
 ) -> None:
-    """Ensures that sync auth requires the exact `Basic` prefix."""
+    """Ensures that sync auth only accepts the exact `Basic` prefix."""
     request = dmr_rf.get('/whatever/', headers={'Authorization': auth_header})
 
     response = _SyncController.as_view()(request)
@@ -326,6 +328,8 @@ def test_sync_auth_scheme(
     ('auth_header', 'status_code'),
     [
         (basic_auth('test', 'pass'), HTTPStatus.OK),
+        # Right scheme, but the credentials are wrong:
+        (basic_auth('test', 'wrong'), HTTPStatus.UNAUTHORIZED),
         *[
             (auth_header, HTTPStatus.UNAUTHORIZED)
             for auth_header in _UNSUPPORTED_SCHEMES
@@ -338,7 +342,7 @@ async def test_async_auth_scheme(
     auth_header: str,
     status_code: HTTPStatus,
 ) -> None:
-    """Ensures that async auth requires the exact `Basic` prefix."""
+    """Ensures that async auth only accepts the exact `Basic` prefix."""
     request = dmr_async_rf.get(
         '/whatever/',
         headers={'Authorization': auth_header},

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -77,7 +77,7 @@ def test_custom_header_schema(
             type='apiKey',
             description=(
                 'HTTP Basic auth via `X-Api-Auth` header using '
-                "`'Basic' <base64(username:password)>` format"
+                '`Basic <base64(username:password)>` format'
             ),
             name='X-Api-Auth',
             security_scheme_in='header',
@@ -194,7 +194,7 @@ async def test_async_percent_credentials(
             'Custom',
             (
                 'HTTP Basic auth via `Authorization` header using '
-                "`'Custom' <base64(username:password)>` format"
+                '`Custom <base64(username:password)>` format'
             ),
         ),
         # `auth_scheme` is matched exactly, so casing matters:
@@ -202,7 +202,7 @@ async def test_async_percent_credentials(
             'basic',
             (
                 'HTTP Basic auth via `Authorization` header using '
-                "`'basic' <base64(username:password)>` format"
+                '`basic <base64(username:password)>` format'
             ),
         ),
         # Empty scheme reads the credentials without any prefix:
@@ -210,7 +210,7 @@ async def test_async_percent_credentials(
             '',
             (
                 'HTTP Basic auth via `Authorization` header using '
-                "`'' <base64(username:password)>` format"
+                '`<base64(username:password)>` format'
             ),
         ),
     ],


### PR DESCRIPTION
# I have made things!
**`dmr/security/http.py`**

- `_HttpBasicAuth.__init__` gains `auth_scheme: str = 'Basic'` (new slot), documented alongside `header` and `security_scheme_name`.
- New `_split_encoded_credentials()` mirrors JWT's `split_encoded_token`: the value must be exactly two space-separated parts and `parts[0]` must equal `auth_scheme`. A bare `<base64>` value is no longer accepted.
- `dmr/security/http.py:82-85`: once the prefix matches, an undecodable payload now `raise NotAuthenticatedError from None` instead of returning `None` — so it fails the request immediately and does not fall through to the next auth in the chain.
- `_uses_standard_http_basic_auth()` additionally requires `auth_scheme.casefold() == 'basic'`, so a custom scheme is emitted as an `apiKey` scheme; the OpenAPI description is now `` `{auth_scheme} <base64(username:password)>` format `` (the "or bare value" alternative is gone).
- `basic_auth()` is unchanged in behaviour; its second doctest switched from `prefix=''` to `prefix='Custom '`, and it notes that `prefix` must match the reader's `auth_scheme`.

**Tests** — `tests/test_unit/test_security/test_http_basic_auth.py` grew from 2 to 15 tests (sync + async): scheme/case-insensitive-`basic` schema, custom-header and custom-scheme schema, accepted vs rejected header values (no prefix, `basic`, `Bearer`, prefix-only, extra parts), and two chained-auth tests that pin the new raise semantics — a missing header still falls through to a second auth (200), while broken credentials with the right prefix return 401 even though the fallback auth would have succeeded. Integration: added `'basic dGVzdDpwYXNz'` and `'dGVzdDpwYXNz'` to the rejected headers in `tests/test_integration/test_contollers/test_auth.py:64-69`, and `tests/test_integration/test_contollers/test_invalid_requests.py:109` no longer uses `prefix=''`.

**Docs/changelog** — new "Customization" section in `docs/pages/auth/http-basic.rst:48-67`, `.. versionchanged:: 0.15.0` on both classes, two breaking-change entries in `CHANGELOG.md:30-37`.
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1330
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
