### PR TITLE
Document safe RedirectTo usage in DMR skill, #1367

### DIFF
--- a/.agents/skills/dmr/SKILL.md
+++ b/.agents/skills/dmr/SKILL.md
@@ -314,6 +314,69 @@ Docs: https://django-modern-rest.readthedocs.io/en/latest/pages/error-handling.h
 
 ## Redirects
 
+### Choose a redirect compatible with the endpoint style
+
+Raise `RedirectTo` from `@modify` endpoints, because they cannot return
+`HttpResponse` subclasses. `@validate` endpoints support both raising
+`RedirectTo` and returning Django's `HttpResponseRedirect` equally. Returning
+`HttpResponseRedirect` from `@validate` is an exception to the general rule
+against returning Django responses directly.
+
+Whichever redirect style you use, document the `Location` header in its
+`ResponseSpec`. For `@modify`, add the spec to `extra_responses`; for
+`@validate`, pass the spec directly:
+
+```python
+from http import HTTPStatus
+from typing import Final
+
+from django.http import HttpResponse, HttpResponseRedirect
+
+from dmr import (
+    Controller,
+    HeaderSpec,
+    RedirectTo,
+    ResponseSpec,
+    modify,
+    validate,
+)
+from dmr.plugins.msgspec import MsgspecSerializer
+
+_REDIRECT_SPEC: Final = ResponseSpec(
+    None,
+    status_code=HTTPStatus.FOUND,
+    headers={'Location': HeaderSpec()},
+)
+
+
+class UserController(Controller[MsgspecSerializer]):
+    @modify(extra_responses=[_REDIRECT_SPEC])
+    def get(self) -> str:
+        raise RedirectTo(
+            '/api/new/users/',
+            status_code=HTTPStatus.FOUND,
+        )
+
+    @validate(_REDIRECT_SPEC)
+    def post(self) -> HttpResponse:
+        raise RedirectTo(
+            '/api/new/users/',
+            status_code=HTTPStatus.FOUND,
+        )
+
+    @validate(_REDIRECT_SPEC)
+    def put(self) -> HttpResponseRedirect:
+        return HttpResponseRedirect(
+            '/api/new/users/',
+            content_type='application/json',
+        )
+```
+
+Select the redirect status code according to the
+[Redirection 3xx section of the HTTP Semantics specification][http-redirects].
+
+[http-redirects]: https://www.rfc-editor.org/rfc/rfc9110.html#name-redirection-3xx
+
 ### Validate user-provided URLs before passing them to `RedirectTo`
 
 `RedirectTo` validates a URL's length and scheme, but does not check whether

--- a/.agents/skills/dmr/SKILL.md
+++ b/.agents/skills/dmr/SKILL.md
@@ -312,6 +312,52 @@ You can also use `self.to_error` when using `@validate` endpoints.
 Docs: https://django-modern-rest.readthedocs.io/en/latest/pages/error-handling.html
 
 
+## Redirects
+
+### Validate user-provided URLs before passing them to `RedirectTo`
+
+`RedirectTo` validates a URL's length and scheme, but does not check whether
+the destination host is trusted. Passing an untrusted URL directly can create
+an open redirect vulnerability.
+
+Wrong:
+
+```python
+from typing import Never
+
+from dmr import RedirectTo
+
+
+def redirect_to_next(next_url: str) -> Never:
+    raise RedirectTo(next_url)
+```
+
+Correct:
+
+```python
+from typing import Never
+
+from django.http import HttpRequest
+from django.utils.http import url_has_allowed_host_and_scheme
+
+from dmr import RedirectTo
+
+
+def redirect_to_next(request: HttpRequest, next_url: str) -> Never:
+    url_is_safe = url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    )
+    raise RedirectTo(next_url if url_is_safe else '/')
+```
+
+**Limitations:** validation is required for user-provided or otherwise
+untrusted redirect targets; hard-coded local URLs do not need this check.
+
+Docs: https://django-modern-rest.readthedocs.io/en/latest/pages/using-controller/redirects.html
+
+
 ## Routing
 
 ### Use `dmr.routing.path` instead of `django.urls.path`


### PR DESCRIPTION
Follow-up to #1365, as suggested by @sobolevn.

  The `/dmr` agent skill now explains that `RedirectTo` validates a URL's length and scheme, but does not check whether the destination host is trusted. Passing user-provided URLs, including protocol-relative URLs such as `//evil.example/x`, can therefore cause an open redirect.

  This PR adds a redirects section recommending that user-provided redirect targets be checked with Django's `url_has_allowed_host_and_scheme`, with a safe local fallback when validation fails.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1367 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
