### PR TITLE
Increase default DMR_MAX_CACHE_SIZE to 1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ are stored as descriptions in version releases on GitHub, example:
 https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 
+## Unreleased
+
+### Features
+
+- Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
+
+
 ## 0.15.0 (2026-09-11)
 
 ### Breaking changes

--- a/dmr/envs.py
+++ b/dmr/envs.py
@@ -5,7 +5,7 @@ from typing import Final
 # ---------------------------
 
 #: Cache size setting for the whole app cache system.
-MAX_CACHE_SIZE: Final = int(os.environ.get('DMR_MAX_CACHE_SIZE', '256'))
+MAX_CACHE_SIZE: Final = int(os.environ.get('DMR_MAX_CACHE_SIZE', '1024'))
 
 #: Prefer to use compiled modules if available. True by default.
 USE_COMPILED: Final = os.environ.get('DMR_USE_COMPILED', '1').strip() != '0'

--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -552,7 +552,7 @@ Environment variables
 
 .. envvar:: DMR_MAX_CACHE_SIZE
 
-  Default: ``256``
+  Default: ``1024``
 
   We use :func:`functools.lru_cache` in many places internally.
   For example:


### PR DESCRIPTION
Fixes #1448

The default LRU cache size of 256 is too small for projects with many schemas. This raises \`DMR_MAX_CACHE_SIZE\` to **1024** so more schemas stay cached by default.

- \`dmr/envs.py\` default: \`256\` → \`1024\`
- docs \`configuration.rst\` updated to match
- changelog note under Unreleased