### PR TITLE
Add `header_name_server_managed` validation to `HttpSpec` (#1341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,8 @@ of requirements for an API to count as public.
 ### Features
 
 - Added initial `ty` support, #1257
+- Added `header_name_server_managed` to `HttpSpec` to restrict server-managed headers
+  in responses, #1341
 - Added support of reusable controllers with `@validate`, #1259
 - Added default value to `prefix` parameter in `Router.__init__`, #1267
 - Added `to_urlpatterns` function to include `Router`

--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -97,7 +97,7 @@ class HttpSpec(enum.StrEnum):
             like ``204`` must not have response bodies.
         header_name_server_managed: Disables validation that headers
             like ``Te``, ``Server``, ``Keep-Alive``, etc. can't be
-            included in response headers
+            included in response headers.
 
     """
 

--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -96,7 +96,7 @@ class HttpSpec(enum.StrEnum):
         empty_response_body: Disables validation that some status codes
             like ``204`` must not have response bodies.
         header_name_server_managed: Disables validation that headers
-            like ``Te``, ``Server``, ``Keep-Alive``, etc. can't be
+            like ``Server``, ``Keep-Alive``, etc. can't be
             included in response headers.
 
     """

--- a/dmr/settings.py
+++ b/dmr/settings.py
@@ -95,11 +95,15 @@ class HttpSpec(enum.StrEnum):
             like ``GET`` and ``HEAD`` can't have request bodies.
         empty_response_body: Disables validation that some status codes
             like ``204`` must not have response bodies.
+        header_name_server_managed: Disables validation that headers
+            like ``Te``, ``Server``, ``Keep-Alive``, etc. can't be
+            included in response headers
 
     """
 
     empty_request_body = 'empty_request_body'
     empty_response_body = 'empty_response_body'
+    header_name_server_managed = 'header_name_server_managed'
 
 
 class SettingsDict(TypedDict, total=False):

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -45,6 +45,23 @@ if TYPE_CHECKING:
     from dmr.controller import Controller
     from dmr.errors import AsyncErrorHandler, SyncErrorHandler
 
+#: HTTP headers that are connection-specific or
+#: normally managed by the server.
+#: See RFC 9110 for more details.
+_FORBIDDEN_RESPONSE_HEADERS: Final = frozenset((
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+    'content-length',
+    'date',
+    'server',
+))
+
 #: HTTP methods that should not have a request body according to HTTP spec.
 #: These methods are: GET, HEAD, DELETE, CONNECT, TRACE.
 #: See RFC 7231 for more details.
@@ -141,6 +158,12 @@ class _ResponseListValidator:  # noqa: WPS214
             not in self.metadata.no_validate_http_spec
         ):
             self._check_empty_response_body(responses)
+        if (
+            HttpSpec.header_name_server_managed
+            not in self.metadata.no_validate_http_spec
+        ):
+            self._check_header_name_server_managed(responses)
+
         # TODO: add more checks
 
     def _check_empty_response_body(
@@ -163,6 +186,25 @@ class _ResponseListValidator:  # noqa: WPS214
                     f'from an endpoint {endpoint_name!r} '
                     f'with status code {response.status_code}',
                 )
+
+    def _check_header_name_server_managed(  # noqa: WPS231
+        self,
+        responses: list[ResponseSpec],
+    ) -> None:
+        endpoint_name = self.metadata.endpoint_name
+        for response in responses:
+            if not response.headers:
+                continue
+
+            for header_name, header in response.headers.items():
+                if (
+                    header_name.lower() in _FORBIDDEN_RESPONSE_HEADERS
+                    and not header.skip_validation
+                ):
+                    raise EndpointMetadataError(
+                        f'Header {header_name!r} is not allowed in responses '
+                        f'from endpoint {endpoint_name!r}.',
+                    )
 
     def _convert_responses(
         self,

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -1,10 +1,17 @@
 import dataclasses
 import inspect
 import warnings
-from collections.abc import Callable, Sequence, Set
+from collections.abc import Callable, ItemsView, Sequence, Set
 from http import HTTPMethod, HTTPStatus
 from types import NoneType
-from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeVar, assert_never
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Final,
+    TypeVar,
+    assert_never,
+)
 
 from django.contrib.admindocs.utils import parse_docstring
 from django.core.cache.backends import dummy, locmem
@@ -57,7 +64,6 @@ _FORBIDDEN_RESPONSE_HEADERS: Final = frozenset((
     'trailer',
     'transfer-encoding',
     'upgrade',
-    'content-length',
     'date',
     'server',
 ))
@@ -187,7 +193,7 @@ class _ResponseListValidator:  # noqa: WPS214
                     f'with status code {response.status_code}',
                 )
 
-    def _check_header_name_server_managed(  # noqa: WPS231
+    def _check_header_name_server_managed(
         self,
         responses: list[ResponseSpec],
     ) -> None:
@@ -196,21 +202,34 @@ class _ResponseListValidator:  # noqa: WPS214
             if not response.headers:
                 continue
 
-            for header_name, header in response.headers.items():
-                if (
-                    header_name.lower() in _FORBIDDEN_RESPONSE_HEADERS
-                    and not header.skip_validation
-                ):
-                    raise EndpointMetadataError(
-                        f'Header {header_name!r} is not allowed in responses '
-                        f'from endpoint {endpoint_name!r}.',
-                    )
+            forbidden_header = self._get_forbidden_header(
+                response.headers.items(),
+            )
+
+            if forbidden_header:
+                raise EndpointMetadataError(
+                    f'Header {forbidden_header!r} is not allowed in responses '
+                    f'from endpoint {endpoint_name!r}.',
+                )
 
     def _convert_responses(
         self,
         all_responses: list[ResponseSpec],
     ) -> dict[HTTPStatus, ResponseSpec]:
         return {resp.status_code: resp for resp in all_responses}
+
+    def _get_forbidden_header(
+        self,
+        response_headers: ItemsView[str, HeaderSpec],
+    ) -> str | None:
+
+        for header_name, header in response_headers:
+            if (
+                header_name.lower() in _FORBIDDEN_RESPONSE_HEADERS
+                and not header.skip_validation
+            ):
+                return header_name
+        return None
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)

--- a/tests/test_unit/test_controllers/test_http_spec/test_empty_response_body.py
+++ b/tests/test_unit/test_controllers/test_http_spec/test_empty_response_body.py
@@ -8,7 +8,6 @@ from dmr.exceptions import EndpointMetadataError
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.settings import HttpSpec
 
-
 @pytest.mark.parametrize(
     'status',
     [HTTPStatus.NO_CONTENT, HTTPStatus.NOT_MODIFIED],

--- a/tests/test_unit/test_controllers/test_http_spec/test_empty_response_body.py
+++ b/tests/test_unit/test_controllers/test_http_spec/test_empty_response_body.py
@@ -8,6 +8,7 @@ from dmr.exceptions import EndpointMetadataError
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.settings import HttpSpec
 
+
 @pytest.mark.parametrize(
     'status',
     [HTTPStatus.NO_CONTENT, HTTPStatus.NOT_MODIFIED],

--- a/tests/test_unit/test_controllers/test_http_spec/test_header_name_server_managed.py
+++ b/tests/test_unit/test_controllers/test_http_spec/test_header_name_server_managed.py
@@ -1,0 +1,167 @@
+from collections.abc import Mapping
+from http import HTTPStatus
+from typing import Final
+
+import pydantic
+import pytest
+from django.http import HttpResponse
+
+from dmr import Controller, HeaderSpec, ResponseSpec, validate
+from dmr.exceptions import EndpointMetadataError
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.settings import HttpSpec
+
+_MATCH_PATTER: Final[str] = (
+    r'Header .+ is not allowed '
+    r'in responses from endpoint .+'
+)
+
+
+class _BodyModel(pydantic.BaseModel):
+    name: str
+
+
+@pytest.mark.parametrize(
+    'header',
+    [
+        'Connection',
+        'Keep-Alive',
+        'Proxy-Authenticate',
+        'Proxy-Authorization',
+        'Te',
+        'Trailer',
+        'Transfer-Encoding',
+        'Upgrade',
+        'Content-Length',
+        'Date',
+        'Server',
+    ],
+)
+def test_header_name_server_managed(
+    header: str,
+) -> None:
+    """Ensure that responses must not have server managed headers."""
+    header_spec = {header: HeaderSpec()}
+
+    with pytest.raises(
+        EndpointMetadataError,
+        match=_MATCH_PATTER,
+    ):
+
+        class _Mixed(Controller[PydanticSerializer]):
+            @validate(
+                ResponseSpec(
+                    status_code=HTTPStatus.OK,
+                    headers=header_spec,
+                    return_type=None,
+                ),
+            )
+            def get(self) -> HttpResponse:
+                raise NotImplementedError
+
+
+@pytest.mark.parametrize(
+    'header',
+    [{'CONNECTION': HeaderSpec()}, {'Content-LENGTH': HeaderSpec()}],
+)
+def test_header_name_server_managed_casing(
+    header: Mapping[str, HeaderSpec],
+) -> None:
+    """Ensure that validation is case-insensitive."""
+    with pytest.raises(
+        EndpointMetadataError,
+        match=_MATCH_PATTER,
+    ):
+
+        class _Mixed(Controller[PydanticSerializer]):
+            @validate(
+                ResponseSpec(
+                    status_code=HTTPStatus.OK,
+                    headers=header,
+                    return_type=None,
+                ),
+            )
+            def get(self) -> HttpResponse:
+                raise NotImplementedError
+
+
+def test_header_name_server_managed_controller() -> None:
+    """Ensure that the validation can be disabled on controller level."""
+    header = {'Content-Length': HeaderSpec()}
+
+    class _Mixed(Controller[PydanticSerializer]):
+        @validate(
+            ResponseSpec(
+                status_code=HTTPStatus.OK,
+                headers=header,
+                return_type=None,
+            ),
+            no_validate_http_spec={HttpSpec.header_name_server_managed},
+        )
+        def get(self) -> HttpResponse:
+            raise NotImplementedError
+
+
+def test_server_managed_header_controller_scoped() -> None:
+    """Ensure that disabling on one controller does not affect other."""
+    header = {'Keep-Alive': HeaderSpec()}
+
+    class GoodController(Controller[PydanticSerializer]):
+        @validate(
+            ResponseSpec(
+                status_code=HTTPStatus.OK,
+                headers=header,
+                return_type=None,
+            ),
+            no_validate_http_spec={HttpSpec.header_name_server_managed},
+        )
+        def get(self) -> HttpResponse:
+            raise NotImplementedError
+
+    with pytest.raises(
+        EndpointMetadataError,
+        match=_MATCH_PATTER,
+    ):
+
+        class BadController(Controller[PydanticSerializer]):
+            @validate(
+                ResponseSpec(
+                    status_code=HTTPStatus.OK,
+                    headers=header,
+                    return_type=None,
+                ),
+            )
+            def get(self) -> HttpResponse:
+                raise NotImplementedError
+
+
+def test_server_managed_header_skip_validation() -> None:
+    """Ensure skip_validation allows server-managed response headers."""
+    header = {'Proxy-Authorization': HeaderSpec(skip_validation=True)}
+
+    class _Mixed(Controller[PydanticSerializer]):
+        @validate(
+            ResponseSpec(
+                status_code=HTTPStatus.OK,
+                headers=header,
+                return_type=None,
+            ),
+        )
+        def get(self) -> HttpResponse:
+            raise NotImplementedError
+
+
+def test_server_managed_header_with_other_headers() -> None:
+    """Ensure that other headers don't raise EndpointMetadataError."""
+    header = {'X-API-TOKEN': HeaderSpec(), 'csrf-token': HeaderSpec()}
+
+    class _Mixed(Controller[PydanticSerializer]):
+        @validate(
+            ResponseSpec(
+                status_code=HTTPStatus.OK,
+                headers=header,
+                return_type=None,
+            ),
+        )
+        def get(self) -> HttpResponse:
+            raise NotImplementedError

--- a/tests/test_unit/test_controllers/test_http_spec/test_header_name_server_managed.py
+++ b/tests/test_unit/test_controllers/test_http_spec/test_header_name_server_managed.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+import re
 from http import HTTPStatus
 from typing import Final
 
@@ -11,9 +11,8 @@ from dmr.exceptions import EndpointMetadataError
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.settings import HttpSpec
 
-_MATCH_PATTER: Final[str] = (
-    r'Header .+ is not allowed '
-    r'in responses from endpoint .+'
+_MATCH_PATTERN: Final = re.compile(
+    r'Header .+ is not allowed in responses from endpoint .+',
 )
 
 
@@ -24,7 +23,7 @@ class _BodyModel(pydantic.BaseModel):
 @pytest.mark.parametrize(
     'header',
     [
-        'Connection',
+        'CONNECTION',
         'Keep-Alive',
         'Proxy-Authenticate',
         'Proxy-Authorization',
@@ -32,9 +31,8 @@ class _BodyModel(pydantic.BaseModel):
         'Trailer',
         'Transfer-Encoding',
         'Upgrade',
-        'Content-Length',
         'Date',
-        'Server',
+        'server',
     ],
 )
 def test_header_name_server_managed(
@@ -45,7 +43,7 @@ def test_header_name_server_managed(
 
     with pytest.raises(
         EndpointMetadataError,
-        match=_MATCH_PATTER,
+        match=_MATCH_PATTERN,
     ):
 
         class _Mixed(Controller[PydanticSerializer]):
@@ -53,31 +51,6 @@ def test_header_name_server_managed(
                 ResponseSpec(
                     status_code=HTTPStatus.OK,
                     headers=header_spec,
-                    return_type=None,
-                ),
-            )
-            def get(self) -> HttpResponse:
-                raise NotImplementedError
-
-
-@pytest.mark.parametrize(
-    'header',
-    [{'CONNECTION': HeaderSpec()}, {'Content-LENGTH': HeaderSpec()}],
-)
-def test_header_name_server_managed_casing(
-    header: Mapping[str, HeaderSpec],
-) -> None:
-    """Ensure that validation is case-insensitive."""
-    with pytest.raises(
-        EndpointMetadataError,
-        match=_MATCH_PATTER,
-    ):
-
-        class _Mixed(Controller[PydanticSerializer]):
-            @validate(
-                ResponseSpec(
-                    status_code=HTTPStatus.OK,
-                    headers=header,
                     return_type=None,
                 ),
             )
@@ -102,58 +75,9 @@ def test_header_name_server_managed_controller() -> None:
             raise NotImplementedError
 
 
-def test_server_managed_header_controller_scoped() -> None:
-    """Ensure that disabling on one controller does not affect other."""
-    header = {'Keep-Alive': HeaderSpec()}
-
-    class GoodController(Controller[PydanticSerializer]):
-        @validate(
-            ResponseSpec(
-                status_code=HTTPStatus.OK,
-                headers=header,
-                return_type=None,
-            ),
-            no_validate_http_spec={HttpSpec.header_name_server_managed},
-        )
-        def get(self) -> HttpResponse:
-            raise NotImplementedError
-
-    with pytest.raises(
-        EndpointMetadataError,
-        match=_MATCH_PATTER,
-    ):
-
-        class BadController(Controller[PydanticSerializer]):
-            @validate(
-                ResponseSpec(
-                    status_code=HTTPStatus.OK,
-                    headers=header,
-                    return_type=None,
-                ),
-            )
-            def get(self) -> HttpResponse:
-                raise NotImplementedError
-
-
 def test_server_managed_header_skip_validation() -> None:
     """Ensure skip_validation allows server-managed response headers."""
     header = {'Proxy-Authorization': HeaderSpec(skip_validation=True)}
-
-    class _Mixed(Controller[PydanticSerializer]):
-        @validate(
-            ResponseSpec(
-                status_code=HTTPStatus.OK,
-                headers=header,
-                return_type=None,
-            ),
-        )
-        def get(self) -> HttpResponse:
-            raise NotImplementedError
-
-
-def test_server_managed_header_with_other_headers() -> None:
-    """Ensure that other headers don't raise EndpointMetadataError."""
-    header = {'X-API-TOKEN': HeaderSpec(), 'csrf-token': HeaderSpec()}
 
     class _Mixed(Controller[PydanticSerializer]):
         @validate(

--- a/tests/test_unit/test_endpoint/test_return_file.py
+++ b/tests/test_unit/test_endpoint/test_return_file.py
@@ -13,6 +13,7 @@ from dmr.files import FileResponseSpec
 from dmr.headers import HeaderSpec
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.renderers import FileRenderer
+from dmr.settings import HttpSpec
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 
 _FILEPATH: Final = (
@@ -30,6 +31,7 @@ class _FileSyncController(Controller[PydanticSerializer]):
     @validate(
         FileResponseSpec(as_attachment=True),
         renderers=[FileRenderer()],
+        no_validate_http_spec={HttpSpec.header_name_server_managed},
     )
     def get(self) -> FileResponse:
         return FileResponse(
@@ -45,6 +47,7 @@ class _InlineFileSyncController(Controller[PydanticSerializer]):
     @validate(
         FileResponseSpec(),
         renderers=[FileRenderer('text/plain')],
+        no_validate_http_spec={HttpSpec.header_name_server_managed},
     )
     def get(self) -> FileResponse:
         return FileResponse(
@@ -128,7 +131,10 @@ def test_file_attachment_headers() -> None:
 class _FileAsyncController(Controller[PydanticSerializer]):
     renderers = (FileRenderer('text/plain'),)
 
-    @validate(FileResponseSpec(as_attachment=True))
+    @validate(
+        FileResponseSpec(as_attachment=True),
+        no_validate_http_spec={HttpSpec.header_name_server_managed},
+    )
     async def get(self) -> FileResponse:
         return FileResponse(
             # We don't care that it is sync:

--- a/tests/test_unit/test_openapi/test_files_snapshots.py
+++ b/tests/test_unit/test_openapi/test_files_snapshots.py
@@ -15,6 +15,7 @@ from dmr.parsers import JsonParser, MultiPartParser
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.renderers import FileRenderer
 from dmr.routing import Router
+from dmr.settings import HttpSpec
 from tests.infra.octet import OCTET_STREAM, OctetFileModel, OctetStreamParser
 
 
@@ -63,6 +64,7 @@ class _FileResponseController(Controller[PydanticSerializer]):
     @validate(
         FileResponseSpec(),
         renderers=[FileRenderer('image/png')],
+        no_validate_http_spec={HttpSpec.header_name_server_managed},
     )
     async def get(self) -> FileResponse:
         raise NotImplementedError
@@ -72,6 +74,7 @@ class _AttachmentFileResponseController(Controller[PydanticSerializer]):
     @validate(
         FileResponseSpec(as_attachment=True),
         renderers=[FileRenderer('image/png')],
+        no_validate_http_spec={HttpSpec.header_name_server_managed},
     )
     async def get(self) -> FileResponse:
         raise NotImplementedError


### PR DESCRIPTION
# I have made things!

Added new `HttpSpec` validation, now, unless included in `no_validate_http_spec`, using hop-by-hop and server-managed headers in responses raises `EndpointMetadataError`.

I also updated the existing tests in `tests/test_unit/test_openapi/test_files_snapshots.py` and `tests/test_unit/test_endpoint/test_return_file.py` to reflect the new behavior and ensure they continue to work properly.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues
- Refs №1341 — implements the `header_name_server_managed` validation bullet