### PR TITLE
docs: improve grammar and wording on getting started

### DIFF
--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -65,8 +65,8 @@ Extras for different features:
   unless you want to serve static files for OpenAPI.
 
 
-LLM support
------------
+LLMs support
+------------
 
 Are you using AI for assisted coding?
 We've got you covered. Use these files for context to make sure that the LLM

--- a/docs/pages/getting-started.rst
+++ b/docs/pages/getting-started.rst
@@ -44,32 +44,32 @@ Extras for different features:
   `jwt <https://pyjwt.readthedocs.io>`_ support
 - ``'django-modern-rest[openapi]'`` for
   `OpenAPI schema validation <https://github.com/python-openapi/openapi-spec-validator>`_
-  and better examples generation
+  and better example generation
 
 
 .. important::
 
-  We highly recommend to always install
+  We highly recommend always installing
   `msgspec <https://github.com/jcrist/msgspec>`_, even when using just
-  `pydantic <https://github.com/pydantic/pydantic>`_ for APIs,
-  because we use ``msgspec`` to parse ``json``, when it is available,
-  since it is `the fastest <https://msgspec.dev/benchmarks>`_
+  `pydantic <https://github.com/pydantic/pydantic>`_ for APIs.
+  We use ``msgspec`` to parse ``json`` when it is available
+  because it is `the fastest <https://msgspec.dev/benchmarks>`_
   library out there for this task.
 
-  We also recommend to always install `django-stubs`_
+  We also recommend always installing `django-stubs`_
   for typing Django itself.
 
 .. note::
 
-  You don't need to add ``'dmr'`` to ``INSTALLED_APPS``,
+  You don't need to add ``'dmr'`` to ``INSTALLED_APPS``
   unless you want to serve static files for OpenAPI.
 
 
-LLMs support
-------------
+LLM support
+-----------
 
 Are you using AI for assisted coding?
-We got you covered, use these files for context to make sure that the LLM
+We've got you covered. Use these files for context to make sure that the LLM
 knows our framework:
 
 - https://django-modern-rest.readthedocs.io/llms.txt
@@ -79,14 +79,14 @@ knows our framework:
 
 We also support
 `Context7 <https://context7.com/wemake-services/django-modern-rest>`_
-for up-to-date docs for the LLMs.
+for up-to-date docs for LLMs.
 
 Use cases we officially support:
 
 - Learning ``django-modern-rest`` with the help
   of `DeepWiki <https://deepwiki.com/wemake-services/django-modern-rest>`_
 - AI-guided migrations for any API changes.
-  We break something? We provide a prompt for you, so you can automatically
+  Did we break something? We provide a prompt for you, so you can automatically
   upgrade to a newer version using an AI tool of your choice
 
 We support several custom agent skills:
@@ -129,7 +129,7 @@ Let's see the basics and learn how to use ``dmr`` in a single example:
     .. tip::
 
       If you only use ``json`` :doc:`parsers and renderers <negotiation>`,
-      it would be faster to use
+      it is faster to use
       :class:`~dmr.plugins.pydantic.PydanticFastSerializer` instead.
 
     .. literalinclude:: /examples/getting_started/pydantic_controller.py
@@ -184,28 +184,28 @@ Let's see the basics and learn how to use ``dmr`` in a single example:
 .. important::
 
   You can choose a serializer per controller, which will give you
-  the freedom to choose the best serializer and model for the job.
+  the freedom to pick the best serializer and model for the job.
   ``msgspec`` gives you more speed,
   while ``pydantic`` gives you more flexibility.
 
 
 In this example:
 
-1. We defined regular ``pydantic``, ``msgspec``, or whatever models
-   that we will use for our API
-2. We added two component parsers: one for request's
+1. We defined regular ``pydantic``, ``msgspec``, or any other models
+   we will use for our API
+2. We added two component parsers: one for the request's
    :data:`~dmr.components.Body` and one
-   for :data:`~dmr.components.Headers`
+   for :data:`~dmr.components.Headers`,
    which will parse them into the typed models
    that we pass to these components as type parameters
-3. Next we created
+3. Next, we created
    a :class:`~dmr.controller.Controller` class
    with :class:`~dmr.plugins.pydantic.PydanticSerializer`
    or :class:`~dmr.plugins.msgspec.MsgspecSerializer`
    to serialize input and output data for us
-4. We also defined ``post`` API endpoint and returned
-   a simple model response from it, it will be automatically
-   transformed into :class:`django.http.HttpResponse` instance
+4. We also defined a ``post`` API endpoint and returned
+   a simple model response from it. It will be automatically
+   transformed into a :class:`django.http.HttpResponse` instance
    by ``django-modern-rest``
 
 Now, let's add our controller to the list of URLs:
@@ -218,7 +218,7 @@ Now, let's add our controller to the list of URLs:
 Your first ``django-modern-rest`` API is ready.
 Next, you can learn:
 
-- How to generate OpenAPI schema
+- How to generate an OpenAPI schema
 - How to handle errors
 - How to customize controllers and endpoints
 
@@ -230,16 +230,16 @@ If you were ever told that Django is too big and complicated,
 that was misleading, to say the least.
 
 Here's a :doc:`single-file application <structure/micro-framework>`
-that looks pretty much the same as any other micro-framework, like:
+that looks pretty much the same as any other micro-framework, like
 FastAPI, Litestar, or Flask.
 
 .. literalinclude:: /examples/structure/micro_framework/single_file_asgi.py
    :language: python
    :linenos:
 
-You can copy it by clicking "Copy" in the right upper corner of the example,
-it shows up on hovering the code example. Paste it as ``example.py``,
-install the ``django-modern-rest`` and run it with:
+You can copy it by clicking "Copy" in the upper-right corner of the example.
+The copy button appears when you hover over the code example. Paste it as ``example.py``,
+install ``django-modern-rest``, and run it with:
 
 .. tabs::
 
@@ -265,7 +265,7 @@ Your API is now live:
 
 - ``POST`` http://localhost:8000/api/user/ — create a user
 
-And then visit https://localhost:8000/docs/swagger/ for the interactive docs.
+Then visit http://localhost:8000/docs/swagger/ for the interactive docs.
 
 .. image:: /_static/images/swagger.png
    :alt: Swagger view
@@ -274,33 +274,34 @@ And then visit https://localhost:8000/docs/swagger/ for the interactive docs.
 That's it, enjoy your new project!
 
 
-But, this is too simple for my use-case!
-----------------------------------------
+But this is too simple for my use case!
+---------------------------------------
 
 What is great about Django is that it scales.
-You can start with a single file app and scale it up to a full
-featured monolith with strict context boundaries, DDD, reusable apps, etc.
+You can start with a single-file app and scale it up to a full-featured
+monolith with strict context boundaries, DDD, reusable apps, etc.
 
 We recommend starting new big projects with
-https://github.com/wemake-services/wemake-django-template
+https://github.com/wemake-services/wemake-django-template.
 
-It is strict, security-first, battle-proven, highload-tested boilerplate
-for real apps of the modern age.
+It is a strict, security-first, battle-proven, highload-tested
+boilerplate for real apps of the modern age.
 
 
 Type checking
 -------------
 
-``django-modern-rest`` officially supports all major Python type-checkers
-in strict modes (listed in the order of recommendation):
+``django-modern-rest`` officially supports all major Python type checkers
+in strict mode (listed in order of recommendation):
 
-- `mypy <https://github.com/python/mypy>`_ which has the best support
-  due to `django-stubs`_ plugin
+- `mypy <https://github.com/python/mypy>`_, which has the best support
+  due to the `django-stubs`_ plugin
 - `pyrefly <https://github.com/facebook/pyrefly>`_
 - `pyright <https://github.com/microsoft/pyright>`_
 - `ty <https://github.com/astral-sh/ty>`_
 
 Installing `django-stubs`_ is required for all of them.
+
 
 Next up
 -------

--- a/docs/pages/openapi/openapi.rst
+++ b/docs/pages/openapi/openapi.rst
@@ -41,7 +41,7 @@ Here's how it works:
   :language: python
   :linenos:
 
-And then visit https://localhost:8000/docs/swagger/ (or any other renderer)
+And then visit http://localhost:8000/docs/swagger/ (or any other renderer)
 for the interactive docs.
 
 .. image:: /_static/images/swagger.png


### PR DESCRIPTION
# I have made things!

Improve grammar and wording (such as missing articles) on the getting started page.

And, use consistent localhost URL scheme (http instead of https).

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
