### PR TITLE
test: cover __dmr_converter_schema__ path converter customization

### DIFF
--- a/tests/test_unit/test_openapi/test_schema_snapshots.py
+++ b/tests/test_unit/test_openapi/test_schema_snapshots.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from typing import Annotated, ClassVar, TypeAlias
 
 import pydantic
-from django.urls import path, re_path
+from django.urls import path, re_path, register_converter
 from syrupy.assertion import SnapshotAssertion
 
 from dmr import Body, Controller, Cookies, Path, Query, ResponseSpec
@@ -262,6 +262,41 @@ class _GetPostController(Controller[PydanticSerializer]):
 
     def get(self) -> str:
         raise NotImplementedError
+
+
+
+class _YearIntConverter:
+    """Custom converter that reports ``int`` via ``__dmr_converter_schema__``."""
+
+    regex = '[0-9]{4}'
+    __dmr_converter_schema__ = int
+
+    def to_python(self, value: str) -> int:
+        return int(value)
+
+    def to_url(self, value: int) -> str:
+        return str(value)
+
+
+def test_custom_converter_schema() -> None:
+    """Ensure ``__dmr_converter_schema__`` is used for custom path converters."""
+    register_converter(_YearIntConverter, 'dmr_year_int')
+    schema = build_schema(
+        Router(
+            'api/v1/',
+            [
+                path(
+                    'archive/<dmr_year_int:year>/',
+                    _GetPostController.as_view(),
+                ),
+            ],
+        ),
+    ).convert()
+    params = schema['paths']['/api/v1/archive/{year}/']['get']['parameters']
+    year_param = next(param for param in params if param['name'] == 'year')
+    assert year_param['in'] == 'path'
+    assert year_param['required'] is True
+    assert year_param['schema']['type'] == 'integer'
 
 
 def test_raw_path_schema(snapshot: SnapshotAssertion) -> None:

--- a/tests/test_unit/test_openapi/test_schema_snapshots.py
+++ b/tests/test_unit/test_openapi/test_schema_snapshots.py
@@ -264,7 +264,6 @@ class _GetPostController(Controller[PydanticSerializer]):
         raise NotImplementedError
 
 
-
 class _YearIntConverter:
     """Custom converter that reports ``int`` via ``__dmr_converter_schema__``."""
 

--- a/tests/test_unit/test_openapi/test_schema_validation.py
+++ b/tests/test_unit/test_openapi/test_schema_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from django.urls import path
+from django.urls import path, register_converter
 from faker import Faker
 from inline_snapshot import snapshot
 from syrupy.assertion import SnapshotAssertion
@@ -7,6 +7,7 @@ from typing_extensions import override
 
 from dmr import Controller, modify
 from dmr.endpoint import Endpoint
+from dmr.exceptions import UnsolvableAnnotationsError
 from dmr.openapi import OpenAPIConfig, build_schema
 from dmr.openapi.objects import (
     Components,
@@ -141,3 +142,45 @@ def test_schema_validation_after_cache_clear() -> None:
         match=r'["\']scheme["\'] is a required property',
     ):
         schema.convert()
+
+
+class _UnserializableConverterType:
+    """Type that cannot be converted into an OpenAPI schema."""
+
+
+class _InvalidSchemaConverter:
+    """Custom converter whose schema type cannot be serialized."""
+
+    regex = '[^/]+'
+    __dmr_converter_schema__ = _UnserializableConverterType
+
+    def to_python(self, value: str) -> str:
+        return value
+
+    def to_url(self, value: str) -> str:
+        return value
+
+
+class _InvalidConverterController(Controller[PydanticSerializer]):
+    def get(self) -> str:
+        raise NotImplementedError
+
+
+def test_invalid_converter_schema_fails_validation() -> None:
+    """Ensure invalid ``__dmr_converter_schema__`` fails schema generation."""
+    register_converter(_InvalidSchemaConverter, 'dmr_invalid_schema')
+    router = Router(
+        'api/v1/',
+        [
+            path(
+                'item/<dmr_invalid_schema:item>/',
+                _InvalidConverterController.as_view(),
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        UnsolvableAnnotationsError,
+        match='Cannot generate OpenAPI schema',
+    ):
+        build_schema(router).convert()


### PR DESCRIPTION
## Summary

Adds tests for the documented `__dmr_converter_schema__` attribute on custom Django path converters.

Closes #1440

## Motivation

`ComponentParserGenerator` already reads `__dmr_converter_schema__` when building path-parameter schemas, but that path was untested.

## Implementation

- Valid customization: register a converter whose `__dmr_converter_schema__` is `int` and assert the generated path parameter schema type is `integer`.
- Invalid customization: register a converter whose schema type cannot be serialized and assert `UnsolvableAnnotationsError` is raised during `build_schema(...).convert()`.

## Testing

Behavior of both cases was checked against the current generator by constructing a `Router` with `register_converter` and calling `build_schema(...).convert()`:

- valid converter produced `{type: integer}` for the path parameter
- unserializable converter type raised `UnsolvableAnnotationsError` matching `Cannot generate OpenAPI schema`

Full project `just unit` was not run in this environment because the sandbox could not install the complete extra/dev stack (system PyJWT / missing venv tooling). CI on this PR should run the usual unit and lint jobs.