### PR TITLE
Remove OpenAPI 3.0.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ are stored as descriptions in version releases on GitHub, example:
 https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 
+## 0.16.0 WIP
+
+### Breaking changes
+
+- `OpenAPIConfig` now raises `ValueError` for `openapi_version` below `3.1.0`.
+  OpenAPI `3.0.x` was never really supported: it predates JSON Schema,
+  which is what `pydantic` and `msgspec` generate for our models, #1435
+
+
 ## 0.15.0 (2026-09-11)
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - [x] Fully typed and checked with `mypy`, `pyright`, `ty`, and `pyrefly` in strict modes
 - [x] Supports content negotiation, has default implementations for `json`, `msgpack`, SSE, Json Lines, and more
 - [x] Strict schema validation of both requests and responses, including errors
-- [x] Supports OpenAPI 3.0 / 3.1 / 3.2 semantic schema generation out of the box
+- [x] Supports OpenAPI 3.1 / 3.2 semantic schema generation out of the box
 - [x] Supports all your existing `django` primitives and packages, no custom runtimes
 - [x] Great testing tools with [schemathesis](https://github.com/schemathesis/schemathesis), [polyfactory](https://github.com/litestar-org/polyfactory), [tracecov](https://django-modern-rest.readthedocs.io/en/latest/pages/testing/tracecov.html), bundled `pytest` plugin, and default Django's testing primitives
 - [x] 100% test coverage with 3000+ of carefully designed unit, integration, typing, and property-based tests

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -81,6 +81,10 @@ class OpenAPIConfig:
             ValueError: if ``openapi_version`` is older than ``'3.1.0'``.
 
         """
+        # NOTE: we don't limit the upper bound on purpose,
+        # we would only limit in the future if case
+        # of a real incompatibility. There's a high chance
+        # that it will just work (c)
         if self.openapi_version_info[:2] < _MIN_OPENAPI_VERSION:
             raise ValueError(
                 'OpenAPI versions before 3.1.0 are not supported, because '

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import cast
+from typing import Final, cast
 
 from dmr.openapi.objects import (  # noqa: WPS235
     Components,
@@ -12,6 +12,9 @@ from dmr.openapi.objects import (  # noqa: WPS235
     Server,
     Tag,
 )
+
+#: Oldest OpenAPI version we support: earlier ones are not JSON Schema based.
+_MIN_OPENAPI_VERSION: Final = (3, 1)
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -30,6 +33,8 @@ class OpenAPIConfig:
         version: Version of your API
             (your application's own version, not the OpenAPI spec version).
         openapi_version: Version of the OpenAPI specification to target.
+            Only ``'3.1.0'`` and newer versions are supported,
+            because older ones are not based on JSON Schema.
             Defaults to ``'3.1.0'``.
         summary: Short, one-line summary of the API.
         description: Longer description of the API. May use CommonMark syntax.
@@ -45,6 +50,10 @@ class OpenAPIConfig:
         tags: Metadata tags used to group operations in the documentation.
         webhooks: Webhook definitions that may be initiated by the API,
             keyed by name.
+
+    .. versionchanged:: 0.16.0
+        ``openapi_version`` older than ``'3.1.0'`` now raises a ``ValueError``.
+
     """
 
     title: str
@@ -63,6 +72,21 @@ class OpenAPIConfig:
     servers: list[Server] | None = None
     tags: list[Tag] | None = None
     webhooks: dict[str, PathItem | Reference] | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Validates that ``openapi_version`` is supported.
+
+        Raises:
+            ValueError: if ``openapi_version`` is older than ``'3.1.0'``.
+
+        """
+        if self.openapi_version_info[:2] < _MIN_OPENAPI_VERSION:
+            raise ValueError(
+                'OpenAPI versions before 3.1.0 are not supported, because '
+                'they are not based on JSON Schema, which is what we use '
+                f'to generate model schemas, got {self.openapi_version!r}',
+            )
 
     @property
     def openapi_version_info(self) -> tuple[int, int, int]:

--- a/docs/pages/openapi/openapi.rst
+++ b/docs/pages/openapi/openapi.rst
@@ -1,13 +1,20 @@
 OpenAPI
 =======
 
-We support OpenAPI versions from ``3.0.0`` through ``3.2.0``.
+We support OpenAPI versions from ``3.1.0`` through ``3.2.0``.
 
 .. note::
 
   By default, we use OpenAPI ``3.1.0``, since tooling such as Swagger, Scalar,
   Redoc, and Stoplight does not yet fully support the latest specification.
   You can track the `current progress here <https://github.com/wemake-services/django-modern-rest/issues/519>`_.
+
+.. important::
+
+  OpenAPI ``3.0.x`` is not supported. It predates JSON Schema,
+  while we generate all model schemas as JSON Schema with ``pydantic``
+  or ``msgspec``. Passing it to :class:`dmr.openapi.OpenAPIConfig`
+  raises a ``ValueError``.
 
 
 Setting up OpenAPI views

--- a/tests/test_unit/test_openapi/test_config.py
+++ b/tests/test_unit/test_openapi/test_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from dmr.openapi import OpenAPIConfig
+
+
+@pytest.mark.parametrize(
+    'openapi_version',
+    [
+        '3.1.0',
+        '3.1.1',
+        '3.2.0',
+        '4.0.0',
+    ],
+)
+def test_supported_openapi_versions(openapi_version: str) -> None:
+    """Ensures that ``3.1.0`` and newer versions are allowed."""
+    config = OpenAPIConfig(
+        title='my title',
+        version='1.0.0',
+        openapi_version=openapi_version,
+    )
+
+    assert config.openapi_version == openapi_version
+
+
+@pytest.mark.parametrize(
+    'openapi_version',
+    [
+        '3.0.0',
+        '3.0.4',
+        '2.0.0',
+    ],
+)
+def test_unsupported_openapi_versions(openapi_version: str) -> None:
+    """Ensures that versions older than ``3.1.0`` are rejected."""
+    with pytest.raises(ValueError, match=r'versions before 3\.1\.0'):
+        OpenAPIConfig(
+            title='my title',
+            version='1.0.0',
+            openapi_version=openapi_version,
+        )


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`OpenAPIConfig` now raises `ValueError` for any `openapi_version` below `3.1.0`.

There was no 3.0 code path to remove. Nothing branches on the version except `openapi_version_info >= (3, 2)` in `dmr/metadata.py:139`, for `itemSchema`. The string went straight into the `openapi` field at `dmr/openapi/core/merger.py:27` and nothing else read it.

It did not even produce a valid 3.0 document. With the `[openapi]` extra installed, the test app's schema declared as `3.0.3` fails `openapi-spec-validator` on `info.license.identifier`, and on `info.summary` once you drop the license. Both are 3.1-only fields, so the validator stops there and never reaches the model schemas the issue is about.

The check sits in `__post_init__` and compares `(major, minor)`, so `'3.1'` passes along with `'3.1.1'` and `'3.2.0'`. You get the error when you build the config, not when you build the schema.

I left `load_schema` alone. It reads a foreign spec into our dataclasses rather than generating one, and the fixture behind it, `django-allauth.yml`, is a 3.0.3 document. Refusing to read those is a different call from the one the issue asks for, so I left it.

The changelog entry went into a new `0.16.0 WIP` section, since 0.15.0 is already out and this breaks anyone passing `3.0.x`. Renumber it if you had something else in mind.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1435
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
