### PR TITLE
Allow changing `responses` of shipped controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ of requirements for an API to count as public.
 
 ### Bugfixes
 
+- Fixed `responses` of `ObtainTokenSyncController`,
+  `ObtainTokenAsyncController`, `DjangoSessionSyncController`,
+  and `DjangoSessionAsyncController` being narrowed
+  to a fixed-size tuple, subclasses could not change it, #1371
 - Added missing `@sensitive_variables` decorator to all auth views,
   so credentials and tokens are hidden
   in error reporting middlewares and logs, #1323

--- a/dmr/security/django_session/views.py
+++ b/dmr/security/django_session/views.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from http import HTTPStatus
-from typing import Any, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar
 
 from django.conf import settings
 from django.contrib.auth import aauthenticate, alogin, authenticate, login
@@ -55,7 +55,7 @@ class DjangoSessionSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -130,7 +130,7 @@ class DjangoSessionAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,

--- a/dmr/security/token/views.py
+++ b/dmr/security/token/views.py
@@ -1,9 +1,9 @@
 import datetime as dt
 import uuid
 from abc import abstractmethod
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from http import HTTPStatus
-from typing import Any, Generic
+from typing import Any, ClassVar, Generic
 
 from django.contrib.auth import aauthenticate, authenticate
 from django.contrib.auth.base_user import AbstractBaseUser
@@ -90,7 +90,7 @@ class ObtainTokenSyncController(
 
     token_cls: type[TokenLikeSync[_UserT]]
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -194,7 +194,7 @@ class ObtainTokenAsyncController(
 
     token_cls: type[TokenLikeAsync[_UserT]]
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,

--- a/docs/examples/reusable_code/reusable_options.py
+++ b/docs/examples/reusable_code/reusable_options.py
@@ -1,0 +1,30 @@
+from collections.abc import Sequence
+from http import HTTPStatus
+from typing import ClassVar
+
+from dmr import Controller, ResponseSpec
+from dmr.errors import ErrorModel
+from dmr.plugins.pydantic import PydanticSerializer
+
+
+class MyBaseController(Controller[PydanticSerializer]):
+    responses: ClassVar[Sequence[ResponseSpec]] = (
+        ResponseSpec(ErrorModel, status_code=HTTPStatus.NOT_FOUND),
+    )
+
+    def get(self) -> str:
+        return 'reusable'
+
+
+class MyController(MyBaseController):
+    # This works only because `responses` is annotated in the parent class.
+    # Without that annotation type-checkers infer the type of `responses`
+    # from the parent's value, which is a tuple of exactly one item,
+    # and this assignment fails with:
+    # Incompatible types in assignment (expression has type
+    # "tuple[ResponseSpec, ResponseSpec]", base class "MyBaseController"
+    # defined the type as "tuple[ResponseSpec]")
+    responses = (
+        *MyBaseController.responses,
+        ResponseSpec(ErrorModel, status_code=HTTPStatus.CONFLICT),
+    )

--- a/docs/pages/reusable-code.rst
+++ b/docs/pages/reusable-code.rst
@@ -58,6 +58,39 @@ Let's try to create two exact controllers with exact serializers:
 Basically - we just specify what kind of serializer to use. And that's it.
 But, this is just the first step. We can do much more!
 
+.. tip::
+
+  Annotate class-level options like ``responses``, ``auth``, ``parsers``,
+  ``renderers``, and ``throttling`` in controllers that will be subclassed.
+
+  Without an annotation type-checkers infer a fixed-size tuple
+  from the value you assign, and subclasses won't be able
+  to add or to remove items from it.
+
+  .. code:: python
+
+    >>> from collections.abc import Sequence
+    >>> from http import HTTPStatus
+    >>> from typing import ClassVar
+
+    >>> from dmr import Controller, ResponseSpec
+    >>> from dmr.errors import ErrorModel
+    >>> from dmr.plugins.pydantic import PydanticSerializer
+
+    >>> class MyBaseController(Controller[PydanticSerializer]):
+    ...     responses: ClassVar[Sequence[ResponseSpec]] = (
+    ...         ResponseSpec(ErrorModel, status_code=HTTPStatus.NOT_FOUND),
+    ...     )
+    ...
+    ...     def get(self) -> str:
+    ...         return 'reusable'
+
+    >>> class MyController(MyBaseController):
+    ...     responses = (
+    ...         *MyBaseController.responses,
+    ...         ResponseSpec(ErrorModel, status_code=HTTPStatus.CONFLICT),
+    ...     )
+
 
 Generic parsing and response models
 -----------------------------------

--- a/docs/pages/reusable-code.rst
+++ b/docs/pages/reusable-code.rst
@@ -67,29 +67,10 @@ But, this is just the first step. We can do much more!
   from the value you assign, and subclasses won't be able
   to add or to remove items from it.
 
-  .. code:: python
-
-    >>> from collections.abc import Sequence
-    >>> from http import HTTPStatus
-    >>> from typing import ClassVar
-
-    >>> from dmr import Controller, ResponseSpec
-    >>> from dmr.errors import ErrorModel
-    >>> from dmr.plugins.pydantic import PydanticSerializer
-
-    >>> class MyBaseController(Controller[PydanticSerializer]):
-    ...     responses: ClassVar[Sequence[ResponseSpec]] = (
-    ...         ResponseSpec(ErrorModel, status_code=HTTPStatus.NOT_FOUND),
-    ...     )
-    ...
-    ...     def get(self) -> str:
-    ...         return 'reusable'
-
-    >>> class MyController(MyBaseController):
-    ...     responses = (
-    ...         *MyBaseController.responses,
-    ...         ResponseSpec(ErrorModel, status_code=HTTPStatus.CONFLICT),
-    ...     )
+  .. literalinclude:: /examples/reusable_code/reusable_options.py
+    :caption: views.py
+    :linenos:
+    :language: python
 
 
 Generic parsing and response models

--- a/typesafety/assert_type/test_security/test_shipped_responses.py
+++ b/typesafety/assert_type/test_security/test_shipped_responses.py
@@ -1,0 +1,65 @@
+from http import HTTPStatus
+from typing import Final
+
+from dmr import ResponseSpec
+from dmr.errors import ErrorModel
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.security.django_session.views import (
+    DjangoSessionAsyncController,
+    DjangoSessionPayload,
+    DjangoSessionResponse,
+    DjangoSessionSyncController,
+)
+from dmr.security.token.views import (
+    ObtainTokenAsyncController,
+    ObtainTokenPayload,
+    ObtainTokenResponse,
+    ObtainTokenSyncController,
+)
+
+# Controllers we ship must not narrow `responses` to a fixed-size tuple,
+# otherwise no subclass can add a spec of its own.
+_SERVER_ERROR: Final = ResponseSpec(
+    return_type=ErrorModel,
+    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+)
+
+
+class ExtendedTokenController(
+    ObtainTokenSyncController[
+        PydanticSerializer,
+        ObtainTokenPayload,
+        ObtainTokenResponse,
+    ],
+):
+    responses = (*ObtainTokenSyncController.responses, _SERVER_ERROR)
+
+
+class ExtendedSessionController(
+    DjangoSessionSyncController[
+        PydanticSerializer,
+        DjangoSessionPayload,
+        DjangoSessionResponse,
+    ],
+):
+    responses = (*DjangoSessionSyncController.responses, _SERVER_ERROR)
+
+
+class ExtendedAsyncTokenController(
+    ObtainTokenAsyncController[
+        PydanticSerializer,
+        ObtainTokenPayload,
+        ObtainTokenResponse,
+    ],
+):
+    responses = (*ObtainTokenAsyncController.responses, _SERVER_ERROR)
+
+
+class ExtendedAsyncSessionController(
+    DjangoSessionAsyncController[
+        PydanticSerializer,
+        DjangoSessionPayload,
+        DjangoSessionResponse,
+    ],
+):
+    responses = (*DjangoSessionAsyncController.responses, _SERVER_ERROR)


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`responses` on the four controllers listed in the issue is now spelled out as `ClassVar[Sequence[ResponseSpec]]`, so a subclass can add or drop a spec. Nothing changes at runtime — this is purely about what type-checkers infer.

## What changed

* `dmr/security/token/views.py` — `ObtainTokenSyncController`, `ObtainTokenAsyncController`
* `dmr/security/django_session/views.py` — `DjangoSessionSyncController`, `DjangoSessionAsyncController`

## About the other `ClassVar` options

The issue asked whether `auth`, `parsers`, `renderers` and `throttling` have the same problem. **They do**, and I reproduced all four:

```python
class AuthBase(Controller[PydanticSerializer]):
    auth = (JWTSyncAuth(),)

class AuthChild(AuthBase):
    auth = (JWTSyncAuth(), CookieJWTSyncAuth())
```

```
error: Incompatible types in assignment (expression has type
"tuple[HeaderJWTSyncAuth, CookieJWTSyncAuth]", base class "AuthBase"
defined the type as "tuple[HeaderJWTSyncAuth]")  [assignment]
```

But there is nothing to fix for them on our side: no controller we ship assigns `auth`, `parsers`, `renderers` or `throttling` in a class body — `responses` is the only one. The trap is entirely in user code, in anyone's own base controller.

So instead of a code change I added a tip to the "Reusable controllers" docs, which is exactly where people build such hierarchies: annotate these options if the controller will be subclassed. The example there is executable — `.rst` files are collected as doctests (`--doctest-glob=*.rst`), and I checked that this one runs.

## The jwt views are deliberately not in this PR

They are being fixed in #1369, which is still open, and touching the same lines here would only produce a merge conflict. Once both land, every controller we ship is annotated, and the sentence saying so can be added to that docs tip — I left it out for now because it is not true on this branch yet.

## Tests

`typesafety/assert_type/test_security/test_shipped_responses.py` subclasses all four controllers and extends `responses` **without an annotation of its own**, which is what a user would write. Files under `typesafety/` are checked by all four type-checkers in `just type-check` and are excluded from pytest, so this is the kind of test that can actually catch this bug.

I checked that the test is not vacuous: with the source change reverted, `mypy` fails on both classes with the original `tuple[ResponseSpec]` error.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1371
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
