### PR TITLE
Document safe usage of `RedirectTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ of requirements for an API to count as public.
 ### Misc
 
 - Fixes AI docs and plugin install instructions, #1311
+- Documented safe use of user-provided redirect targets with `RedirectTo`,
+  #1326
 - Added `dmr-from-dj-rest-auth` agent skill to migrate `dj-rest-auth`
   installations to `django-modern-rest` and `django-allauth` headless, #1193
 

--- a/docs/examples/using_controller/redirect_safe.py
+++ b/docs/examples/using_controller/redirect_safe.py
@@ -1,0 +1,15 @@
+from typing import Never
+
+from django.http import HttpRequest
+from django.utils.http import url_has_allowed_host_and_scheme
+
+from dmr import RedirectTo
+
+
+def redirect_to_next(request: HttpRequest, next_url: str) -> Never:
+    url_is_safe = url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    )
+    raise RedirectTo(next_url if url_is_safe else '/')

--- a/docs/pages/using-controller/redirects.rst
+++ b/docs/pages/using-controller/redirects.rst
@@ -30,6 +30,25 @@ together with :func:`~dmr.endpoint.validate`:
 Note that in both cases you would need to document ``Location`` header
 in a response spec.
 
+.. warning::
+
+  :class:`~dmr.response.RedirectTo` accepts absolute and protocol-relative
+  URLs, such as ``https://example.com/path`` and ``//example.com/path``.
+  It validates the URL length and scheme, but does not check whether the
+  destination host is trusted.
+  Do not pass user-provided redirect targets to it without validation,
+  because this can create an open redirect vulnerability.
+
+  Use Django's
+  `url_has_allowed_host_and_scheme <https://github.com/django/django/blob/73cc09f14f13fedddc14d6ba5b287cb33c24e4a4/django/utils/http.py#L274>`_
+  helper to check untrusted redirect targets against the expected hosts
+  and protocol:
+
+  .. literalinclude:: /examples/using_controller/redirect_safe.py
+    :caption: views.py
+    :language: python
+    :linenos:
+
 
 API Reference
 -------------


### PR DESCRIPTION
`RedirectTo` validates a URL's length and scheme, but does not check whether its destination host is trusted. As a result, passing user-provided protocol-relative URLs such as `//evil.example/x` can cause an open redirect.

  This PR documents the risk and adds an example using Django's `url_has_allowed_host_and_scheme`. The example falls back to `/` when validation fails.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1326

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
