### PR TITLE
Fix JWT refresh token authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ of requirements for an API to count as public.
 - Fixed `JWToken.decode` validating `exp` and `iat` twice,
   now `leeway`, `verify_exp`, and `verify_iat` are respected
   and invalid tokens return `401` instead of `500`, #1324
+- JWT authentication now rejects refresh tokens when access tokens are expected,
+  #1320
 
 ### Misc
 

--- a/dmr/security/jwt/auth.py
+++ b/dmr/security/jwt/auth.py
@@ -48,6 +48,8 @@ class _BaseJWTAuth:  # noqa: WPS214, WPS230
     :meth:`get_token_from_request` and :meth:`split_encoded_token`.
     """
 
+    expected_token_type: str = 'access'  # noqa: S105
+
     __slots__ = (
         'accepted_audiences',
         'accepted_issuers',
@@ -153,7 +155,7 @@ class _BaseJWTAuth:  # noqa: WPS214, WPS230
 
     def decode_token(self, encoded_token: str) -> JWToken:
         """Decodes token object from the encoded string."""
-        return self.token_cls.decode(
+        token = self.token_cls.decode(
             encoded_token=encoded_token,
             secret=self.secret,
             algorithm=self.algorithm,
@@ -169,6 +171,9 @@ class _BaseJWTAuth:  # noqa: WPS214, WPS230
             strict_audience=self.strict_audience,
             enforce_minimum_key_length=self.enforce_minimum_key_length,
         )
+        if token.extras.get('type') != self.expected_token_type:
+            raise NotAuthenticatedError
+        return token
 
     def claim_from_token(self, token: JWToken) -> str:
         """

--- a/tests/test_integration/test_jwt_auth/test_jwt_cookie_flow.py
+++ b/tests/test_integration/test_jwt_auth/test_jwt_cookie_flow.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from faker import Faker
-from inline_snapshot import snapshot
 
 from dmr.security.jwt.token import JWToken
 from dmr.test import DMRClient
@@ -28,6 +27,7 @@ def access_token(user: User) -> str:
     return JWToken(
         sub=str(user.pk),
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
 
 
@@ -52,11 +52,11 @@ def test_jwt_cookie_auth(
     response = dmr_client.get(check_url)
 
     assert response.status_code == HTTPStatus.OK, response.content
-    assert response.json() == snapshot({
+    assert response.json() == {
         'username': user.username,
         'email': user.email,
         'is_active': True,
-    })
+    }
 
 
 @pytest.mark.django_db

--- a/tests/test_integration/test_jwt_auth/test_jwt_integration.py
+++ b/tests/test_integration/test_jwt_auth/test_jwt_integration.py
@@ -70,6 +70,7 @@ def test_valid_auth(
     token = JWToken(
         sub=str(admin_user.pk),
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
     ).encode(settings.SECRET_KEY, algorithm='HS256')
     response = dmr_client.post(
         url,
@@ -106,6 +107,7 @@ def test_missing_user(
     token = JWToken(
         sub='-1',
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
     ).encode(settings.SECRET_KEY, algorithm='HS256')
     response = dmr_client.post(
         url,
@@ -144,6 +146,7 @@ def test_inactive_user(
     token = JWToken(
         sub=str(admin_user.pk),
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
+        extras={'type': 'access'},
     ).encode(settings.SECRET_KEY, algorithm='HS256')
     response = dmr_client.post(
         url,

--- a/tests/test_integration/test_jwt_auth/test_jwt_views.py
+++ b/tests/test_integration/test_jwt_auth/test_jwt_views.py
@@ -58,10 +58,10 @@ def inactive_user(faker: Faker, password: str) -> User:
     ],
 )
 @pytest.mark.parametrize(
-    'token_type',
+    ('token_type', 'expected_status'),
     [
-        'access_token',
-        'refresh_token',
+        ('access_token', HTTPStatus.CREATED),
+        ('refresh_token', HTTPStatus.UNAUTHORIZED),
     ],
 )
 def test_correct_auth_params(
@@ -72,6 +72,7 @@ def test_correct_auth_params(
     url: str,
     check_url: str,
     token_type: str,
+    expected_status: HTTPStatus,
 ) -> None:
     """Ensures that correct auth params fit."""
     response = dmr_client.post(
@@ -83,6 +84,7 @@ def test_correct_auth_params(
     assert response.headers['Content-Type'] == 'application/json'
     assert response.headers['Cache-Control'] == 'no-store'
     response_body = response.json()
+
     access = jwt.decode(
         response_body['access_token'],
         key=settings.SECRET_KEY,
@@ -95,6 +97,7 @@ def test_correct_auth_params(
         'jti': IsStr(),
         'extras': {'type': 'access'},
     }
+
     refresh = jwt.decode(
         response_body['refresh_token'],
         key=settings.SECRET_KEY,
@@ -119,13 +122,24 @@ def test_correct_auth_params(
         },
     )
 
-    assert response.status_code == HTTPStatus.CREATED, response.content
+    assert response.status_code == expected_status, response.content
     assert response.headers['Content-Type'] == 'application/json'
-    assert response.json() == {
-        'username': user.username,
-        'email': user.email,
-        'is_active': user.is_active,
-    }
+
+    if expected_status == HTTPStatus.CREATED:
+        assert response.json() == {
+            'username': user.username,
+            'email': user.email,
+            'is_active': user.is_active,
+        }
+    else:
+        assert response.json() == snapshot({
+            'detail': [
+                {
+                    'msg': 'Not authenticated',
+                    'type': 'security',
+                },
+            ],
+        })
 
 
 @pytest.mark.django_db

--- a/tests/test_unit/test_security/test_jwt/test_blocklist/test_blocklist_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_blocklist/test_blocklist_auth.py
@@ -51,6 +51,7 @@ def build_user_token(admin_user: User, settings: LazySettings) -> _TokenBuilder:
     """Token factory for tests."""
 
     def factory(**kwargs: Unpack[_JWTokenKwargs]) -> str:
+        kwargs.setdefault('extras', {'type': 'access'})
         token = JWToken(
             sub=str(admin_user.pk),
             **kwargs,

--- a/tests/test_unit/test_security/test_jwt/test_jwt_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_auth.py
@@ -47,6 +47,7 @@ async def test_async_jwt_view(
     token = JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
     request = dmr_async_rf.get(
         f'/whatever/?user_id={admin_user.pk}',
@@ -94,6 +95,7 @@ def test_sync_jwt_view(
     token = JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
     request = dmr_rf.get(
         f'/whatever/?user_id={admin_user.pk}',

--- a/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
@@ -35,6 +35,7 @@ def _encode(user: User, secret: str) -> str:
     return JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(user.pk),
+        extras={'type': 'access'},
     ).encode(secret=secret, algorithm='HS256')
 
 
@@ -333,6 +334,7 @@ def test_sync_cookie_jwt_custom_algorithm(
     matching = JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS512')
     request = dmr_rf.get('/whatever/')
     request.COOKIES['access_token'] = matching
@@ -370,6 +372,7 @@ def test_sync_cookie_jwt_custom_user_id_field(
     token = JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=admin_user.username,
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
     request = dmr_rf.get('/whatever/')
     request.COOKIES['access_token'] = token
@@ -400,6 +403,7 @@ def test_sync_cookie_jwt_custom_secret(
     request.COOKIES['access_token'] = JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
+        extras={'type': 'access'},
     ).encode(secret=secret, algorithm='HS256')
 
     response = _CookieController.as_view()(request)
@@ -446,6 +450,7 @@ def test_sync_cookie_jwt_accepted_issuers(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
         iss=issuer,
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
 
     response = _CookieController.as_view()(request)
@@ -483,6 +488,7 @@ def test_sync_cookie_jwt_accepted_audiences(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
         aud=audience,
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
 
     response = _CookieController.as_view()(request)
@@ -520,7 +526,10 @@ def test_sync_cookie_jwt_custom_token_cls(
     request.COOKIES['access_token'] = _EmailToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=str(admin_user.pk),
-        extras={'email': admin_user.email},
+        extras={
+            'email': admin_user.email,
+            'type': 'access',
+        },
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
 
     response = _CookieController.as_view()(request)
@@ -559,6 +568,7 @@ def test_sync_cookie_jwt_leeway(
     token = JWToken(
         exp=dt.datetime.now(dt.UTC),
         sub=str(admin_user.pk),
+        extras={'type': 'access'},
     ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
     # Move into the future, so the token is already expired:
     freezer.tick(delta=elapsed)

--- a/tests/test_unit/test_security/test_jwt/test_jwt_features.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_features.py
@@ -37,6 +37,7 @@ def build_user_token(admin_user: User, settings: LazySettings) -> _TokenBuilder:
 
         kwargs.setdefault('sub', str(admin_user.pk))
         kwargs.setdefault('exp', exp_date)
+        kwargs.setdefault('extras', {'type': 'access'})
         return JWToken(
             **kwargs,
         ).encode(secret=settings.SECRET_KEY, algorithm='HS256')
@@ -253,4 +254,41 @@ async def test_custom_jwt_header(
 
     assert isinstance(response, HttpResponse)
     assert response.headers == {'Content-Type': 'application/json'}
+    assert response.status_code == response_code
+
+
+@final
+class _TokenTypeController(Controller[PydanticSerializer]):
+    @modify(auth=[JWTSyncAuth()])
+    def get(self) -> str:
+        return 'authed'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('token_type', 'response_code'),
+    [
+        ('access', HTTPStatus.OK),
+        ('refresh', HTTPStatus.UNAUTHORIZED),
+    ],
+)
+def test_jwt_token_type_validation(
+    dmr_rf: DMRRequestFactory,
+    build_user_token: _TokenBuilder,
+    *,
+    token_type: str,
+    response_code: HTTPStatus,
+) -> None:
+    """Ensures that only access tokens can be used for authentication."""
+    token = build_user_token(extras={'type': token_type})
+    request = dmr_rf.get(
+        '/whatever/',
+        headers={
+            'Authorization': f'Bearer {token}',
+        },
+    )
+
+    response = _TokenTypeController.as_view()(request)
+
+    assert isinstance(response, HttpResponse)
     assert response.status_code == response_code

--- a/tests/test_unit/test_security/test_jwt/test_jwt_invalid_subject.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_invalid_subject.py
@@ -17,6 +17,7 @@ def _encode(subject: str, secret: str) -> str:
     return JWToken(
         exp=dt.datetime.now(dt.UTC) + dt.timedelta(days=1),
         sub=subject,
+        extras={'type': 'access'},
     ).encode(secret=secret, algorithm='HS256')
 
 


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [] I have updated the documentation for the changes I have made

## Related issues

- Closes #1320 

Summary
- refresh tokens could also be used for authentication
- block authentication if the token type does not match expected_token_type

Testing
- just test
- just lint

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #1320 
- Refs #1320 

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
