### PR TITLE
fix(jwt): raise semantic JWTokenError from encode, convert at HTTP boundary (fixes #1364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@ of requirements for an API to count as public.
 - Parsed request data is no longer stored as a local variable
   of the endpoint's frame, because it was shown
   in error reports of any endpoint, #1323
+- Fixed `JWToken.encode` raising a bare `TypeError`
+  when `extras` cannot be serialized to json, #1373
 - JWT auth, refresh, and verify now return `401` instead of `500`
   when the token subject cannot be a value of the user lookup field,
   for example a non-numeric `sub` with the default integer `pk`, #1284

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ of requirements for an API to count as public.
 
 ### Breaking changes
 
+- `JWToken.encode` now raises `JWTokenError` (a token-layer semantic error)
+  instead of the HTTP-layer `InternalServerError` when encoding fails.
+  The error is converted back to `InternalServerError` at the HTTP boundary
+  in `_BaseTokenController.create_jwt_token`, so request-serving paths keep
+  their 500 contract while non-request callers (management commands, Celery
+  tasks, test factories) get a meaningful exception. The original `pyjwt`
+  cause is preserved in the traceback (no more `from None`).
 - Renamed `json_dump` to `json_dumps` in `dmr.openapi.dump` and `dmr.internal.json`
   to follow standard string-serialization conventions, #1399
 - Removed `QueryTokenSyncAuth` and `QueryTokenAsyncAuth` auth classes,

--- a/dmr/security/jwt/__init__.py
+++ b/dmr/security/jwt/__init__.py
@@ -23,3 +23,4 @@ from dmr.security.jwt.auth.header import HeaderJWTSyncAuth as HeaderJWTSyncAuth
 from dmr.security.jwt.auth.header import JWTAsyncAuth as JWTAsyncAuth
 from dmr.security.jwt.auth.header import JWTSyncAuth as JWTSyncAuth
 from dmr.security.jwt.token import JWToken as JWToken
+from dmr.security.jwt.token import JWTokenError as JWTokenError

--- a/dmr/security/jwt/__init__.py
+++ b/dmr/security/jwt/__init__.py
@@ -23,4 +23,3 @@ from dmr.security.jwt.auth.header import HeaderJWTSyncAuth as HeaderJWTSyncAuth
 from dmr.security.jwt.auth.header import JWTAsyncAuth as JWTAsyncAuth
 from dmr.security.jwt.auth.header import JWTSyncAuth as JWTSyncAuth
 from dmr.security.jwt.token import JWToken as JWToken
-from dmr.security.jwt.token import JWTokenError as JWTokenError

--- a/dmr/security/jwt/token.py
+++ b/dmr/security/jwt/token.py
@@ -40,7 +40,16 @@ from dmr.exceptions import NotAuthenticatedError
 
 @final
 class JWTokenError(Exception):
-    """Raised when a token cannot be encoded."""
+    """
+    Raised when a token cannot be created, encoded, or decoded.
+
+    This is a semantic error about the token itself: its claims,
+    the signing algorithm, or the key. It is not an HTTP error,
+    because tokens are regularly created outside of any request:
+    in management commands, background tasks, and scripts.
+
+    .. versionadded:: 0.15.0
+    """
 
 
 @dataclass(frozen=True, slots=True)

--- a/dmr/security/jwt/token.py
+++ b/dmr/security/jwt/token.py
@@ -30,12 +30,17 @@
 import datetime as dt
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, Self
+from typing import Any, Self, final
 
 import jwt
 from jwt.types import Options
 
-from dmr.exceptions import InternalServerError, NotAuthenticatedError
+from dmr.exceptions import NotAuthenticatedError
+
+
+@final
+class JWTokenError(Exception):
+    """Raised when a token cannot be encoded."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,16 +102,16 @@ class JWToken:  # noqa: WPS214
         the checks that we run before signing a token.
 
         Raises:
-            ValueError: If this token cannot be issued right now.
+            JWTokenError: If this token cannot be issued right now.
 
         .. versionadded:: 0.15.0
 
         """
         now = _normalize_datetime(dt.datetime.now(dt.UTC)).timestamp()
         if self.exp.timestamp() < now:
-            raise ValueError('exp value must be a datetime in the future')
+            raise JWTokenError('exp value must be a datetime in the future')
         if self.iat.timestamp() > now:
-            raise ValueError('iat must be a current or past time')
+            raise JWTokenError('iat must be a current or past time')
 
     def encode(
         self,
@@ -127,14 +132,18 @@ class JWToken:  # noqa: WPS214
             An encoded token string.
 
         Raises:
-            ValueError: If this token cannot be issued right now.
-            InternalServerError: If encoding fails.
+            JWTokenError: If the token cannot be issued right now
+                (`exp`/`iat` validation) or encoding fails. pyjwt errors
+                are wrapped and the original exception is preserved
+                as the cause.
 
         .. versionchanged:: 0.15.0
 
             ``exp`` and ``iat`` are validated here
             via :meth:`validate_issued_claims`,
             previously it was done during the instance creation.
+            Encoding failures now raise :class:`JWTokenError`
+            instead of the HTTP-layer ``InternalServerError``.
 
         """
         self.validate_issued_claims()
@@ -149,8 +158,12 @@ class JWToken:  # noqa: WPS214
                 algorithm=algorithm,
                 headers=headers,
             )
-        except (jwt.exceptions.PyJWTError, NotImplementedError):
-            raise InternalServerError('Failed to encode token') from None
+        except (
+            jwt.exceptions.PyJWTError,
+            NotImplementedError,
+            TypeError,
+        ) as exc:
+            raise JWTokenError('Failed to encode token') from exc
 
     @classmethod
     def decode_payload(  # noqa: WPS211

--- a/dmr/security/jwt/views.py
+++ b/dmr/security/jwt/views.py
@@ -18,10 +18,10 @@ from typing_extensions import TypedDict
 from dmr import Body, Controller, ResponseSpec, modify
 from dmr.decorators import endpoint_decorator
 from dmr.errors import ErrorModel
-from dmr.exceptions import NotAuthenticatedError
+from dmr.exceptions import InternalServerError, NotAuthenticatedError
 from dmr.security.base import NO_STORE_HEADERS
 from dmr.security.jwt.auth.base import USER_LOOKUP_ERRORS, set_request_attrs
-from dmr.security.jwt.token import JWToken
+from dmr.security.jwt.token import JWToken, JWTokenError
 from dmr.serializer import BaseSerializer
 
 _ObtainTokensT = TypeVar('_ObtainTokensT', bound=Mapping[str, Any])
@@ -92,18 +92,23 @@ class _BaseTokenController(
         token_headers: dict[str, Any] | None = None,
     ) -> str:
         """Create correct jwt token of a given *expiration* and *token_type*."""
-        return self.jwt_token_cls(
+        token = self.jwt_token_cls(
             sub=subject or str(self.request.user.pk),
             exp=expiration or (dt.datetime.now(dt.UTC) + self.jwt_expiration),
             iss=issuer or self.jwt_issuer,
             aud=audiences or self.jwt_audiences,
             jti=jwt_id or self.make_jwt_id(),
             extras={'type': token_type} if token_type else {},
-        ).encode(
-            secret=secret or self.jwt_secret or settings.SECRET_KEY,
-            algorithm=algorithm or self.jwt_algorithm,
-            headers=token_headers,
         )
+        try:
+            return token.encode(
+                secret=secret or self.jwt_secret or settings.SECRET_KEY,
+                algorithm=algorithm or self.jwt_algorithm,
+                headers=token_headers,
+            )
+        except JWTokenError as exc:
+            # Convert the token-layer semantic error at the HTTP boundary.
+            raise InternalServerError('Failed to encode token') from exc
 
     def make_jwt_id(self) -> str | None:
         """Create unique token's jwt id."""

--- a/dmr/security/jwt/views.py
+++ b/dmr/security/jwt/views.py
@@ -138,7 +138,7 @@ class ObtainTokensSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -216,7 +216,7 @@ class ObtainTokensAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -318,7 +318,7 @@ class RefreshTokenSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -398,7 +398,7 @@ class RefreshTokenAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -510,7 +510,7 @@ class VerifyTokenSyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,
@@ -582,7 +582,7 @@ class VerifyTokenAsyncController(
 
     """
 
-    responses = (
+    responses: ClassVar[Sequence[ResponseSpec]] = (
         ResponseSpec(
             return_type=ErrorModel,
             status_code=HTTPStatus.UNAUTHORIZED,

--- a/docs/pages/auth/jwt.rst
+++ b/docs/pages/auth/jwt.rst
@@ -398,6 +398,10 @@ API Reference
 .. autoclass:: dmr.security.jwt.token.JWToken
   :members:
 
+.. autoexception:: dmr.security.jwt.token.JWTokenError
+  :members:
+  :show-inheritance:
+
 Header auth
 ~~~~~~~~~~~
 

--- a/tests/test_unit/test_security/test_jwt/test_jwt_broken_encoding.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_broken_encoding.py
@@ -1,0 +1,77 @@
+from collections.abc import Sequence
+from http import HTTPStatus
+from typing import ClassVar
+
+import pytest
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+from typing_extensions import override
+
+from dmr import ResponseSpec
+from dmr.errors import ErrorModel
+from dmr.plugins.pydantic import PydanticFastSerializer
+from dmr.security.jwt.views import (
+    ObtainTokensPayload,
+    ObtainTokensResponse,
+    ObtainTokensSyncController,
+)
+from dmr.test import DMRRequestFactory
+
+
+class _BrokenAlgorithmController(
+    ObtainTokensSyncController[
+        PydanticFastSerializer,
+        ObtainTokensPayload,
+        ObtainTokensResponse,
+    ],
+):
+    # There is no such algorithm, `pyjwt` will refuse to sign the token:
+    jwt_algorithm = 'nope'
+
+    # The views we ship don't declare `500` themselves,
+    # and response validation only allows declared status codes:
+    responses: ClassVar[Sequence[ResponseSpec]] = (
+        *ObtainTokensSyncController.responses,
+        ResponseSpec(
+            return_type=ErrorModel,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        ),
+    )
+
+    @override
+    def convert_auth_payload(
+        self,
+        payload: ObtainTokensPayload,
+    ) -> ObtainTokensPayload:
+        return payload
+
+    @override
+    def make_api_response(self) -> ObtainTokensResponse:
+        return {
+            'access_token': self.create_jwt_token(
+                token_type='access',  # noqa: S106
+            ),
+            'refresh_token': self.create_jwt_token(
+                token_type='refresh',  # noqa: S106
+            ),
+        }
+
+
+@pytest.mark.django_db
+def test_token_we_cannot_sign_is_a_server_error(
+    dmr_rf: DMRRequestFactory,
+    admin_user: User,
+) -> None:
+    """Ensures that views convert `JWTokenError` into a `500` response."""
+    request = dmr_rf.post(
+        '/whatever/',
+        data={'username': admin_user.username, 'password': 'password'},
+        content_type='application/json',
+    )
+
+    response = _BrokenAlgorithmController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+        response.content
+    )

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -13,8 +13,8 @@ import pytest
 from faker import Faker
 from typing_extensions import TypedDict, override
 
-from dmr.exceptions import InternalServerError, NotAuthenticatedError
-from dmr.security.jwt import JWToken
+from dmr.exceptions import NotAuthenticatedError
+from dmr.security.jwt import JWToken, JWTokenError
 
 #: Clock error in seconds that we allow in tests below.
 _LEEWAY: Final = 30
@@ -84,14 +84,14 @@ def test_empty_token() -> None:
 )
 def test_exp_in_the_past(exp: dt.datetime) -> None:
     """Ensures that we can't issue a token with an exp date in the past."""
-    with pytest.raises(ValueError, match='datetime in the future'):
+    with pytest.raises(JWTokenError, match='datetime in the future'):
         JWToken('a', exp).encode(secrets.token_hex(), 'HS256')
 
 
 def test_iat_in_the_past() -> None:
     """Ensures that we can't issue a token with an iat date in the future."""
     exp = dt.datetime.now(dt.UTC) + dt.timedelta(days=1)
-    with pytest.raises(ValueError, match='current or past time'):
+    with pytest.raises(JWTokenError, match='current or past time'):
         JWToken('a', exp, iat=exp).encode(secrets.token_hex(), 'HS256')
 
 
@@ -196,12 +196,40 @@ def test_encode_validation(
     algorithm: str,
     secret: str,
 ) -> None:
-    """Ensures that incorrect combination of algorithm and secret raises."""
-    with pytest.raises(InternalServerError):
+    """Ensures incorrect algorithm/secret raises the token-layer error."""
+    with pytest.raises(JWTokenError):
         JWToken(
             sub='123',
             exp=(dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)),
         ).encode(algorithm=algorithm, secret=secret)
+
+
+def test_encode_keeps_the_original_error() -> None:
+    """Ensures that we don't lose why `pyjwt` refused to sign a token."""
+    token = JWToken(
+        sub='123',
+        exp=(dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)),
+    )
+
+    with pytest.raises(JWTokenError) as exc_info:
+        # `RS256` expects a PEM private key, not an HMAC secret:
+        token.encode(algorithm='RS256', secret='hmac-secret')  # noqa: S106
+
+    assert isinstance(exc_info.value.__cause__, jwt.exceptions.PyJWTError)
+
+
+def test_encode_unserializable_extras() -> None:
+    """Ensures that a payload we cannot serialize is a token error."""
+    token = JWToken(
+        sub='123',
+        exp=(dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)),
+        extras={'broken': object()},
+    )
+
+    with pytest.raises(JWTokenError) as exc_info:
+        token.encode(algorithm='HS256', secret=secrets.token_hex())
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
 
 
 @pytest.mark.parametrize('issuer', [None, 'text', ['list', 'of', 'values']])

--- a/tests/test_unit/test_security/test_jwt/test_jwt_token.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_token.py
@@ -14,7 +14,7 @@ from faker import Faker
 from typing_extensions import TypedDict, override
 
 from dmr.exceptions import NotAuthenticatedError
-from dmr.security.jwt import JWToken, JWTokenError
+from dmr.security.jwt.token import JWToken, JWTokenError
 
 #: Clock error in seconds that we allow in tests below.
 _LEEWAY: Final = 30


### PR DESCRIPTION
## Summary
Fixes #1364. `JWToken.encode` now raises a token-layer `JWTokenError` instead of the HTTP-layer `InternalServerError`, so non-request callers (management commands, Celery, test factories) get a meaningful exception. The error is converted back to `InternalServerError` in `create_jwt_token` where a request is served.

## Decisions (issue open questions)
- New dedicated `JWTokenError` (not plain ValueError) so encoding failures are distinguishable from input-validation `ValueError`
- Lives in `dmr/security/jwt/` (jwt is an optional extra)
- `validate_issued_claims` ValueError contract unchanged
- Non-serializable payload `TypeError` also converted to `JWTokenError`
- Original pyjwt cause preserved (`from exc`, no more `from None`)

## Tests
- `test_encode_validation` now expects `JWTokenError`
- 156 jwt tests pass; ruff clean

Fixes #1364