### PR TITLE
Raise `JWTokenError` from `JWToken.encode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ of requirements for an API to count as public.
   it is only used by `JWToken.decode` now, #1324
 - `JWToken` does not validate `exp` and `iat` on creation anymore,
   now `JWToken.encode` validates them instead, #1324
+- `JWToken.encode` and `JWToken.validate_issued_claims` now raise
+  `JWTokenError` instead of `InternalServerError` and `ValueError`,
+  because a token can be created far away from any request,
+  views that we ship still return `500`, #1364
 
 ### Features
 
@@ -53,12 +57,17 @@ of requirements for an API to count as public.
   file schema from the parser, #1278
 - Added `JWToken.validate_issued_claims` method to customize
   the checks we run before signing a token, #1324
+- Added `JWTokenError` raised by `JWToken.encode`,
+  it is a `ValueError` subclass and it keeps the original
+  error as its `__cause__`, #1364
 - Added `security.NO_STORE_HEADERS`, all auth views we ship now
   return the `Cache-Control: no-store` header
   and document it in the OpenAPI schema, #1335
 
 ### Bugfixes
 
+- Fixed `JWToken.encode` raising a bare `TypeError`
+  when `extras` cannot be serialized to json, #1364
 - Added missing `@sensitive_variables` decorator to all auth views,
   so credentials and tokens are hidden
   in error reporting middlewares and logs, #1323

--- a/dmr/security/jwt/__init__.py
+++ b/dmr/security/jwt/__init__.py
@@ -21,3 +21,4 @@ from dmr.security.jwt.auth import request_jwt as request_jwt
 from dmr.security.jwt.cookie import CookieJWTAsyncAuth as CookieJWTAsyncAuth
 from dmr.security.jwt.cookie import CookieJWTSyncAuth as CookieJWTSyncAuth
 from dmr.security.jwt.token import JWToken as JWToken
+from dmr.security.jwt.token import JWTokenError as JWTokenError

--- a/dmr/security/jwt/token.py
+++ b/dmr/security/jwt/token.py
@@ -30,12 +30,35 @@
 import datetime as dt
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, Self
+from typing import Any, Self, final
 
 import jwt
 from jwt.types import Options
 
-from dmr.exceptions import InternalServerError, NotAuthenticatedError
+from dmr.exceptions import NotAuthenticatedError
+
+
+@final
+class JWTokenError(ValueError):
+    """
+    Raised when a token cannot be created or encoded.
+
+    This is a semantic error about the token itself: its claims,
+    the signing algorithm, or the key. It is not an HTTP error,
+    because tokens are regularly created outside of any request:
+    in management commands, background tasks, and scripts.
+
+    We subclass :exc:`ValueError`, because it always means
+    that some value we were given is wrong.
+
+    Views that we ship convert it
+    into :exc:`dmr.exceptions.InternalServerError`,
+    since a token that our own server cannot sign
+    is a server-side problem.
+
+    .. versionadded:: 0.15.0
+
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,7 +105,7 @@ class JWToken:  # noqa: WPS214
     def __post_init__(self) -> None:
         """Normalizes datetime claims and runs extra validation."""
         if len(self.sub) < 1:
-            raise ValueError(
+            raise JWTokenError(
                 'sub must be a string with a length greater than 0',
             )
 
@@ -97,16 +120,16 @@ class JWToken:  # noqa: WPS214
         the checks that we run before signing a token.
 
         Raises:
-            ValueError: If this token cannot be issued right now.
+            JWTokenError: If this token cannot be issued right now.
 
         .. versionadded:: 0.15.0
 
         """
         now = _normalize_datetime(dt.datetime.now(dt.UTC)).timestamp()
         if self.exp.timestamp() < now:
-            raise ValueError('exp value must be a datetime in the future')
+            raise JWTokenError('exp value must be a datetime in the future')
         if self.iat.timestamp() > now:
-            raise ValueError('iat must be a current or past time')
+            raise JWTokenError('iat must be a current or past time')
 
     def encode(
         self,
@@ -127,14 +150,21 @@ class JWToken:  # noqa: WPS214
             An encoded token string.
 
         Raises:
-            ValueError: If this token cannot be issued right now.
-            InternalServerError: If encoding fails.
+            JWTokenError: If this token cannot be issued or signed:
+                its claims, the algorithm, or the key are wrong.
 
         .. versionchanged:: 0.15.0
 
             ``exp`` and ``iat`` are validated here
             via :meth:`validate_issued_claims`,
             previously it was done during the instance creation.
+
+            Every failure now raises :exc:`JWTokenError`
+            and keeps the original error as its ``__cause__``.
+            Previously bad algorithms and keys
+            raised :exc:`dmr.exceptions.InternalServerError`,
+            while payloads that cannot be serialized
+            raised a bare :exc:`TypeError`.
 
         """
         self.validate_issued_claims()
@@ -149,8 +179,12 @@ class JWToken:  # noqa: WPS214
                 algorithm=algorithm,
                 headers=headers,
             )
-        except (jwt.exceptions.PyJWTError, NotImplementedError):
-            raise InternalServerError('Failed to encode token') from None
+        except (
+            jwt.exceptions.PyJWTError,
+            NotImplementedError,
+            TypeError,
+        ) as exc:
+            raise JWTokenError('Failed to encode token') from exc
 
     @classmethod
     def decode_payload(  # noqa: WPS211

--- a/dmr/security/jwt/views.py
+++ b/dmr/security/jwt/views.py
@@ -18,10 +18,10 @@ from typing_extensions import TypedDict
 from dmr import Body, Controller, ResponseSpec, modify
 from dmr.decorators import endpoint_decorator
 from dmr.errors import ErrorModel
-from dmr.exceptions import NotAuthenticatedError
+from dmr.exceptions import InternalServerError, NotAuthenticatedError
 from dmr.security.base import NO_STORE_HEADERS
 from dmr.security.jwt.auth import USER_LOOKUP_ERRORS, set_request_attrs
-from dmr.security.jwt.token import JWToken
+from dmr.security.jwt.token import JWToken, JWTokenError
 from dmr.serializer import BaseSerializer
 
 _ObtainTokensT = TypeVar('_ObtainTokensT', bound=Mapping[str, Any])
@@ -91,19 +91,38 @@ class _BaseTokenController(
         algorithm: str | None = None,
         token_headers: dict[str, Any] | None = None,
     ) -> str:
-        """Create correct jwt token of a given *expiration* and *token_type*."""
-        return self.jwt_token_cls(
+        """
+        Create correct jwt token of a given *expiration* and *token_type*.
+
+        Raises:
+            InternalServerError: If the token cannot be signed,
+                because here it always means that this server
+                is configured incorrectly.
+
+        .. versionchanged:: 0.15.0
+
+            Converts :exc:`dmr.security.jwt.token.JWTokenError`
+            into :exc:`dmr.exceptions.InternalServerError`,
+            previously :meth:`dmr.security.jwt.token.JWToken.encode`
+            raised it on its own.
+
+        """
+        token = self.jwt_token_cls(
             sub=subject or str(self.request.user.pk),
             exp=expiration or (dt.datetime.now(dt.UTC) + self.jwt_expiration),
             iss=issuer or self.jwt_issuer,
             aud=audiences or self.jwt_audiences,
             jti=jwt_id or self.make_jwt_id(),
             extras={'type': token_type} if token_type else {},
-        ).encode(
-            secret=secret or self.jwt_secret or settings.SECRET_KEY,
-            algorithm=algorithm or self.jwt_algorithm,
-            headers=token_headers,
         )
+        try:
+            return token.encode(
+                secret=secret or self.jwt_secret or settings.SECRET_KEY,
+                algorithm=algorithm or self.jwt_algorithm,
+                headers=token_headers,
+            )
+        except JWTokenError as exc:
+            raise InternalServerError('Failed to encode token') from exc
 
     def make_jwt_id(self) -> str | None:
         """Create unique token's jwt id."""
@@ -133,7 +152,7 @@ class ObtainTokensSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -211,7 +230,7 @@ class ObtainTokensAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -313,7 +332,7 @@ class RefreshTokenSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -393,7 +412,7 @@ class RefreshTokenAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -505,7 +524,7 @@ class VerifyTokenSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -577,7 +596,7 @@ class VerifyTokenAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,

--- a/docs/pages/auth/jwt.rst
+++ b/docs/pages/auth/jwt.rst
@@ -383,6 +383,10 @@ API Reference
 .. autoclass:: dmr.security.jwt.token.JWToken
   :members:
 
+.. autoexception:: dmr.security.jwt.token.JWTokenError
+  :members:
+  :show-inheritance:
+
 .. autoclass:: dmr.security.jwt.auth.HeaderJWTSyncAuth
   :members:
   :inherited-members:

--- a/tests/test_unit/test_security/test_jwt/test_jwt_broken_encoding.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_broken_encoding.py
@@ -1,0 +1,77 @@
+from collections.abc import Sequence
+from http import HTTPStatus
+from typing import ClassVar
+
+import pytest
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+from typing_extensions import override
+
+from dmr import ResponseSpec
+from dmr.errors import ErrorModel
+from dmr.plugins.pydantic import PydanticFastSerializer
+from dmr.security.jwt.views import (
+    ObtainTokensPayload,
+    ObtainTokensResponse,
+    ObtainTokensSyncController,
+)
+from dmr.test import DMRRequestFactory
+
+
+class _BrokenAlgorithmController(
+    ObtainTokensSyncController[
+        PydanticFastSerializer,
+        ObtainTokensPayload,
+        ObtainTokensResponse,
+    ],
+):
+    # There is no such algorithm, `pyjwt` will refuse to sign the token:
+    jwt_algorithm = 'nope'
+
+    # The views we ship don't declare `500` themselves,
+    # and response validation only allows declared status codes:
+    responses: ClassVar[Sequence[ResponseSpec]] = (
+        *ObtainTokensSyncController.responses,
+        ResponseSpec(
+            return_type=ErrorModel,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        ),
+    )
+
+    @override
+    def convert_auth_payload(
+        self,
+        payload: ObtainTokensPayload,
+    ) -> ObtainTokensPayload:
+        return payload
+
+    @override
+    def make_api_response(self) -> ObtainTokensResponse:
+        return {
+            'access_token': self.create_jwt_token(
+                token_type='access',  # noqa: S106
+            ),
+            'refresh_token': self.create_jwt_token(
+                token_type='refresh',  # noqa: S106
+            ),
+        }
+
+
+@pytest.mark.django_db
+def test_token_we_cannot_sign_is_a_server_error(
+    dmr_rf: DMRRequestFactory,
+    admin_user: User,
+) -> None:
+    """Ensures that views convert `JWTokenError` into a `500` response."""
+    request = dmr_rf.post(
+        '/whatever/',
+        data={'username': admin_user.username, 'password': 'password'},
+        content_type='application/json',
+    )
+
+    response = _BrokenAlgorithmController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+        response.content
+    )

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -13,8 +13,8 @@ import pytest
 from faker import Faker
 from typing_extensions import TypedDict, override
 
-from dmr.exceptions import InternalServerError, NotAuthenticatedError
-from dmr.security.jwt import JWToken
+from dmr.exceptions import NotAuthenticatedError
+from dmr.security.jwt import JWToken, JWTokenError
 
 #: Clock error in seconds that we allow in tests below.
 _LEEWAY: Final = 30
@@ -70,7 +70,7 @@ def test_token_roundtrip(
 def test_empty_token() -> None:
     """Ensures that we can't create an empty token."""
     exp = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
-    with pytest.raises(ValueError, match='a length greater than 0'):
+    with pytest.raises(JWTokenError, match='a length greater than 0'):
         JWToken('', exp)
 
 
@@ -84,14 +84,14 @@ def test_empty_token() -> None:
 )
 def test_exp_in_the_past(exp: dt.datetime) -> None:
     """Ensures that we can't issue a token with an exp date in the past."""
-    with pytest.raises(ValueError, match='datetime in the future'):
+    with pytest.raises(JWTokenError, match='datetime in the future'):
         JWToken('a', exp).encode(secrets.token_hex(), 'HS256')
 
 
 def test_iat_in_the_past() -> None:
     """Ensures that we can't issue a token with an iat date in the future."""
     exp = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
-    with pytest.raises(ValueError, match='current or past time'):
+    with pytest.raises(JWTokenError, match='current or past time'):
         JWToken('a', exp, iat=exp).encode(secrets.token_hex(), 'HS256')
 
 
@@ -197,11 +197,40 @@ def test_encode_validation(
     secret: str,
 ) -> None:
     """Ensures that incorrect combination of algorithm and secret raises."""
-    with pytest.raises(InternalServerError):
+    with pytest.raises(JWTokenError):
         JWToken(
             sub='123',
             exp=(dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)),
         ).encode(algorithm=algorithm, secret=secret)
+
+
+def test_encode_keeps_the_original_error() -> None:
+    """Ensures that we don't lose why `pyjwt` refused to sign a token."""
+    token = JWToken(
+        sub='123',
+        exp=(dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)),
+    )
+
+    with pytest.raises(JWTokenError) as exc_info:
+        # `RS256` expects a PEM private key, not an HMAC secret:
+        token.encode(algorithm='RS256', secret='hmac-secret')  # noqa: S106
+
+    assert isinstance(exc_info.value, ValueError)
+    assert isinstance(exc_info.value.__cause__, jwt.exceptions.PyJWTError)
+
+
+def test_encode_unserializable_extras() -> None:
+    """Ensures that a payload we cannot serialize is a token error."""
+    token = JWToken(
+        sub='123',
+        exp=(dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)),
+        extras={'broken': object()},
+    )
+
+    with pytest.raises(JWTokenError) as exc_info:
+        token.encode(algorithm='HS256', secret=secrets.token_hex())
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
 
 
 @pytest.mark.parametrize('issuer', [None, 'text', ['list', 'of', 'values']])


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`JWToken.encode` no longer raises `InternalServerError`. It raises a new `JWTokenError`, and the views we ship convert that into `InternalServerError` themselves.

`JWToken` is a DTO, and tokens get created in management commands, background tasks and scripts, where a "500 response" object means nothing and forces non-HTTP code to import an HTTP exception. What actually goes wrong there is always a wrong value: an algorithm that does not exist, a key that does not match the algorithm, claims that cannot be issued.

* Added `JWTokenError` in `dmr/security/jwt/token.py`, exported from `dmr.security.jwt`.
* `JWToken.encode`, `JWToken.validate_issued_claims` and `JWToken.__post_init__` all raise it now, so the whole class has one error contract.
* `encode` also catches the `TypeError` from a payload that cannot be serialized to json — before it escaped raw, which contradicted the "encoding problems become a 500" promise the code made.
* The original error is kept as `__cause__` instead of being dropped with `from None`.
* `_BaseTokenController.create_jwt_token` catches `JWTokenError` and raises `InternalServerError` from it, so our own views behave as before from the outside.

## One change that is not strictly about the exception

`responses` on the six jwt controllers is now spelled `ClassVar[Sequence[ResponseSpec]]`.

Without it, `responses = (ResponseSpec(...),)` is inferred as a one-element tuple type and *no* subclass can add a spec — not even with an explicit annotation of its own. Since the whole point of this PR is that these views answer with a `500`, and declaring that `500` is what a user has to do to let it through response validation, leaving it unfixed would have made the new behaviour untestable and unusable. No runtime change. The same narrowing is still present in `dmr/security/token/views.py` and `dmr/security/django_session/views.py` — I left those alone and opened a separate issue, see #1371 

## Something for the reviewer to be aware of

The converted `500` does not currently reach the client anyway: response validation rejects any status code that is not declared, so it comes out as `422 "Returned status code 500 is not specified in the list of allowed status codes"`. This is not new and not caused by this PR — a plain controller that raises `InternalServerError` behaves the same way on `master`. I've opened a separate issue about it (see #1370); the test here declares the `500` on its own controller to work around it.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1364
Refs #1361 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
