### PR TITLE
Explain why `openapi_examples_seed` is global only

### DIFF
--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -480,12 +480,33 @@ OpenAPI
   .. code-block:: python
     :caption: settings.py
 
-    >>> from dmr.settings import HttpSpec
-    >>> from dmr.openapi.config import OpenAPIConfig
-
     >>> DMR_SETTINGS = {
     ...     Settings.openapi_examples_seed: 10,
     ... }
+
+  .. note::
+
+    Unlike most other settings, this one can only be set globally.
+    There are no controller and endpoint level counterparts for it.
+
+    Examples are attached to schemas in ``components/schemas``,
+    and schemas are generated per spec, not per endpoint:
+    a type is turned into a schema once,
+    and every endpoint and controller that uses this type
+    points to that single schema with a ``$ref``.
+
+    So, a schema does not belong to any particular endpoint
+    or controller, and there is nothing to read a local seed from.
+    If several endpoints sharing a schema declared different seeds,
+    the winner would be whichever endpoint happened
+    to be visited first during the spec generation.
+    We prefer one predictable seed
+    over a value that depends on the traversal order.
+
+    Hand-written examples don't have this problem,
+    because they are defined on the type itself,
+    which is exactly where the schema comes from.
+    See :ref:`openapi-examples-generation`.
 
 .. data:: dmr.settings.Settings.openapi_static_cdn
 

--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -486,26 +486,11 @@ OpenAPI
 
   .. note::
 
-    Unlike most other settings, this one can only be set globally.
-    There are no controller and endpoint level counterparts for it.
-
-    Examples are attached to schemas in ``components/schemas``,
-    and schemas are generated per spec, not per endpoint:
-    a type is turned into a schema once,
-    and every endpoint and controller that uses this type
-    points to that single schema with a ``$ref``.
-
-    So, a schema does not belong to any particular endpoint
-    or controller, and there is nothing to read a local seed from.
-    If several endpoints sharing a schema declared different seeds,
-    the winner would be whichever endpoint happened
-    to be visited first during the spec generation.
-    We prefer one predictable seed
-    over a value that depends on the traversal order.
-
-    Hand-written examples don't have this problem,
-    because they are defined on the type itself,
-    which is exactly where the schema comes from.
+    This is a global setting, it cannot be changed
+    per controller or per endpoint.
+    Generated examples are stored on shared ``components/schemas`` entries,
+    which several endpoints and controllers can reference at once,
+    so there's no single endpoint to read a local seed from.
     See :ref:`openapi-examples-generation`.
 
 .. data:: dmr.settings.Settings.openapi_static_cdn

--- a/docs/pages/openapi/openapi.rst
+++ b/docs/pages/openapi/openapi.rst
@@ -423,6 +423,14 @@ but sometimes it is better than nothing.
 
   However, we recommend adding semantic named examples by hand.
 
+.. note::
+
+  The seed is a global setting, it cannot be changed
+  per controller or per endpoint.
+  Generated examples are stored on shared ``components/schemas`` entries,
+  which several endpoints and controllers can reference at once.
+  See :data:`~dmr.settings.Settings.openapi_examples_seed` for the reasoning.
+
 
 Top level API
 -------------


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
Most settings can be set per controller and per endpoint. `openapi_examples_seed` cannot, and the docs did not say why.

The reason is where the generated example ends up. `generate_example` runs while a `Schema` is being built for `components/schemas`, and `SchemaRegistry.register` keys those by name: the second endpoint that needs the same type gets a `$ref` back, and the schema already registered is left alone. So the type becomes a schema once, the example is generated once with it, and every endpoint that uses the type points at that one entry. Nothing there belongs to a single endpoint, so there is no local seed to read. If two endpoints sharing a type asked for different seeds, whichever one the generator reached first would win.

The long version is a note under the setting in `docs/pages/configuration.rst`. `docs/pages/openapi/openapi.rst` gets two sentences and a link to it, because the "Examples generation" section is where people meet the feature before they go looking for the setting.

One thing in the diff that is not the issue: the snippet under that setting imported `HttpSpec` and `OpenAPIConfig` and used neither, which read as if the setting had something to do with them. Dropped both.

I am not sure the second note is wanted. If the explanation belongs only in the settings reference, say so and I will drop it from `openapi.rst`.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1436
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
