### PR TITLE
Allow to use stream data in  `parse_as_post` #1328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ of requirements for an API to count as public.
   instead of failing with a database `IntegrityError`, #1322
 - JWT authentication now rejects refresh tokens when access tokens are expected,
   #1320
+- Fixed a bug when request data might be copied in `parse_as_post` #1328
 
 ### Misc
 

--- a/dmr/internal/django.py
+++ b/dmr/internal/django.py
@@ -141,6 +141,21 @@ def parse_as_post(request: HttpRequest) -> None:
     """
     # This code is adapted from Django itself:
     if request.content_type == 'multipart/form-data':
+        # There is some cases where request cannot has `_stream`` attribute
+        # 1. App uses custom request class inherited from HttpRequest, which not
+        # initialize `_stream`.
+        # 2. Once the stream has been read
+        # (for example, by a custom middleware that inspects or logs
+        # the request body), it becomes empty and cannot be read again.
+        # Subsequent attempts to read from _stream will return no data,
+        #  making `parse_as_post` fail to retrieve the request body.
+        # 3.Django`s `Client` and `RequestFactory` mock the network socket using
+        # `FakePayload``. Once read, this mock stream is automatically emptied
+        # and cleared by Django. Using `getattr(request, '_stream', request)`
+        # provides a safe fallback if the stream was already consumed or
+        # omitted in the test environment.
+        # `HttpRequest` objects is chosen as fallback argument since it has
+        # methods to read data from request body too.
         request_data = getattr(request, '_stream', request)
         # This was introduced in Django 6.1:
         multipart_parser_cls = getattr(

--- a/dmr/internal/django.py
+++ b/dmr/internal/django.py
@@ -157,6 +157,7 @@ def parse_as_post(request: HttpRequest) -> None:
         # `HttpRequest` objects is chosen as fallback argument since it has
         # methods to read data from request body too.
         request_data = getattr(request, '_stream', request)
+
         # This was introduced in Django 6.1:
         multipart_parser_cls = getattr(
             request,

--- a/dmr/internal/django.py
+++ b/dmr/internal/django.py
@@ -141,21 +141,16 @@ def parse_as_post(request: HttpRequest) -> None:
     """
     # This code is adapted from Django itself:
     if request.content_type == 'multipart/form-data':
-        # There is some cases where request cannot has `_stream`` attribute
-        # 1. App uses custom request class inherited from HttpRequest, which not
-        # initialize `_stream`.
-        # 2. Once the stream has been read
-        # (for example, by a custom middleware that inspects or logs
-        # the request body), it becomes empty and cannot be read again.
-        # Subsequent attempts to read from _stream will return no data,
-        #  making `parse_as_post` fail to retrieve the request body.
-        # 3.Django`s `Client` and `RequestFactory` mock the network socket using
-        # `FakePayload``. Once read, this mock stream is automatically emptied
-        # and cleared by Django. Using `getattr(request, '_stream', request)`
-        # provides a safe fallback if the stream was already consumed or
-        # omitted in the test environment.
-        # `HttpRequest` objects is chosen as fallback argument since it has
-        # methods to read data from request body too.
+        # Use Django's current request stream directly instead of materializing
+        # the multipart body in DMR. This keeps DMR itself streaming-friendly,
+        # but it isn't an "always zero-copy" guarantee: if something has already
+        # accessed `request.body`, Django has cached the whole body in memory;
+        # and while parsing, Django's upload handlers decide whether uploaded
+        # files are kept in memory or written to temporary files.
+        #
+        # Some custom or test request objects may not initialize `_stream`.
+        # Falling back to `request` still gives `MultiPartParser` a file-like
+        # object with `read()` methods.
         request_data = getattr(request, '_stream', request)
 
         # This was introduced in Django 6.1:
@@ -182,7 +177,7 @@ def parse_as_post(request: HttpRequest) -> None:
             request._post = post  # type: ignore[attr-defined]
             request._files = files  # type: ignore[attr-defined]
 
-        request._dmr_parsed_as_post = True  # type: ignore[attr-defined]
+        request.__dmr_parsed_as_post__ = True  # type: ignore[attr-defined]
         return
 
     # Django only supports two content types natively,

--- a/dmr/internal/django.py
+++ b/dmr/internal/django.py
@@ -33,7 +33,6 @@
 
 
 from collections.abc import Mapping
-from io import BytesIO
 from typing import Any, Final, TypeAlias
 
 from django.core.exceptions import TooManyFilesSent
@@ -142,7 +141,7 @@ def parse_as_post(request: HttpRequest) -> None:
     """
     # This code is adapted from Django itself:
     if request.content_type == 'multipart/form-data':
-        request_data = BytesIO(request.body)
+        request_data = getattr(request, '_stream', request)
         # This was introduced in Django 6.1:
         multipart_parser_cls = getattr(
             request,

--- a/dmr/parsers.py
+++ b/dmr/parsers.py
@@ -281,7 +281,7 @@ class MultiPartParser(
         from dmr.settings import Settings, resolve_setting  # noqa: PLC0415
 
         if (
-            not getattr(request, '_dmr_parsed_as_post', False)
+            not getattr(request, '__dmr_parsed_as_post__', False)
             and request.method
             and (
                 request.method.upper()
@@ -355,7 +355,7 @@ class FormUrlEncodedParser(
         from dmr.settings import Settings, resolve_setting  # noqa: PLC0415
 
         if (
-            not getattr(request, '_dmr_parsed_as_post', False)
+            not getattr(request, '__dmr_parsed_as_post__', False)
             and request.method
             and (
                 request.method.upper()

--- a/tests/test_unit/test_internal/test_django/test_parse_as_post.py
+++ b/tests/test_unit/test_internal/test_django/test_parse_as_post.py
@@ -1,39 +1,45 @@
 from django.core.files.uploadedfile import (
+    InMemoryUploadedFile,
     SimpleUploadedFile,
     TemporaryUploadedFile,
 )
-from django.test import RequestFactory, override_settings
-from django.test.client import encode_multipart
+from django.test import RequestFactory
+from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 
 from dmr.internal.django import parse_as_post
 
 
-@override_settings(
-    DATA_UPLOAD_MAX_MEMORY_SIZE=1,
-    FILE_UPLOAD_MAX_MEMORY_SIZE=1,
-)
 def test_parse_as_post_not_copy_data(
     rf: RequestFactory,
 ) -> None:
-    """Ensure request body isn't copied."""
+    """
+    Ensure request body isn't copied.
+
+    Django's multipart parser should stream this file through upload handlers
+    and store it only as a temporary file. Keeping it as an in-memory uploaded
+    file would mean the bytes were copied into another Python object.
+    """
     large_content = b'x' * 2
 
-    boundary = 'test_boundary'
     request = rf.put(
         '/whatever/',
         data=encode_multipart(
-            boundary,
+            BOUNDARY,
             {
                 'file': SimpleUploadedFile('large.txt', large_content),
             },
         ),
-        content_type=f'multipart/form-data; boundary={boundary}',
+        content_type=MULTIPART_CONTENT,
     )
 
     parse_as_post(request)
 
     uploaded_file = request.FILES['file']
+    # The uploaded bytes must be represented by Django's temporary-file upload
+    # object, not by an in-memory upload object that keeps a second byte copy.
     assert isinstance(uploaded_file, TemporaryUploadedFile)
+    assert not isinstance(uploaded_file, InMemoryUploadedFile)
+
     assert not hasattr(uploaded_file, '_file')
     assert uploaded_file.size == len(large_content)
 

--- a/tests/test_unit/test_internal/test_django/test_parse_as_post.py
+++ b/tests/test_unit/test_internal/test_django/test_parse_as_post.py
@@ -3,12 +3,14 @@ from django.core.files.uploadedfile import (
     SimpleUploadedFile,
     TemporaryUploadedFile,
 )
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 
 from dmr.internal.django import parse_as_post
 
 
+# Force Django to use TemporaryFileUploadHandler without a large fixture.
+@override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=1)
 def test_parse_as_post_not_copy_data(
     rf: RequestFactory,
 ) -> None:

--- a/tests/test_unit/test_internal/test_django/test_parse_as_post.py
+++ b/tests/test_unit/test_internal/test_django/test_parse_as_post.py
@@ -1,0 +1,40 @@
+from django.core.files.uploadedfile import (
+    SimpleUploadedFile,
+    TemporaryUploadedFile,
+)
+from django.test import RequestFactory, override_settings
+from django.test.client import encode_multipart
+
+from dmr.internal.django import parse_as_post
+
+
+@override_settings(
+    DATA_UPLOAD_MAX_MEMORY_SIZE=1,
+    FILE_UPLOAD_MAX_MEMORY_SIZE=1,
+)
+def test_parse_as_post_not_copy_data(
+    rf: RequestFactory,
+) -> None:
+    """Ensure request body isn't copied."""
+    large_content = b'x' * 2
+
+    boundary = 'test_boundary'
+    request = rf.put(
+        '/whatever/',
+        data=encode_multipart(
+            boundary,
+            {
+                'file': SimpleUploadedFile('large.txt', large_content),
+            },
+        ),
+        content_type=f'multipart/form-data; boundary={boundary}',
+    )
+
+    parse_as_post(request)
+
+    uploaded_file = request.FILES['file']
+    assert isinstance(uploaded_file, TemporaryUploadedFile)
+    assert not hasattr(uploaded_file, '_file')
+    assert uploaded_file.size == len(large_content)
+
+    uploaded_file.close()


### PR DESCRIPTION
# I have made things!

`request.body` calling force to read all data. it causes risk for repeating data read

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

- Closes #1328 

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
