### PR TITLE
[gh-1332] do not expose reason in ensure_csrf check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,9 +172,10 @@ of requirements for an API to count as public.
   instead of failing with a database `IntegrityError`, #1322
 - JWT authentication now rejects refresh tokens when access tokens are expected,
   #1320
-- Fixed a bug when request data might be copied in `parse_as_post` #1328
+- Fixed a bug when request data might be copied in `parse_as_post`, #1328
 - Fixed postponed annotation resolution for wrapped endpoint functions
   whose decorators are defined in another module, #1417
+- Detailed CSRF failure reasons are now included in error responses only in debug mode, #1332
 
 ### Misc
 

--- a/dmr/internal/csrf.py
+++ b/dmr/internal/csrf.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from dmr.serializer import BaseSerializer
 
 _CSRF_FAILED_MSG: Final = _('CSRF Failed: {reason}')
-_NON_DEBUG_CSRF_FAILED_REASON: Final[str] = 'Forbidden.'
+_NON_DEBUG_CSRF_FAILED_REASON: Final = 'Forbidden.'
 
 
 @final

--- a/dmr/internal/csrf.py
+++ b/dmr/internal/csrf.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Final, final
 
+from django.conf import settings
 from django.http import HttpRequest
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.translation import gettext_lazy as _
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
     from dmr.serializer import BaseSerializer
 
 _CSRF_FAILED_MSG: Final = _('CSRF Failed: {reason}')
+_NON_DEBUG_CSRF_FAILED_REASON: Final[str] = 'Forbidden.'
 
 
 @final
@@ -22,22 +24,32 @@ class _EnsureCsrfToken(CsrfViewMiddleware):
 
     def _reject(self, request: HttpRequest, reason: str) -> str:
         # Return the failure reason instead of an ``HttpResponse``.
-        return reason
+        # Expose detailed csrf failure reason on DEBUG mode.
+        # Otherwise, provide default placeholder reason.
+
+        if settings.DEBUG:
+            return reason
+
+        return _NON_DEBUG_CSRF_FAILED_REASON
 
 
-def _get_csrf_failure_reason(request: HttpRequest) -> str | None:
+def _check_csrf_failure(request: HttpRequest) -> tuple[bool, str | None]:
     """Perform CSRF validation using ``_EnsureCsrfToken``."""
     check = _EnsureCsrfToken(lambda _: None)  # type: ignore[arg-type]
     check.process_request(request)
-    return check.process_view(request, None, (), {})  # type: ignore[arg-type, return-value]
+    reason = check.process_view(request, None, (), {})  # type: ignore[arg-type]
+    is_failed = reason is not None
+
+    return is_failed, reason  # type: ignore[return-value]
 
 
 def ensure_csrf(controller: 'Controller[BaseSerializer]') -> None:
     """Raise ``APIError`` (403) if the CSRF check fails."""
     from dmr.response import APIError  # noqa: PLC0415
 
-    reason = _get_csrf_failure_reason(controller.request)
-    if reason:
+    is_failed, reason = _check_csrf_failure(controller.request)
+
+    if is_failed:
         raise APIError(
             controller.format_error(_CSRF_FAILED_MSG.format(reason=reason)),
             status_code=HTTPStatus.FORBIDDEN,

--- a/dmr/internal/csrf.py
+++ b/dmr/internal/csrf.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from dmr.serializer import BaseSerializer
 
 _CSRF_FAILED_MSG: Final = _('CSRF Failed: {reason}')
-_NON_DEBUG_CSRF_FAILED_REASON: Final = 'Forbidden.'
 
 
 @final
@@ -28,29 +27,26 @@ class _EnsureCsrfToken(CsrfViewMiddleware):
         # Otherwise, provide default placeholder reason.
 
         if settings.DEBUG:
-            return reason
+            return _CSRF_FAILED_MSG.format(reason=reason)  # type: ignore[no-any-return]
 
-        return _NON_DEBUG_CSRF_FAILED_REASON
+        return 'CSRF Failed.'
 
 
-def _check_csrf_failure(request: HttpRequest) -> tuple[bool, str | None]:
+def _check_csrf_failure(request: HttpRequest) -> str | None:
     """Perform CSRF validation using ``_EnsureCsrfToken``."""
     check = _EnsureCsrfToken(lambda _: None)  # type: ignore[arg-type]
     check.process_request(request)
-    reason = check.process_view(request, None, (), {})  # type: ignore[arg-type]
-    is_failed = reason is not None
-
-    return is_failed, reason  # type: ignore[return-value]
+    return check.process_view(request, None, (), {})  # type: ignore[arg-type, return-value]
 
 
 def ensure_csrf(controller: 'Controller[BaseSerializer]') -> None:
     """Raise ``APIError`` (403) if the CSRF check fails."""
     from dmr.response import APIError  # noqa: PLC0415
 
-    is_failed, reason = _check_csrf_failure(controller.request)
+    reason = _check_csrf_failure(controller.request)
 
-    if is_failed:
+    if reason is not None:
         raise APIError(
-            controller.format_error(_CSRF_FAILED_MSG.format(reason=reason)),
+            controller.format_error(reason),
             status_code=HTTPStatus.FORBIDDEN,
         )

--- a/docs/pages/integrations.rst
+++ b/docs/pages/integrations.rst
@@ -45,7 +45,8 @@ By default we exempt all controllers from CSRF checks, unless:
    without CSRF is not secure
 
 .. note::
-   ``note`` Detailed CSRF failure reason on response content will be exposed only in debug mode.
+   Detailed CSRF failure reason on response content will be exposed only in debug mode
+   for security reasons.
 
 .. _bring-your-own-di:
 

--- a/docs/pages/integrations.rst
+++ b/docs/pages/integrations.rst
@@ -44,6 +44,8 @@ By default we exempt all controllers from CSRF checks, unless:
    will require CSRF as well. Because using Django sessions
    without CSRF is not secure
 
+.. note::
+   ``note`` Detailed CSRF failure reason on response content will be exposed only in debug mode.
 
 .. _bring-your-own-di:
 

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+with_debug_mode_changed_csrf_failure = pytest.mark.parametrize(
+    ('debug_mode', 'expected_csrf_railure_reason'),
+    [
+        (True, 'CSRF cookie not set.'),
+        (False, 'Forbidden.'),
+    ],
+)

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -17,7 +17,7 @@ CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
 def assert_csrf_failure_message(
     settings: LazySettings,
     request: pytest.FixtureRequest,
-) -> 'CsrfFailureAssertion':
+) -> CsrfFailureAssertion:
     """Assert CSRF failure message according to debug mode setting."""
     is_debug_mode_active = request.param
     settings.DEBUG = is_debug_mode_active

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -10,20 +10,13 @@ from inline_snapshot import snapshot
 CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
 
 
-@pytest.fixture(
-    params=[True, False],
-    ids=['debug_on', 'debug_off'],
-)
 def assert_csrf_failure_message(
     settings: LazySettings,
-    request: pytest.FixtureRequest,
 ) -> CsrfFailureAssertion:
     """Assert CSRF failure message according to debug mode setting."""
-    is_debug_mode_active = request.param
-    settings.DEBUG = is_debug_mode_active
 
-    def _assert(response: HttpResponse) -> None:
-        if is_debug_mode_active:
+    def factory(response: HttpResponse) -> None:
+        if settings.DEBUG:
             assert json.loads(response.content) == snapshot({
                 'detail': [{'msg': 'CSRF Failed: CSRF cookie not set.'}],
             })

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -7,8 +7,7 @@ from django.conf import LazySettings
 from django.http import HttpResponse
 from inline_snapshot import snapshot
 
-if TYPE_CHECKING:
-    CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
+CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
 
 
 @pytest.fixture(

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -1,10 +1,14 @@
 import json
 from collections.abc import Callable
+from typing import TYPE_CHECKING, TypeAlias
 
 import pytest
 from django.conf import LazySettings
 from django.http import HttpResponse
 from inline_snapshot import snapshot
+
+if TYPE_CHECKING:
+    CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
 
 
 @pytest.fixture(
@@ -14,7 +18,7 @@ from inline_snapshot import snapshot
 def assert_csrf_failure_message(
     settings: LazySettings,
     request: pytest.FixtureRequest,
-) -> Callable[[HttpResponse], None]:
+) -> 'CsrfFailureAssertion':
     """Assert CSRF failure message according to debug mode setting."""
     is_debug_mode_active = request.param
     settings.DEBUG = is_debug_mode_active

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -2,6 +2,7 @@ import json
 from collections.abc import Callable
 from typing import TypeAlias
 
+import pytest
 from django.conf import LazySettings
 from django.http import HttpResponse
 from inline_snapshot import snapshot
@@ -9,10 +10,16 @@ from inline_snapshot import snapshot
 CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
 
 
+@pytest.fixture(
+    params=(True, False),
+    ids=('debug_on', 'debug_off'),
+)
 def assert_csrf_failure_message(
     settings: LazySettings,
+    request: pytest.FixtureRequest,
 ) -> CsrfFailureAssertion:
     """Assert CSRF failure message according to debug mode setting."""
+    settings.DEBUG = request.param
 
     def factory(response: HttpResponse) -> None:
         if settings.DEBUG:

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -7,48 +7,26 @@ from django.http import HttpResponse
 from inline_snapshot import snapshot
 
 
-def _assert_on_debug(
-    response: HttpResponse,
-    *,
-    uses_custom_error_model: bool = False,
-) -> None:
-    if uses_custom_error_model:
-        assert json.loads(response.content) == snapshot({
-            'error': [{'message': 'CSRF Failed: CSRF cookie not set.'}],
-        })
-    else:
-        assert json.loads(response.content) == snapshot({
-            'detail': [{'msg': 'CSRF Failed: CSRF cookie not set.'}],
-        })
-
-
-def _assert_on_non_debug(
-    response: HttpResponse,
-    *,
-    uses_custom_error_model: bool = False,
-) -> None:
-    if uses_custom_error_model:
-        assert json.loads(response.content) == snapshot({
-            'error': [{'message': 'CSRF Failed.'}],
-        })
-    else:
-        assert json.loads(response.content) == snapshot({
-            'detail': [{'msg': 'CSRF Failed.'}],
-        })
-
-
 @pytest.fixture(
-    params=[
-        (True, _assert_on_debug),
-        (False, _assert_on_non_debug),
-    ],
+    params=[(True), (False)],
     ids=['debug_on', 'debug_off'],
 )
 def assert_csrf_failure_message(
     settings: LazySettings,
     request: pytest.FixtureRequest,
-) -> Callable[[HttpResponse, bool], None]:
+) -> Callable[[HttpResponse], None]:
     """Assert CSRF failure message according to debug mode setting."""
-    debug_value, assert_function = request.param
-    settings.DEBUG = debug_value
-    return assert_function  # type: ignore[no-any-return]
+    is_debug_mode_active = request.param
+    settings.DEBUG = is_debug_mode_active
+
+    def _assert(response: HttpResponse) -> None:
+        if is_debug_mode_active:
+            assert json.loads(response.content) == snapshot({
+                'detail': [{'msg': 'CSRF Failed: CSRF cookie not set.'}],
+            })
+        else:
+            assert json.loads(response.content) == snapshot({
+                'detail': [{'msg': 'CSRF Failed.'}],
+            })
+
+    return _assert

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TypeAlias
 
 import pytest
 from django.conf import LazySettings

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -2,7 +2,6 @@ import json
 from collections.abc import Callable
 from typing import TypeAlias
 
-import pytest
 from django.conf import LazySettings
 from django.http import HttpResponse
 from inline_snapshot import snapshot
@@ -25,4 +24,4 @@ def assert_csrf_failure_message(
                 'detail': [{'msg': 'CSRF Failed.'}],
             })
 
-    return _assert
+    return factory

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -1,9 +1,54 @@
-import pytest
+import json
+from collections.abc import Callable
 
-with_debug_mode_changed_csrf_failure = pytest.mark.parametrize(
-    ('debug_mode', 'expected_csrf_railure_reason'),
-    [
-        (True, 'CSRF cookie not set.'),
-        (False, 'Forbidden.'),
+import pytest
+from django.conf import LazySettings
+from django.http import HttpResponse
+from inline_snapshot import snapshot
+
+
+def _assert_on_debug(
+    response: HttpResponse,
+    *,
+    uses_custom_error_model: bool = False,
+) -> None:
+    if uses_custom_error_model:
+        assert json.loads(response.content) == snapshot({
+            'error': [{'message': 'CSRF Failed: CSRF cookie not set.'}],
+        })
+    else:
+        assert json.loads(response.content) == snapshot({
+            'detail': [{'msg': 'CSRF Failed: CSRF cookie not set.'}],
+        })
+
+
+def _assert_on_non_debug(
+    response: HttpResponse,
+    *,
+    uses_custom_error_model: bool = False,
+) -> None:
+    if uses_custom_error_model:
+        assert json.loads(response.content) == snapshot({
+            'error': [{'message': 'CSRF Failed.'}],
+        })
+    else:
+        assert json.loads(response.content) == snapshot({
+            'detail': [{'msg': 'CSRF Failed.'}],
+        })
+
+
+@pytest.fixture(
+    params=[
+        (True, _assert_on_debug),
+        (False, _assert_on_non_debug),
     ],
+    ids=['debug_on', 'debug_off'],
 )
+def assert_csrf_failure_message(
+    settings: LazySettings,
+    request: pytest.FixtureRequest,
+) -> Callable[[HttpResponse, bool], None]:
+    """Assert CSRF failure message according to debug mode setting."""
+    debug_value, assert_function = request.param
+    settings.DEBUG = debug_value
+    return assert_function  # type: ignore[no-any-return]

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -11,7 +11,7 @@ CsrfFailureAssertion: TypeAlias = Callable[[HttpResponse], None]
 
 
 @pytest.fixture(
-    params=[(True), (False)],
+    params=[True, False],
     ids=['debug_on', 'debug_off'],
 )
 def assert_csrf_failure_message(

--- a/tests/test_unit/test_plugins/test_pydantic/test_error_model_customization.py
+++ b/tests/test_unit/test_plugins/test_pydantic/test_error_model_customization.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from typing import final
 
 from dirty_equals import IsStr
+from django.conf import LazySettings
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest, HttpResponse
 from inline_snapshot import snapshot
@@ -14,6 +15,7 @@ from dmr.errors import ErrorType, format_error
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security.django_session import DjangoSessionSyncAuth
 from dmr.test import DMRRequestFactory
+from tests.test_unit.conftest import with_debug_mode_changed_csrf_failure
 
 
 @final
@@ -70,11 +72,16 @@ class _CustomErrorModelController(
         )
 
 
+@with_debug_mode_changed_csrf_failure
 def test_error_message_controller_customization(
     dmr_rf: DMRRequestFactory,
     fill_csrf: Callable[[HttpRequest], HttpRequest],
+    settings: LazySettings,
+    debug_mode: bool,  # noqa: FBT001
+    expected_csrf_railure_reason: str,
 ) -> None:
     """Ensures we can customize error message via controller."""
+    settings.DEBUG = debug_mode
     metadata = _CustomErrorModelController.api_endpoints['POST'].metadata
     assert metadata.responses == snapshot({
         HTTPStatus.CREATED: ResponseSpec(
@@ -139,7 +146,7 @@ def test_error_message_controller_customization(
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.FORBIDDEN, response.content
     assert json.loads(response.content) == snapshot({
-        'error': [{'message': 'CSRF Failed: CSRF cookie not set.'}],
+        'error': [{'message': f'CSRF Failed: {expected_csrf_railure_reason}'}],
     })
 
     request = dmr_rf.post('/whatever/', data={})

--- a/tests/test_unit/test_plugins/test_pydantic/test_error_model_customization.py
+++ b/tests/test_unit/test_plugins/test_pydantic/test_error_model_customization.py
@@ -1,9 +1,11 @@
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Protocol, final
+from typing import final
 
+import pytest
 from dirty_equals import IsStr
+from django.conf import LazySettings
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest, HttpResponse
 from inline_snapshot import snapshot
@@ -70,21 +72,20 @@ class _CustomErrorModelController(
         )
 
 
-class _CsrfFailureAssertion(Protocol):
-    def __call__(
-        self,
-        response: HttpResponse,
-        *,
-        uses_custom_error_model: bool = False,
-    ) -> None: ...
-
-
+@pytest.mark.parametrize(
+    'debug_mode',
+    [True, False],
+    ids=['debug_on', 'debug_off'],
+)
 def test_error_message_controller_customization(
     dmr_rf: DMRRequestFactory,
     fill_csrf: Callable[[HttpRequest], HttpRequest],
-    assert_csrf_failure_message: _CsrfFailureAssertion,
+    settings: LazySettings,
+    *,
+    debug_mode: bool,
 ) -> None:
     """Ensures we can customize error message via controller."""
+    settings.DEBUG = debug_mode
     metadata = _CustomErrorModelController.api_endpoints['POST'].metadata
     assert metadata.responses == snapshot({
         HTTPStatus.CREATED: ResponseSpec(
@@ -148,7 +149,15 @@ def test_error_message_controller_customization(
     response = _CustomErrorModelController.as_view()(request)
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.FORBIDDEN, response.content
-    assert_csrf_failure_message(response, uses_custom_error_model=True)
+
+    if settings.DEBUG:
+        assert json.loads(response.content) == snapshot({
+            'error': [{'message': 'CSRF Failed: CSRF cookie not set.'}],
+        })
+    else:
+        assert json.loads(response.content) == snapshot({
+            'error': [{'message': 'CSRF Failed.'}],
+        })
 
     request = dmr_rf.post('/whatever/', data={})
     fill_csrf(request)

--- a/tests/test_unit/test_plugins/test_pydantic/test_error_model_customization.py
+++ b/tests/test_unit/test_plugins/test_pydantic/test_error_model_customization.py
@@ -1,10 +1,9 @@
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import final
+from typing import Protocol, final
 
 from dirty_equals import IsStr
-from django.conf import LazySettings
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest, HttpResponse
 from inline_snapshot import snapshot
@@ -15,7 +14,6 @@ from dmr.errors import ErrorType, format_error
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.security.django_session import DjangoSessionSyncAuth
 from dmr.test import DMRRequestFactory
-from tests.test_unit.conftest import with_debug_mode_changed_csrf_failure
 
 
 @final
@@ -72,16 +70,21 @@ class _CustomErrorModelController(
         )
 
 
-@with_debug_mode_changed_csrf_failure
+class _CsrfFailureAssertion(Protocol):
+    def __call__(
+        self,
+        response: HttpResponse,
+        *,
+        uses_custom_error_model: bool = False,
+    ) -> None: ...
+
+
 def test_error_message_controller_customization(
     dmr_rf: DMRRequestFactory,
     fill_csrf: Callable[[HttpRequest], HttpRequest],
-    settings: LazySettings,
-    debug_mode: bool,  # noqa: FBT001
-    expected_csrf_railure_reason: str,
+    assert_csrf_failure_message: _CsrfFailureAssertion,
 ) -> None:
     """Ensures we can customize error message via controller."""
-    settings.DEBUG = debug_mode
     metadata = _CustomErrorModelController.api_endpoints['POST'].metadata
     assert metadata.responses == snapshot({
         HTTPStatus.CREATED: ResponseSpec(
@@ -145,9 +148,7 @@ def test_error_message_controller_customization(
     response = _CustomErrorModelController.as_view()(request)
     assert isinstance(response, HttpResponse)
     assert response.status_code == HTTPStatus.FORBIDDEN, response.content
-    assert json.loads(response.content) == snapshot({
-        'error': [{'message': f'CSRF Failed: {expected_csrf_railure_reason}'}],
-    })
+    assert_csrf_failure_message(response, uses_custom_error_model=True)
 
     request = dmr_rf.post('/whatever/', data={})
     fill_csrf(request)

--- a/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
@@ -28,6 +28,7 @@ from dmr.security.jwt import (
 )
 from dmr.security.jwt.auth.base import BaseJWTSyncAuth
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+from tests.test_unit.conftest import with_debug_mode_changed_csrf_failure
 
 _LEEWAY: Final = 30  # seconds
 
@@ -162,12 +163,16 @@ async def test_async_cookie_jwt_auth(
 
 
 @pytest.mark.django_db
+@with_debug_mode_changed_csrf_failure
 def test_sync_cookie_jwt_auth_csrf_enforced(
     dmr_rf: DMRRequestFactory,
     admin_user: User,
     settings: LazySettings,
+    debug_mode: bool,  # noqa: FBT001
+    expected_csrf_railure_reason: str,
 ) -> None:
     """Ensures CookieJWTSyncAuth rejects POST without a CSRF token."""
+    settings.DEBUG = debug_mode
 
     class _CookieController(Controller[PydanticFastSerializer]):
         auth = (CookieJWTSyncAuth(),)
@@ -189,7 +194,7 @@ def test_sync_cookie_jwt_auth_csrf_enforced(
     assert json.loads(response.content) == snapshot({
         'detail': [
             {
-                'msg': 'CSRF Failed: CSRF cookie not set.',
+                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
             },
         ],
     })
@@ -197,12 +202,16 @@ def test_sync_cookie_jwt_auth_csrf_enforced(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
+@with_debug_mode_changed_csrf_failure
 async def test_async_cookie_jwt_auth_csrf_enforced(
     dmr_async_rf: DMRAsyncRequestFactory,
     admin_user: User,
     settings: LazySettings,
+    debug_mode: bool,  # noqa: FBT001
+    expected_csrf_railure_reason: str,
 ) -> None:
     """Ensures CookieJWTAsyncAuth rejects POST without a CSRF token."""
+    settings.DEBUG = debug_mode
 
     class _AsyncCookieController(Controller[PydanticFastSerializer]):
         auth = (CookieJWTAsyncAuth(),)
@@ -226,7 +235,7 @@ async def test_async_cookie_jwt_auth_csrf_enforced(
     assert json.loads(response.content) == snapshot({
         'detail': [
             {
-                'msg': 'CSRF Failed: CSRF cookie not set.',
+                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
             },
         ],
     })

--- a/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
@@ -2,7 +2,7 @@ import datetime as dt
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Final
+from typing import Final, Protocol
 
 import pytest
 from django.conf import LazySettings
@@ -28,9 +28,17 @@ from dmr.security.jwt import (
 )
 from dmr.security.jwt.auth.base import BaseJWTSyncAuth
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
-from tests.test_unit.conftest import with_debug_mode_changed_csrf_failure
 
 _LEEWAY: Final = 30  # seconds
+
+
+class _CsrfFailureAssertion(Protocol):
+    def __call__(
+        self,
+        response: HttpResponse,
+        *,
+        uses_custom_error_model: bool = False,
+    ) -> None: ...
 
 
 def _encode(user: User, secret: str) -> str:
@@ -163,16 +171,13 @@ async def test_async_cookie_jwt_auth(
 
 
 @pytest.mark.django_db
-@with_debug_mode_changed_csrf_failure
 def test_sync_cookie_jwt_auth_csrf_enforced(
     dmr_rf: DMRRequestFactory,
     admin_user: User,
     settings: LazySettings,
-    debug_mode: bool,  # noqa: FBT001
-    expected_csrf_railure_reason: str,
+    assert_csrf_failure_message: _CsrfFailureAssertion,
 ) -> None:
     """Ensures CookieJWTSyncAuth rejects POST without a CSRF token."""
-    settings.DEBUG = debug_mode
 
     class _CookieController(Controller[PydanticFastSerializer]):
         auth = (CookieJWTSyncAuth(),)
@@ -190,28 +195,19 @@ def test_sync_cookie_jwt_auth_csrf_enforced(
     response = _CookieController.as_view()(request)
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.FORBIDDEN
-    assert json.loads(response.content) == snapshot({
-        'detail': [
-            {
-                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
-            },
-        ],
-    })
+    assert response.status_code == HTTPStatus.FORBIDDEN, response.content
+    assert_csrf_failure_message(response)
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-@with_debug_mode_changed_csrf_failure
 async def test_async_cookie_jwt_auth_csrf_enforced(
     dmr_async_rf: DMRAsyncRequestFactory,
     admin_user: User,
     settings: LazySettings,
-    debug_mode: bool,  # noqa: FBT001
-    expected_csrf_railure_reason: str,
+    assert_csrf_failure_message: _CsrfFailureAssertion,
 ) -> None:
     """Ensures CookieJWTAsyncAuth rejects POST without a CSRF token."""
-    settings.DEBUG = debug_mode
 
     class _AsyncCookieController(Controller[PydanticFastSerializer]):
         auth = (CookieJWTAsyncAuth(),)
@@ -231,14 +227,8 @@ async def test_async_cookie_jwt_auth_csrf_enforced(
     )
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.FORBIDDEN
-    assert json.loads(response.content) == snapshot({
-        'detail': [
-            {
-                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
-            },
-        ],
-    })
+    assert response.status_code == HTTPStatus.FORBIDDEN, response.content
+    assert_csrf_failure_message(response)
 
 
 @pytest.mark.django_db

--- a/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
@@ -2,7 +2,7 @@ import datetime as dt
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
 from django.conf import LazySettings
@@ -28,6 +28,9 @@ from dmr.security.jwt import (
 )
 from dmr.security.jwt.auth.base import BaseJWTSyncAuth
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+
+if TYPE_CHECKING:
+    from tests.test_unit.conftest import CsrfFailureAssertion
 
 _LEEWAY: Final = 30  # seconds
 
@@ -166,7 +169,7 @@ def test_sync_cookie_jwt_auth_csrf_enforced(
     dmr_rf: DMRRequestFactory,
     admin_user: User,
     settings: LazySettings,
-    assert_csrf_failure_message: Callable[[HttpResponse], None],
+    assert_csrf_failure_message: 'CsrfFailureAssertion',
 ) -> None:
     """Ensures CookieJWTSyncAuth rejects POST without a CSRF token."""
 
@@ -196,7 +199,7 @@ async def test_async_cookie_jwt_auth_csrf_enforced(
     dmr_async_rf: DMRAsyncRequestFactory,
     admin_user: User,
     settings: LazySettings,
-    assert_csrf_failure_message: Callable[[HttpResponse], None],
+    assert_csrf_failure_message: 'CsrfFailureAssertion',
 ) -> None:
     """Ensures CookieJWTAsyncAuth rejects POST without a CSRF token."""
 

--- a/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
+++ b/tests/test_unit/test_security/test_jwt/test_jwt_cookie_auth.py
@@ -2,7 +2,7 @@ import datetime as dt
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Final, Protocol
+from typing import Final
 
 import pytest
 from django.conf import LazySettings
@@ -30,15 +30,6 @@ from dmr.security.jwt.auth.base import BaseJWTSyncAuth
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 
 _LEEWAY: Final = 30  # seconds
-
-
-class _CsrfFailureAssertion(Protocol):
-    def __call__(
-        self,
-        response: HttpResponse,
-        *,
-        uses_custom_error_model: bool = False,
-    ) -> None: ...
 
 
 def _encode(user: User, secret: str) -> str:
@@ -175,7 +166,7 @@ def test_sync_cookie_jwt_auth_csrf_enforced(
     dmr_rf: DMRRequestFactory,
     admin_user: User,
     settings: LazySettings,
-    assert_csrf_failure_message: _CsrfFailureAssertion,
+    assert_csrf_failure_message: Callable[[HttpResponse], None],
 ) -> None:
     """Ensures CookieJWTSyncAuth rejects POST without a CSRF token."""
 
@@ -205,7 +196,7 @@ async def test_async_cookie_jwt_auth_csrf_enforced(
     dmr_async_rf: DMRAsyncRequestFactory,
     admin_user: User,
     settings: LazySettings,
-    assert_csrf_failure_message: _CsrfFailureAssertion,
+    assert_csrf_failure_message: Callable[[HttpResponse], None],
 ) -> None:
     """Ensures CookieJWTAsyncAuth rejects POST without a CSRF token."""
 

--- a/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
+++ b/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from typing import Final
 
 import pytest
-from django.conf import settings
+from django.conf import LazySettings
 from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
 from inline_snapshot import snapshot
@@ -20,6 +20,7 @@ from dmr.security.token import (
 )
 from dmr.security.token.app.models import Token
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+from tests.test_unit.conftest import with_debug_mode_changed_csrf_failure
 
 _CORRECT_TEMPLATE: Final = '{0}'
 
@@ -106,11 +107,16 @@ async def test_async_cookie_token_auth_success(
 
 
 @pytest.mark.django_db
+@with_debug_mode_changed_csrf_failure
 def test_sync_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_rf: DMRRequestFactory,
+    settings: LazySettings,
+    debug_mode: bool,  # noqa: FBT001
+    expected_csrf_railure_reason: str,
 ) -> None:
     """Ensures CookieTokenSyncAuth rejects POST without a CSRF token."""
+    settings.DEBUG = debug_mode
 
     class _CookieController(Controller[PydanticFastSerializer]):
         auth = (CookieTokenSyncAuth(),)
@@ -135,7 +141,7 @@ def test_sync_cookie_token_auth_csrf_enforced(
     assert json.loads(response.content) == snapshot({
         'detail': [
             {
-                'msg': 'CSRF Failed: CSRF cookie not set.',
+                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
             },
         ],
     })
@@ -143,11 +149,16 @@ def test_sync_cookie_token_auth_csrf_enforced(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
+@with_debug_mode_changed_csrf_failure
 async def test_async_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_async_rf: DMRAsyncRequestFactory,
+    settings: LazySettings,
+    debug_mode: bool,  # noqa: FBT001
+    expected_csrf_railure_reason: str,
 ) -> None:
     """Ensures CookieTokenAsyncAuth rejects POST without a CSRF token."""
+    settings.DEBUG = debug_mode
 
     class _AsyncCookieController(Controller[PydanticFastSerializer]):
         auth = (CookieTokenAsyncAuth(),)
@@ -174,7 +185,7 @@ async def test_async_cookie_token_auth_csrf_enforced(
     assert json.loads(response.content) == snapshot({
         'detail': [
             {
-                'msg': 'CSRF Failed: CSRF cookie not set.',
+                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
             },
         ],
     })
@@ -279,6 +290,7 @@ def test_cookie_auth_try_next_sync(
 async def test_cookie_auth_try_next_async(
     dmr_async_rf: DMRAsyncRequestFactory,
     admin_user: User,
+    settings: LazySettings,
 ) -> None:
     """Ensures async controllers work with token auth."""
 

--- a/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
+++ b/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Final, Protocol
+from typing import Final
 
 import pytest
 from django.conf import LazySettings
@@ -21,15 +21,6 @@ from dmr.security.token.app.models import Token
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
 
 _CORRECT_TEMPLATE: Final = '{0}'
-
-
-class _CsrfFailureAssertion(Protocol):
-    def __call__(
-        self,
-        response: HttpResponse,
-        *,
-        uses_custom_error_model: bool = False,
-    ) -> None: ...
 
 
 @pytest.mark.django_db
@@ -118,7 +109,7 @@ def test_sync_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_rf: DMRRequestFactory,
     settings: LazySettings,
-    assert_csrf_failure_message: _CsrfFailureAssertion,
+    assert_csrf_failure_message: Callable[[HttpResponse], None],
 ) -> None:
     """Ensures CookieTokenSyncAuth rejects POST without a CSRF token."""
 
@@ -151,7 +142,7 @@ async def test_async_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_async_rf: DMRAsyncRequestFactory,
     settings: LazySettings,
-    assert_csrf_failure_message: _CsrfFailureAssertion,
+    assert_csrf_failure_message: Callable[[HttpResponse], None],
 ) -> None:
     """Ensures CookieTokenAsyncAuth rejects POST without a CSRF token."""
 

--- a/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
+++ b/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
@@ -1,13 +1,12 @@
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Final
+from typing import Final, Protocol
 
 import pytest
 from django.conf import LazySettings
 from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
-from inline_snapshot import snapshot
 
 from dmr import Controller
 from dmr.plugins.pydantic import PydanticFastSerializer
@@ -20,9 +19,17 @@ from dmr.security.token import (
 )
 from dmr.security.token.app.models import Token
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
-from tests.test_unit.conftest import with_debug_mode_changed_csrf_failure
 
 _CORRECT_TEMPLATE: Final = '{0}'
+
+
+class _CsrfFailureAssertion(Protocol):
+    def __call__(
+        self,
+        response: HttpResponse,
+        *,
+        uses_custom_error_model: bool = False,
+    ) -> None: ...
 
 
 @pytest.mark.django_db
@@ -107,16 +114,13 @@ async def test_async_cookie_token_auth_success(
 
 
 @pytest.mark.django_db
-@with_debug_mode_changed_csrf_failure
 def test_sync_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_rf: DMRRequestFactory,
     settings: LazySettings,
-    debug_mode: bool,  # noqa: FBT001
-    expected_csrf_railure_reason: str,
+    assert_csrf_failure_message: _CsrfFailureAssertion,
 ) -> None:
     """Ensures CookieTokenSyncAuth rejects POST without a CSRF token."""
-    settings.DEBUG = debug_mode
 
     class _CookieController(Controller[PydanticFastSerializer]):
         auth = (CookieTokenSyncAuth(),)
@@ -137,28 +141,19 @@ def test_sync_cookie_token_auth_csrf_enforced(
     response = _CookieController.as_view()(request)
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.FORBIDDEN
-    assert json.loads(response.content) == snapshot({
-        'detail': [
-            {
-                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
-            },
-        ],
-    })
+    assert response.status_code == HTTPStatus.FORBIDDEN, response.content
+    assert_csrf_failure_message(response)
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
-@with_debug_mode_changed_csrf_failure
 async def test_async_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_async_rf: DMRAsyncRequestFactory,
     settings: LazySettings,
-    debug_mode: bool,  # noqa: FBT001
-    expected_csrf_railure_reason: str,
+    assert_csrf_failure_message: _CsrfFailureAssertion,
 ) -> None:
     """Ensures CookieTokenAsyncAuth rejects POST without a CSRF token."""
-    settings.DEBUG = debug_mode
 
     class _AsyncCookieController(Controller[PydanticFastSerializer]):
         auth = (CookieTokenAsyncAuth(),)
@@ -181,14 +176,8 @@ async def test_async_cookie_token_auth_csrf_enforced(
     )
 
     assert isinstance(response, HttpResponse)
-    assert response.status_code == HTTPStatus.FORBIDDEN
-    assert json.loads(response.content) == snapshot({
-        'detail': [
-            {
-                'msg': f'CSRF Failed: {expected_csrf_railure_reason}',
-            },
-        ],
-    })
+    assert response.status_code == HTTPStatus.FORBIDDEN, response.content
+    assert_csrf_failure_message(response)
 
 
 @pytest.mark.django_db

--- a/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
+++ b/tests/test_unit/test_security/test_token/test_token_auth/test_cookie_auth.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
 from django.conf import LazySettings
@@ -19,6 +19,9 @@ from dmr.security.token import (
 )
 from dmr.security.token.app.models import Token
 from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+
+if TYPE_CHECKING:
+    from tests.test_unit.conftest import CsrfFailureAssertion
 
 _CORRECT_TEMPLATE: Final = '{0}'
 
@@ -109,7 +112,7 @@ def test_sync_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_rf: DMRRequestFactory,
     settings: LazySettings,
-    assert_csrf_failure_message: Callable[[HttpResponse], None],
+    assert_csrf_failure_message: 'CsrfFailureAssertion',
 ) -> None:
     """Ensures CookieTokenSyncAuth rejects POST without a CSRF token."""
 
@@ -142,7 +145,7 @@ async def test_async_cookie_token_auth_csrf_enforced(
     admin_user: User,
     dmr_async_rf: DMRAsyncRequestFactory,
     settings: LazySettings,
-    assert_csrf_failure_message: Callable[[HttpResponse], None],
+    assert_csrf_failure_message: 'CsrfFailureAssertion',
 ) -> None:
     """Ensures CookieTokenAsyncAuth rejects POST without a CSRF token."""
 


### PR DESCRIPTION
# What's been done

On non-debug mode, it will leave `reason` as "Forbidden.".

As I see, middleware overrides `_reject` - so that view will return reason(string) only. If csrf failure succeeds, it will return `None`(in django's implementation).

I've renamed the `_get_csrf_failure_reason` into `_check_csrf_failure` so that it will explicitly says "csrf failed", its more readable too.

No new tests, rather I adapted existing ones - to make them run on debug/non-debug mode, and check csrf failure body accordingly.

To avoid redundancy(same multiple pytest parametrize decorator), I've created new `conftest.py` not sure whether this the best approach.

Saw this one:

https://github.com/wemake-services/django-modern-rest/blob/58ae46f9d1de6e2cf174479aeb1441c36b57bd77/tests/test_integration/conftest.py#L34-L39

I don't think this fully applicable.

One small unrelated change on `test_cookie_auth_try_next_async`, I think tests should not directly use `settings`.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result - **not used any**

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc) - **explained above**
- [x] I have created at least one test case for the changes I have made - adapted affected/existing ones**
- [x] I have updated the documentation for the changes I have made

## Related issues

Closes #1332 
