### PR TITLE
Hash throttle cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ of requirements for an API to count as public.
   it is only used by `JWToken.decode` now, #1324
 - `JWToken` does not validate `exp` and `iat` on creation anymore,
   now `JWToken.encode` validates them instead, #1324
+- Throttling cache keys are now hashed to keep their length bounded, #1337
 
 ### Features
 

--- a/dmr/throttling/base.py
+++ b/dmr/throttling/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import enum
+import hashlib
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
@@ -138,17 +139,21 @@ class _BaseThrottle(ResponseSpecProvider, Generic[_BackendT]):
         if cache_key is None:
             return None
 
-        metadata = endpoint.metadata
-        backend_name = type(self._backend).__qualname__
-        algorithm_name = type(self._algorithm).__qualname__
-        cache_key_name = type(self.cache_key).__qualname__
-        # This must ensure that endpoint key is unique:
-        return (
-            f'{metadata.operation_id}::{metadata.method}::'
-            f'{backend_name}::{algorithm_name}::'
-            f'{cache_key_name}::{cache_key}::'
-            f'{self.max_requests}::{self.duration_in_seconds}'
-        )
+        raw_cache_key = '::'.join((
+            str(endpoint.metadata.operation_id),
+            endpoint.metadata.method,
+            type(self._backend).__qualname__,
+            type(self._algorithm).__qualname__,
+            type(self.cache_key).__qualname__,
+            cache_key,
+            str(self.max_requests),
+            str(self.duration_in_seconds),
+        ))
+        cache_key_hash = hashlib.sha256(
+            raw_cache_key.encode('utf-8'),
+        ).hexdigest()
+        cache_key_name = self.cache_key.name
+        return f'{cache_key_name}::{cache_key_hash}'
 
     def replace(
         self,

--- a/tests/test_unit/test_throttling/test_throttling.py
+++ b/tests/test_unit/test_throttling/test_throttling.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from http import HTTPMethod, HTTPStatus
 from typing import Final, TypeAlias
@@ -14,6 +15,7 @@ from dmr.serializer import BaseSerializer
 from dmr.settings import Settings
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 from dmr.throttling import AsyncThrottle, Rate, SyncThrottle
+from dmr.throttling.cache_keys import RemoteAddr
 
 _Serializes: TypeAlias = list[type[BaseSerializer]]
 serializers: Final[_Serializes] = [
@@ -381,3 +383,76 @@ def test_throttle_sync_rates(
     assert response.status_code == HTTPStatus.OK, response.headers
     assert response.headers == {'Content-Type': 'application/json'}
     assert json.loads(response.content) == 'inside'
+
+
+def test_throttle_full_cache_key_is_hashed(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures that full throttle cache keys are hashed."""
+    throttle = SyncThrottle(
+        5,
+        Rate.minute,
+        cache_key=RemoteAddr(name='per-ip'),
+    )
+
+    class _SyncController(Controller[PydanticSerializer]):
+        throttling = [throttle]
+
+        def get(self) -> str:  # pragma: no cover
+            return 'inside'
+
+    controller = _SyncController()
+    controller.setup(
+        dmr_rf.get('/whatever/', REMOTE_ADDR='192.0.2.1'),
+    )
+    endpoint = _SyncController.api_endpoints['GET']
+
+    raw_cache_key = '::'.join((
+        str(endpoint.metadata.operation_id),
+        endpoint.metadata.method,
+        'SyncDjangoCache',
+        'SimpleRate',
+        'RemoteAddr',
+        '192.0.2.1',
+        '5',
+        '60',
+    ))
+    expected_hash = hashlib.sha256(
+        raw_cache_key.encode('utf-8'),
+    ).hexdigest()
+
+    assert throttle.full_cache_key(endpoint, controller) == (
+        f'per-ip::{expected_hash}'  # noqa: WPS237
+    )
+
+
+def test_throttle_full_cache_key_is_unique(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Ensures different throttle inputs produce different cache keys."""
+    throttle = SyncThrottle(
+        5,
+        Rate.minute,
+        cache_key=RemoteAddr(name='per-ip'),
+    )
+
+    class _SyncController(Controller[PydanticSerializer]):
+        throttling = [throttle]
+
+        def get(self) -> str:  # pragma: no cover
+            return 'inside'
+
+    endpoint = _SyncController.api_endpoints['GET']
+    controller = _SyncController()
+
+    controller.setup(
+        dmr_rf.get('/whatever/', REMOTE_ADDR='192.0.2.1'),
+    )
+    first_key = throttle.full_cache_key(endpoint, controller)
+
+    controller.setup(
+        dmr_rf.get('/whatever/', REMOTE_ADDR='192.0.2.2'),
+    )
+    second_key = throttle.full_cache_key(endpoint, controller)
+
+    assert first_key != second_key


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues
- Closes #1337 

## Summary

- Fixes #1337
- Hash throttle cache keys with SHA-256 while keeping the cache key name as a readable prefix
- I tested below
  - `just lint`
  - `just type-check`
  - `just unit`

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
