### PR TITLE
Add controller-level `tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ are stored as descriptions in version releases on GitHub, example:
 https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 
+## 0.16.0 WIP
+
+### Features
+
+- Added `tags` controller attribute to apply OpenAPI tags
+  to all endpoints of this controller. They are merged
+  with router-level and endpoint-level tags, #1434
+
+
 ## 0.15.0 (2026-09-11)
 
 ### Breaking changes

--- a/dmr/controller.py
+++ b/dmr/controller.py
@@ -128,6 +128,9 @@ class Controller(View, Generic[_SerializerT_co]):  # noqa: WPS214
             Is ``True`` by default.
         summary: A short summary of what this path item does.
         description: A verbose explanation of the path item behavior.
+        tags: A list of tags to group all operations
+            from this controller in OpenAPI documentation.
+            These are merged with router-level and endpoint-level tags.
         servers: An alternative servers array to service this path item.
         ignore_from_spec: If set to ``True``, all endpoints from this controller
             would not be added to the final OpenAPI spec.
@@ -178,6 +181,7 @@ class Controller(View, Generic[_SerializerT_co]):  # noqa: WPS214
     # OpenAPI:
     summary: ClassVar['_StrOrPromise | None'] = None
     description: ClassVar['_StrOrPromise | None'] = None
+    tags: ClassVar[Sequence[str] | None] = None
     servers: ClassVar[Sequence[Server] | None] = None
     ignore_from_spec: ClassVar[bool] = False
 

--- a/dmr/internal/endpoint.py
+++ b/dmr/internal/endpoint.py
@@ -259,6 +259,7 @@ class _ModifyEndpoint:  # we can't use slots here, because docs won't build :(
         description: A verbose explanation of the operation behavior.
         tags: A list of tags for API documentation control.
             Used to group operations in OpenAPI documentation.
+            These are merged with controller-level and router-level tags.
         operation_id: Unique string used to identify the operation.
         deprecated: Declares this operation to be deprecated.
         external_docs: Additional external documentation for this operation.
@@ -645,6 +646,7 @@ class _ValidateEndpoint:  # we can't use slots here, because docs won't build :(
         description: A verbose explanation of the operation behavior.
         tags: A list of tags for API documentation control.
             Used to group operations in OpenAPI documentation.
+            These are merged with controller-level and router-level tags.
         operation_id: Unique string used to identify the operation.
         deprecated: Declares this operation to be deprecated.
         external_docs: Additional external documentation for this operation.

--- a/dmr/metadata.py
+++ b/dmr/metadata.py
@@ -408,6 +408,8 @@ class EndpointMetadata:
         description: A verbose explanation of the operation behavior.
         tags: A list of tags for API documentation control.
             Used to group operations in OpenAPI documentation.
+            Controller-level tags are already included here,
+            router-level ones are added during the schema generation.
         operation_id: Unique string used to identify the operation.
         deprecated: Declares this operation to be deprecated.
         security: A declaration of which security mechanisms can be used

--- a/dmr/validation/endpoint_metadata.py
+++ b/dmr/validation/endpoint_metadata.py
@@ -475,7 +475,7 @@ class EndpointMetadataBuilder:  # noqa: WPS214
             validate_events=self._build_validate_events(),
             summary=summary,
             description=description,
-            tags=payload.tags,
+            tags=self._build_tags(payload.tags),
             operation_id=payload.operation_id,
             deprecated=payload.deprecated,
             external_docs=payload.external_docs,
@@ -539,7 +539,7 @@ class EndpointMetadataBuilder:  # noqa: WPS214
             validate_events=self._build_validate_events(),
             summary=summary,
             description=description,
-            tags=payload.tags,
+            tags=self._build_tags(payload.tags),
             operation_id=payload.operation_id,
             deprecated=payload.deprecated,
             external_docs=payload.external_docs,
@@ -597,7 +597,7 @@ class EndpointMetadataBuilder:  # noqa: WPS214
             validate_events=self._build_validate_events(),
             summary=summary,
             description=description,
-            tags=None,
+            tags=self._build_tags(None),
             operation_id=None,
             deprecated=False,
             external_docs=None,
@@ -892,6 +892,15 @@ class EndpointMetadataBuilder:  # noqa: WPS214
         if self.payload and self.payload.ignore_from_spec is not None:
             return self.payload.ignore_from_spec
         return self.controller_cls.ignore_from_spec
+
+    def _build_tags(self, payload_tags: list[str] | None) -> list[str] | None:
+        # Controller tags are prepended to the endpoint ones,
+        # the same way router tags are prepended to these later on.
+        tags = [
+            *(self.controller_cls.tags or []),
+            *(payload_tags or []),
+        ]
+        return tags or None
 
     def _build_error_handler(
         self,

--- a/docs/examples/openapi/controller_tags.py
+++ b/docs/examples/openapi/controller_tags.py
@@ -1,0 +1,16 @@
+from dmr import Controller, modify
+from dmr.plugins.msgspec import MsgspecSerializer
+
+
+class UserController(Controller[MsgspecSerializer]):
+    tags = ('users',)  # All endpoints are tagged as 'users'
+
+    def get(self) -> str:
+        return 'get'
+
+    @modify(tags=['admin'])  # This one is tagged as 'users' and 'admin'
+    def post(self) -> str:
+        return 'post'
+
+
+# openapi: {"controller": "UserController", "openapi_url": "/docs/openapi.json/"}  # noqa: ERA001, E501

--- a/docs/pages/openapi/openapi.rst
+++ b/docs/pages/openapi/openapi.rst
@@ -333,6 +333,32 @@ You can also set ``tags`` and ``deprecated`` at the individual endpoint level
 via :deco:`~dmr.endpoint.modify` to override or extend router-level settings.
 
 
+.. _customizing_tags_openapi:
+
+Customizing tags
+~~~~~~~~~~~~~~~~
+
+Tags can be defined on three levels:
+
+1. On a router with the ``tags`` parameter
+2. On a controller with
+   the :attr:`~dmr.controller.Controller.tags` attribute,
+   it applies to all endpoints of this controller
+3. On an endpoint with the ``tags`` parameter
+   of :deco:`~dmr.endpoint.modify` or :deco:`~dmr.endpoint.validate`
+
+All of them are merged together in this exact order,
+none of them replaces the others:
+
+.. literalinclude:: /examples/openapi/controller_tags.py
+  :caption: views.py
+  :language: python
+  :linenos:
+
+.. versionadded:: 0.16.0
+  Controller-level ``tags``.
+
+
 .. _customizing_parameter_openapi:
 
 Customizing parameter

--- a/tests/test_unit/test_openapi/__snapshots__/test_controller_tags.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_controller_tags.ambr
@@ -1,0 +1,210 @@
+# serializer version: 1
+# name: test_controller_tags_schema
+  '''
+  {
+    "info": {
+      "title": "Your Awesome Project",
+      "version": "0.1.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {
+      "/api/v1/users/": {
+        "get": {
+          "tags": [
+            "v1",
+            "users"
+          ],
+          "operationId": "getTaggedcontrollerApiV1Users",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/_SimpleModel"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Raised when returned response does not match the response schema",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Raised when provided `Accept` header cannot be satisfied",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            }
+          },
+          "deprecated": false
+        },
+        "put": {
+          "tags": [
+            "v1",
+            "users",
+            "admin"
+          ],
+          "operationId": "putTaggedcontrollerApiV1Users",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/_SimpleModel"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Raised when returned response does not match the response schema",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Raised when provided `Accept` header cannot be satisfied",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            }
+          },
+          "deprecated": false
+        },
+        "post": {
+          "tags": [
+            "v1",
+            "users",
+            "admin"
+          ],
+          "operationId": "postTaggedcontrollerApiV1Users",
+          "responses": {
+            "201": {
+              "description": "Created",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/_SimpleModel"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Raised when returned response does not match the response schema",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Raised when provided `Accept` header cannot be satisfied",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ErrorModel"
+                  }
+                }
+              }
+            }
+          },
+          "deprecated": false
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "ErrorDetail": {
+          "properties": {
+            "msg": {
+              "type": "string",
+              "title": "Msg"
+            },
+            "type": {
+              "type": "string",
+              "title": "Type"
+            },
+            "loc": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array",
+              "title": "Loc"
+            }
+          },
+          "type": "object",
+          "required": [
+            "msg"
+          ],
+          "title": "ErrorDetail",
+          "description": "Base schema for error details description."
+        },
+        "ErrorModel": {
+          "properties": {
+            "detail": {
+              "items": {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              "type": "array",
+              "title": "Detail"
+            }
+          },
+          "type": "object",
+          "required": [
+            "detail"
+          ],
+          "title": "ErrorModel",
+          "description": "Default error response schema.\n\nCan be customized.\nSee :ref:`customizing-error-messages` for more details."
+        },
+        "_SimpleModel": {
+          "properties": {
+            "id": {
+              "type": "integer",
+              "title": "Id"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          "type": "object",
+          "required": [
+            "id",
+            "name"
+          ],
+          "title": "_SimpleModel"
+        }
+      },
+      "securitySchemes": {}
+    }
+  }
+  '''
+# ---

--- a/tests/test_unit/test_openapi/test_controller_tags.py
+++ b/tests/test_unit/test_openapi/test_controller_tags.py
@@ -1,0 +1,93 @@
+import json
+from http import HTTPStatus
+
+import pydantic
+from django.http import HttpResponse
+from django.urls import path
+from syrupy.assertion import SnapshotAssertion
+
+from dmr import Controller, ResponseSpec, modify, validate
+from dmr.openapi import build_schema
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.routing import Router
+
+
+class _SimpleModel(pydantic.BaseModel):
+    id: int
+    name: str
+
+
+class _TaggedController(Controller[PydanticSerializer]):
+    tags = ('users',)
+
+    def get(self) -> _SimpleModel:
+        raise NotImplementedError
+
+    @modify(tags=['admin'])
+    def post(self) -> _SimpleModel:
+        raise NotImplementedError
+
+    @validate(
+        ResponseSpec(_SimpleModel, status_code=HTTPStatus.OK),
+        tags=['admin'],
+    )
+    def put(self) -> HttpResponse:
+        raise NotImplementedError
+
+
+def test_controller_tags() -> None:
+    """Controller tags are applied to all endpoints of this controller."""
+    assert _TaggedController.api_endpoints['GET'].metadata.tags == ['users']
+    assert _TaggedController.api_endpoints['POST'].metadata.tags == [
+        'users',
+        'admin',
+    ]
+    assert _TaggedController.api_endpoints['PUT'].metadata.tags == [
+        'users',
+        'admin',
+    ]
+
+
+def test_controller_tags_schema(snapshot: SnapshotAssertion) -> None:
+    """Router, controller, and endpoint tags are merged in this order."""
+    assert (
+        json.dumps(
+            build_schema(
+                Router(
+                    'api/v1/users/',
+                    [path('', _TaggedController.as_view())],
+                    tags=['v1'],
+                ),
+            ).convert(),
+            indent=2,
+        )
+        == snapshot
+    )
+
+
+class _UntaggedController(Controller[PydanticSerializer]):
+    def get(self) -> _SimpleModel:
+        raise NotImplementedError
+
+    @modify(tags=['admin'])
+    def post(self) -> _SimpleModel:
+        raise NotImplementedError
+
+
+def test_no_controller_tags() -> None:
+    """Endpoint tags are not affected when a controller has no tags."""
+    assert _UntaggedController.api_endpoints['GET'].metadata.tags is None
+    assert _UntaggedController.api_endpoints['POST'].metadata.tags == ['admin']
+
+
+class _SubTaggedController(_TaggedController):
+    tags = ('admins',)
+
+
+def test_subclass_controller_tags() -> None:
+    """Subclasses can redefine tags of the base controller."""
+    assert _SubTaggedController.api_endpoints['GET'].metadata.tags == ['admins']
+    assert _SubTaggedController.api_endpoints['POST'].metadata.tags == [
+        'admins',
+        'admin',
+    ]


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`Controller.tags`, a class-level attribute that applies OpenAPI tags to every endpoint of the controller. We had tags per endpoint and per router, but nothing in between.

The merge happens in `EndpointMetadataBuilder._build_tags`, so controller tags are already in `EndpointMetadata.tags` by the time the class is built. `Endpoint.get_schema` prepends router tags to whatever the metadata holds, so it needed no changes at all. The final order comes out router, controller, endpoint.

Controller tags merge with endpoint ones instead of replacing them, the way router tags already merge: `@modify(tags=['admin'])` inside a controller tagged `'users'` gives you both. This is the one call I am unsure about. `ignore_from_spec` goes the other way, where the endpoint value wins over the controller one, so there is an argument for override here too. It is a two-line change in `_build_tags` if you prefer that.

Docs get a new "Customizing tags" section that lists all three levels in one place, with a runnable example. `CHANGELOG.md` opens `0.16.0 WIP`, since `0.15.0` is already released.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1434
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
