### PR TITLE
Fix HTTP basic auth URL decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ of requirements for an API to count as public.
 - `JWToken` does not validate `exp` and `iat` on creation anymore,
   now `JWToken.encode` validates them instead, #1324
 - Throttling cache keys are now hashed to keep their length bounded, #1337
+- HTTP Basic Auth credentials are no longer URL-decoded,
+  so percent-encoded characters such as `%40` are preserved as-is, #1363
 
 ### Features
 

--- a/dmr/security/http.py
+++ b/dmr/security/http.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 from base64 import b64decode, b64encode
 from typing import TYPE_CHECKING, Final, Self
-from urllib.parse import unquote
 
 from typing_extensions import override
 
@@ -108,7 +107,7 @@ class _HttpBasicAuth:
             username, password = b64decode(encoded).decode().split(':', 1)
         except Exception:
             return None
-        return unquote(username), unquote(password)
+        return username, password
 
     def _uses_standard_http_basic_auth(self) -> bool:
         """Whether the auth contract matches OpenAPI HTTP basic auth."""

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -1,8 +1,18 @@
-import pytest
-from inline_snapshot import snapshot
+from http import HTTPStatus
+from typing import Final, Self, final
 
+import pytest
+from django.http import HttpResponse
+from inline_snapshot import snapshot
+from typing_extensions import override
+
+from dmr import Controller
+from dmr.endpoint import Endpoint
 from dmr.openapi.objects import SecurityScheme
-from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.security.http import HttpBasicAsyncAuth, HttpBasicSyncAuth, basic_auth
+from dmr.serializer import BaseSerializer
+from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 
 
 @pytest.mark.parametrize('typ', [HttpBasicSyncAuth, HttpBasicAsyncAuth])
@@ -43,3 +53,103 @@ def test_custom_header_schema(
         ),
     })
     assert instance.security_requirement == snapshot({'http_basic': []})
+
+
+_USERNAME: Final = 'user%40name'
+_PASSWORD: Final = 'pass%3Aword'
+
+_CREDENTIALS: Final = (
+    ((_USERNAME, _PASSWORD), HTTPStatus.OK),
+    (('user@name', _PASSWORD), HTTPStatus.UNAUTHORIZED),
+    ((_USERNAME, 'pass:word'), HTTPStatus.UNAUTHORIZED),
+    (('user@name', 'pass:word'), HTTPStatus.UNAUTHORIZED),
+)
+
+
+class _SyncPercentAuth(HttpBasicSyncAuth):
+    __slots__ = ()
+
+    @override
+    def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        if (username, password) == (_USERNAME, _PASSWORD):
+            return self
+        return None
+
+
+class _AsyncPercentAuth(HttpBasicAsyncAuth):
+    __slots__ = ()
+
+    @override
+    async def authenticate(
+        self,
+        endpoint: Endpoint,
+        controller: Controller[BaseSerializer],
+        username: str,
+        password: str,
+    ) -> Self | None:
+        if (username, password) == (_USERNAME, _PASSWORD):
+            return self
+        return None
+
+
+@final
+class _SyncPercentController(Controller[PydanticSerializer]):
+    auth = (_SyncPercentAuth(),)
+
+    def get(self) -> str:
+        return 'authed'
+
+
+@final
+class _AsyncPercentController(Controller[PydanticSerializer]):
+    auth = (_AsyncPercentAuth(),)
+
+    async def get(self) -> str:
+        return 'authed'
+
+
+@pytest.mark.parametrize(('credentials', 'status'), _CREDENTIALS)
+def test_sync_percent_credentials(
+    dmr_rf: DMRRequestFactory,
+    *,
+    credentials: tuple[str, str],
+    status: HTTPStatus,
+) -> None:
+    """Ensures that sync auth never url-decodes the given credentials."""
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={'Authorization': basic_auth(*credentials)},
+    )
+
+    response = _SyncPercentController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status, response.content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(('credentials', 'status'), _CREDENTIALS)
+async def test_async_percent_credentials(
+    dmr_async_rf: DMRAsyncRequestFactory,
+    *,
+    credentials: tuple[str, str],
+    status: HTTPStatus,
+) -> None:
+    """Ensures that async auth never url-decodes the given credentials."""
+    request = dmr_async_rf.get(
+        '/whatever/',
+        headers={'Authorization': basic_auth(*credentials)},
+    )
+
+    response = await dmr_async_rf.wrap(
+        _AsyncPercentController.as_view()(request),
+    )
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == status, response.content

--- a/tests/test_unit/test_security/test_http_basic_auth.py
+++ b/tests/test_unit/test_security/test_http_basic_auth.py
@@ -56,7 +56,7 @@ def test_custom_header_schema(
 
 
 _USERNAME: Final = 'user%40name'
-_PASSWORD: Final = 'pass%3Aword'
+_PASSWORD: Final = 'pass%3Aword'  # noqa: S105
 
 _CREDENTIALS: Final = (
     ((_USERNAME, _PASSWORD), HTTPStatus.OK),


### PR DESCRIPTION
# I have made things!

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

- Closes #1331