### PR TITLE
Do not require describing our own error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ of requirements for an API to count as public.
 
 ### Bugfixes
 
+- Fixed `InternalServerError` and other errors we handle ourselves
+  being returned as `422` when their status code
+  was not listed in `responses`, #1370
 - Added missing `@sensitive_variables` decorator to all auth views,
   so credentials and tokens are hidden
   in error reporting middlewares and logs, #1323

--- a/dmr/errors.py
+++ b/dmr/errors.py
@@ -26,6 +26,7 @@ from dmr.exceptions import (
     TooManyRequestsError,
     ValidationError,
 )
+from dmr.internal.errors import mark_handled_error
 
 if TYPE_CHECKING:
     from dmr.controller import Controller
@@ -305,11 +306,13 @@ def global_error_handler(
 
     """
     if isinstance(exc, _default_handled_excs):
-        return controller.to_error(
-            controller.format_error(exc),
-            status_code=exc.status_code,
-            headers=getattr(exc, 'headers', None),
-            cookies=getattr(exc, 'cookies', None),
-            renderer=getattr(exc, 'renderer', None),
+        return mark_handled_error(
+            controller.to_error(
+                controller.format_error(exc),
+                status_code=exc.status_code,
+                headers=getattr(exc, 'headers', None),
+                cookies=getattr(exc, 'cookies', None),
+                renderer=getattr(exc, 'renderer', None),
+            ),
         )
     raise  # noqa: PLE0704

--- a/dmr/internal/errors.py
+++ b/dmr/internal/errors.py
@@ -1,0 +1,23 @@
+from typing import TypeVar
+
+from django.http import HttpResponseBase
+
+_ResponseT = TypeVar('_ResponseT', bound=HttpResponseBase)
+
+
+def mark_handled_error(response: _ResponseT) -> _ResponseT:
+    """
+    Mark a response that we have built for an exception that we handle.
+
+    Users describe the responses that *their* endpoints return.
+    Errors that we raise and handle ourselves are not a part of that
+    contract, so response validation lets them through
+    even when their status code is not described.
+    """
+    response.__dmr_handled_error__ = True  # type: ignore[attr-defined]
+    return response
+
+
+def is_handled_error(response: HttpResponseBase) -> bool:
+    """Tells whether this response was built by our own error handling."""
+    return getattr(response, '__dmr_handled_error__', False)

--- a/dmr/validation/response.py
+++ b/dmr/validation/response.py
@@ -13,6 +13,7 @@ from dmr.exceptions import (
 )
 from dmr.files import FileBody
 from dmr.internal.enums import stringify
+from dmr.internal.errors import is_handled_error
 from dmr.internal.negotiation import (
     media_by_precedence,
     negotiatiate_response_validation,
@@ -51,8 +52,18 @@ class ResponseValidator:  # noqa: WPS214
         controller: 'Controller[BaseSerializer]',
         response: _ResponseT,
     ) -> _ResponseT:
-        """Validate response based on provided schema."""
+        """
+        Validate response based on provided schema.
+
+        .. versionchanged:: 0.15.0
+
+            Our own error responses are not validated
+            when their status code is not described by the user.
+
+        """
         if not self._should_validate_responses():
+            return response
+        if self._is_undescribed_handled_error(response):
             return response
         schema = self._get_response_schema(response.status_code)
         self._validate_content_type(response, endpoint.metadata)
@@ -115,6 +126,25 @@ class ResponseValidator:  # noqa: WPS214
 
     def _should_validate_responses(self) -> bool:
         return self.metadata.validate_responses is True
+
+    def _is_undescribed_handled_error(
+        self,
+        response: HttpResponseBase,
+    ) -> bool:
+        """
+        Detects our own error responses that the user did not describe.
+
+        We build them ourselves for the exceptions that we handle,
+        so there's no user schema to validate them against.
+        Telling the client that its request was unprocessable,
+        because we failed to describe our own ``500``, helps nobody.
+
+        Describing such a status code, for example with
+        :data:`~dmr.settings.Settings.responses`, brings the validation back.
+        """
+        if not is_handled_error(response):
+            return False
+        return HTTPStatus(response.status_code) not in self.metadata.responses
 
     def _get_response_schema(
         self,

--- a/docs/pages/error-handling.rst
+++ b/docs/pages/error-handling.rst
@@ -52,6 +52,24 @@ Here's how it works:
   You don't need to catch ``APIError`` in any way,
   unless you know what you are doing.
 
+.. note::
+
+  .. versionchanged:: 0.15.0
+
+  Responses that :func:`~dmr.errors.global_error_handler` builds
+  for the exceptions we handle ourselves, like
+  :exc:`~dmr.exceptions.InternalServerError`, are not required
+  to be listed in :attr:`~dmr.controller.Controller.responses`.
+  They are our data and not yours, so response validation lets them through.
+
+  Errors that your own handlers return still have to be described,
+  as any other response of your endpoint.
+
+  Describing a status code that we can return, for example with
+  :data:`~dmr.settings.Settings.responses`, is still worth doing:
+  it documents the response in the OpenAPI schema
+  and turns the validation back on for it.
+
 
 Customizing endpoint error handler
 ----------------------------------

--- a/tests/test_unit/test_endpoint/test_error_response_validation.py
+++ b/tests/test_unit/test_endpoint/test_error_response_validation.py
@@ -1,0 +1,144 @@
+import json
+from collections.abc import Sequence
+from http import HTTPStatus
+from typing import ClassVar, final
+
+import pytest
+from django.http import HttpResponse
+from inline_snapshot import snapshot
+from typing_extensions import override
+
+from dmr import Controller, ResponseSpec
+from dmr.endpoint import Endpoint
+from dmr.errors import ErrorModel
+from dmr.exceptions import InternalServerError
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+
+
+@final
+class _UndeclaredSyncController(Controller[PydanticSerializer]):
+    def get(self) -> str:
+        raise InternalServerError('database is down')
+
+
+@final
+class _UndeclaredAsyncController(Controller[PydanticSerializer]):
+    async def get(self) -> str:
+        raise InternalServerError('database is down')
+
+
+def test_sync_undeclared_error_status(dmr_rf: DMRRequestFactory) -> None:
+    """Ensures that our own errors don't have to be described by the user."""
+    request = dmr_rf.get('/whatever/')
+
+    response = _UndeclaredSyncController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Internal server error'}],
+    })
+
+
+@pytest.mark.asyncio
+async def test_async_undeclared_error_status(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """Ensures that our own errors don't have to be described by the user."""
+    request = dmr_async_rf.get('/whatever/')
+
+    response = await dmr_async_rf.wrap(
+        _UndeclaredAsyncController.as_view()(request),
+    )
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Internal server error'}],
+    })
+
+
+@final
+class _DeclaredController(Controller[PydanticSerializer]):
+    responses: ClassVar[Sequence[ResponseSpec]] = (
+        ResponseSpec(ErrorModel, status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+    )
+
+    def get(self) -> str:
+        raise InternalServerError('database is down')
+
+
+def test_declared_error_status(dmr_rf: DMRRequestFactory) -> None:
+    """Ensures that describing our error status code still works."""
+    request = dmr_rf.get('/whatever/')
+
+    response = _DeclaredController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert json.loads(response.content) == snapshot({
+        'detail': [{'msg': 'Internal server error'}],
+    })
+
+
+@final
+class _WronglyDeclaredController(Controller[PydanticSerializer]):
+    # Our errors are `ErrorModel` objects, not lists of integers:
+    responses: ClassVar[Sequence[ResponseSpec]] = (
+        ResponseSpec(list[int], status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+    )
+
+    def get(self) -> str:
+        raise InternalServerError('database is down')
+
+
+def test_wrongly_declared_error_status(dmr_rf: DMRRequestFactory) -> None:
+    """Ensures that describing a status code brings the validation back."""
+    request = dmr_rf.get('/whatever/')
+
+    response = _WronglyDeclaredController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@final
+class _CustomHandlerController(Controller[PydanticSerializer]):
+    def get(self) -> str:
+        raise ZeroDivisionError
+
+    @override
+    def handle_error(
+        self,
+        endpoint: Endpoint,
+        controller: 'Controller[PydanticSerializer]',
+        exc: Exception,
+    ) -> HttpResponse:
+        return self.to_error(
+            'custom',
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+        )
+
+
+def test_custom_handler_status_is_validated(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures that user's own error responses are still validated."""
+    request = dmr_rf.get('/whatever/')
+
+    response = _CustomHandlerController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert json.loads(response.content) == snapshot({
+        'detail': [
+            {
+                'msg': (
+                    'Returned status code 501 is not specified in the list '
+                    'of allowed status codes: [200, 422, 406]'
+                ),
+                'type': 'value_error',
+            },
+        ],
+    })


### PR DESCRIPTION
# I have made things!

Errors that we raise and handle ourselves are no longer turned into a `422` when the user has not listed their status code in `responses`. The reproducer from the issue now answers what it should:

```
STATUS: 500 {"detail":[{"msg":"Internal server error"}]}
```

This is direction 1 from the issue: responses built by `global_error_handler` for our own handled exceptions skip the declared-status check.

## How

The whole question is how to tell "our response to our own exception" apart from a response the user produced. The mark is set in exactly one place — the `_default_handled_excs` branch of `global_error_handler` — and nowhere else:

* `dmr/internal/errors.py` — `mark_handled_error()` / `is_handled_error()` over a `__dmr_handled_error__` attribute, the same trick the codebase already uses for `__dmr_auth__` and `__dmr_endpoint__`. It lives in `internal/` so that `dmr/errors.py` and `dmr/validation/response.py` don't have to import protected names from each other.
* `dmr/errors.py` — marks the response it builds for a handled exception.
* `dmr/validation/response.py` — `_is_undescribed_handled_error()` lets such a response through.

Deliberately **not** marked: `Controller.to_error()` itself, and the error handling path as a whole. `to_error` is public API that people call from their own handlers, and those responses have to keep being validated like any other response of their endpoint.

## The skip is narrow on purpose

Validation is skipped only when the status code is **not described**. If `500` is declared — per controller, or globally via `Settings.responses` — everything works exactly as before, body included. So the self-checks we already have for described statuses (`401` from auth, `429` from throttling) are untouched, and this is the smallest behavioural change that fixes the report.

The OpenAPI schema does not change: `500` still shows up only if the user declares it.

## Tests

`tests/test_unit/test_endpoint/test_error_response_validation.py`:

* an undescribed `500` from a sync and from an async endpoint — now a real `500`;
* a described `500` — still a `500`, nothing regressed;
* a `500` described with the *wrong* type (`list[int]`) — comes back as `422`, which proves that describing a status code brings the validation back rather than silently disabling it;
* a custom `handle_error` returning an undescribed `501` — still `422`, which pins down the boundary of this change.

The existing `test_validate_status_code` (a user endpoint returning an undeclared `200`) stays green: user responses are validated exactly as before.

## Docs

A note in `docs/pages/error-handling.rst`, next to the description of the three handler levels: our errors don't have to be described, yours do, and describing ours is still worth it because it puts them in the OpenAPI schema and turns validation back on for them.

## Worth knowing for #1369

That PR converts `JWTokenError` into `InternalServerError` inside `create_jwt_token`, and I noted there that the resulting `500` did not actually reach the client. This is the fix for that: once both land, a server that cannot sign its own tokens answers `500` instead of a misleading `422`, without anyone having to declare anything first.
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1370 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
