### PR TITLE
Precompile bytecode and relax test timeout in wheel test envs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,9 +222,17 @@ before-test = [
   uv export --format requirements.txt --group unit-test --no-group dev \
   --all-extras > _temp.txt\
   """,
-  "uv pip install -r _temp.txt",
+  # `uv` does not write `.pyc` files by default, unlike `pip`.
+  # Without them, imports that only happen inside a test
+  # have to compile their modules at runtime, which is slow enough
+  # on Windows to trip `pytest-timeout`. See:
+  # https://github.com/wemake-services/django-modern-rest/issues/1401
+  "uv pip install --compile-bytecode -r _temp.txt",
 ]
-test-command = 'pytest {project}/tests/test_unit -o addopts=""'
+# These envs are freshly created for a single run and are much slower
+# than local machines, so our default `timeout = 5` is too strict here.
+# Hanging tests are still reported, just later:
+test-command = 'pytest {project}/tests/test_unit -o addopts="" -o timeout=30'
 
 [tool.cibuildwheel.environment]
 HATCH_BUILD_HOOKS_ENABLE = "1"


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`uv` does not write `.pyc` files by default, so every module that is first imported inside a test had to be compiled and written to disk during the timed part of the run. On Windows this was slow enough to trip the 5s `pytest-timeout` limit.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1401
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
