### PR TITLE
Copy `re_path` group patterns into parameter schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 ### Features
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
+- Url parameters of `re_path()` routes now have `pattern` in their schema,
+  it is copied from the sub-pattern of the matching named group:
+  `r'^v(?P<version>\d+)/$'` documents `version`
+  as `{'type': 'string', 'pattern': '^(?:\d+)$'}`, #1439
 
 
 ## 0.15.0 (2026-09-11)

--- a/dmr/internal/regex.py
+++ b/dmr/internal/regex.py
@@ -46,8 +46,8 @@ def parse_named_groups(source: str) -> dict[str, str]:
 
 def _closed_named_group(
     source: str,
-    opened: 're.Match[str]',
-    closed: 're.Match[str]',
+    opened: re.Match[str],
+    closed: re.Match[str],
 ) -> dict[str, str]:
     group_name = opened.group('name')
     if group_name is None:  # unnamed group, like `(\d+)`

--- a/dmr/internal/regex.py
+++ b/dmr/internal/regex.py
@@ -1,0 +1,55 @@
+import re
+from typing import Final
+
+#: Tokens that can change the group nesting inside a regex pattern.
+#: Escaped characters and character classes are matched to be skipped:
+#: `\(` and `[(]` do not open any groups.
+_GROUP_TOKENS: Final = re.compile(
+    r"""
+    \\. |                                # escaped char, like `\(`
+    \[ \^? \]? (?: [^\]\\] | \\. )* \] | # char class, like `[^\]]`
+    \(\?P<(?P<name>\w+)> |               # named group, like `(?P<year>`
+    \( |                                 # any other group start
+    \)                                   # group end
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def parse_named_groups(source: str) -> dict[str, str]:
+    r"""
+    Parse sub-patterns of all named groups in a regex pattern.
+
+    We only look at the group nesting, everything that cannot open
+    or close a group is skipped: like ``(`` in ``\(`` and in ``[(]``.
+    Unmatched ``)`` tokens are ignored, they can only happen
+    in patterns we don't fully understand, like verbose mode comments.
+
+    Args:
+        source: Regex pattern source, like ``r'^(?P<year>\d{4})/$'``.
+
+    Returns:
+        Named groups with their sub-patterns, like ``{'year': r'\d{4}'}``.
+
+    """
+    named_groups: dict[str, str] = {}
+    opened_groups: list[re.Match[str]] = []
+    for token in _GROUP_TOKENS.finditer(source):
+        if token.group().startswith('('):
+            opened_groups.append(token)
+        elif token.group() == ')' and opened_groups:
+            named_groups.update(
+                _closed_named_group(source, opened_groups.pop(), token),
+            )
+    return named_groups
+
+
+def _closed_named_group(
+    source: str,
+    opened: 're.Match[str]',
+    closed: 're.Match[str]',
+) -> dict[str, str]:
+    group_name = opened.group('name')
+    if group_name is None:  # unnamed group, like `(\d+)`
+        return {}
+    return {group_name: source[opened.end() : closed.start()]}

--- a/dmr/openapi/generators/component_parsers.py
+++ b/dmr/openapi/generators/component_parsers.py
@@ -1,11 +1,12 @@
 import dataclasses
 import uuid
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, cast
 
 from django.urls import URLPattern, converters
 from typing_extensions import TypedDict
 
+from dmr.internal.regex import parse_named_groups
 from dmr.openapi.objects import (
     MediaType,
     Parameter,
@@ -141,15 +142,39 @@ class ComponentParserGenerator:
         )
         if schema:
             params_list.extend(
-                self._context.generators.parameter(
-                    TypedDict(f'{operation_id}_RePath', schema),  # type: ignore[operator]
-                    (),
-                    serializer,
-                    self._context,
-                    param_in='path',
+                self._add_group_patterns(
+                    self._context.generators.parameter(
+                        TypedDict(f'{operation_id}_RePath', schema),  # type: ignore[operator]
+                        (),
+                        serializer,
+                        self._context,
+                        param_in='path',
+                    ),
+                    regex.pattern,
                 ),
             )
         return params_list or None
+
+    def _add_group_patterns(
+        self,
+        params_list: list[Parameter | Reference],
+        regex_source: str,
+    ) -> list[Parameter | Reference]:
+        # Named groups are wrapped, because otherwise top-level alternations
+        # like `a|b` would only be anchored on one side: `^a|b$`.
+        named_groups = {
+            group_name: f'^(?:{group_source})$'
+            for group_name, group_source in parse_named_groups(
+                regex_source,
+            ).items()
+        }
+        # Named groups are the only source of `re_path()` parameters,
+        # so all the parameters here are plain `str` schemas we've just built.
+        for param_spec in cast('list[Parameter]', params_list):
+            cast('Schema', param_spec.schema).pattern = named_groups.get(
+                param_spec.name,
+            )
+        return params_list
 
     def _merge_bodies(
         self,

--- a/docs/pages/components/path.rst
+++ b/docs/pages/components/path.rst
@@ -55,6 +55,18 @@ use :data:`~dmr.components.Path` component with a model.
   you can use set ``__dmr_converter_schema__`` attribute
   with the specific type that you need in the schema.
 
+.. note::
+
+  With :func:`django.urls.re_path`, url parameters are always typed
+  as ``str``, because we cannot infer any better type from a regex.
+  But, we do copy the sub-pattern of each named group into the schema,
+  so ``r'^v(?P<version>\d+)/$'`` documents ``version``
+  as ``{'type': 'string', 'pattern': '^(?:\d+)$'}``.
+
+  Sub-patterns are copied as-is and only wrapped into anchors,
+  we don't translate them. JSON Schema requires ECMA-262 regexes,
+  so Python-only syntax might not be supported by all OpenAPI tools.
+
 
 Using Path component and parsing models
 ---------------------------------------

--- a/tests/test_unit/test_internal/test_regex.py
+++ b/tests/test_unit/test_internal/test_regex.py
@@ -1,0 +1,45 @@
+import re
+
+import pytest
+
+from dmr.internal.regex import parse_named_groups
+
+
+@pytest.mark.parametrize(
+    ('source', 'named_groups'),
+    [
+        # No groups at all:
+        (r'^articles/$', {}),
+        # Unnamed groups are ignored:
+        (r'^articles/(\d{4})/$', {}),
+        # Regular named groups:
+        (r'^v(?P<version>\d+)/$', {'version': r'\d+'}),
+        (
+            r'^articles/(?P<year>[0-9]{4})/(?P<slug>[\w-]+)/$',
+            {'year': '[0-9]{4}', 'slug': r'[\w-]+'},
+        ),
+        # Top level alternation:
+        (r'^(?P<format>json|xml)$', {'format': 'json|xml'}),
+        # Escaped and quantified parens do not open or close groups:
+        (r'^(?P<price>\d+\(\$\))$', {'price': r'\d+\(\$\)'}),
+        (r'^(?P<call>[()]+)$', {'call': '[()]+'}),
+        (r'^(?P<bracket>[^]]+)$', {'bracket': '[^]]+'}),
+        # Nested groups:
+        (
+            r'^(?P<date>(?P<year>\d{4})-(\d{2}))$',
+            {'date': r'(?P<year>\d{4})-(\d{2})', 'year': r'\d{4}'},
+        ),
+        # Comments are balanced, so they are parsed correctly:
+        (r'^(?#some comment)(?P<id>\d+)$', {'id': r'\d+'}),
+        # Unmatched `)` inside a verbose mode comment is ignored:
+        ('(?x) [a-z]  # ) \n (?P<id>[0-9]+)', {'id': '[0-9]+'}),
+    ],
+)
+def test_parse_named_groups(
+    source: str,
+    named_groups: dict[str, str],
+) -> None:
+    """Ensure that named groups are parsed with their sub-patterns."""
+    assert parse_named_groups(source) == named_groups
+    # All named groups that `re` knows about must be found:
+    assert set(re.compile(source).groupindex) == set(named_groups)

--- a/tests/test_unit/test_openapi/__snapshots__/test_schema_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_schema_snapshots.ambr
@@ -830,6 +830,7 @@
               "in": "path",
               "schema": {
                 "type": "string",
+                "pattern": "^(?:[0-9]{4})$",
                 "title": "Year"
               },
               "required": true
@@ -840,6 +841,7 @@
               "in": "path",
               "schema": {
                 "type": "string",
+                "pattern": "^(?:[\\w-]+)$",
                 "title": "Slug"
               },
               "required": true

--- a/tests/test_unit/test_openapi/test_generators/test_component_generator.py
+++ b/tests/test_unit/test_openapi/test_generators/test_component_generator.py
@@ -2,7 +2,7 @@ import re
 from typing import Annotated, Any, Generic, TypeAlias, TypeVar
 
 import pytest
-from django.urls import path
+from django.urls import path, re_path
 from typing_extensions import override
 
 from dmr import Controller
@@ -10,6 +10,7 @@ from dmr.components import ComponentParser
 from dmr.endpoint import Endpoint
 from dmr.metadata import EndpointMetadata
 from dmr.openapi.core.context import OpenAPIContext
+from dmr.openapi.objects import Parameter, Schema
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.serializer import BaseSerializer
 
@@ -63,3 +64,32 @@ def test_fake_component(openapi_context: OpenAPIContext) -> None:
             _FakeController.api_endpoints['GET'].metadata,
             PydanticSerializer,
         )
+
+
+class _RePathController(Controller[PydanticSerializer]):
+    def get(self) -> str:
+        raise NotImplementedError
+
+
+def test_re_path_group_patterns(openapi_context: OpenAPIContext) -> None:
+    """Ensures that `re_path` groups are copied into parameter schemas."""
+    _, params_list = openapi_context.generators.component_parsers(
+        'unique-operationid',
+        re_path(
+            r'^(?P<year>[0-9]{4})/(?P<format>json|xml)/$',
+            _RePathController.as_view(),
+        ),
+        _RePathController.api_endpoints['GET'].metadata,
+        PydanticSerializer,
+    )
+
+    assert params_list is not None
+    assert [
+        (param_spec.name, param_spec.schema.pattern)
+        for param_spec in params_list
+        if isinstance(param_spec, Parameter)
+        and isinstance(param_spec.schema, Schema)
+    ] == [
+        ('year', '^(?:[0-9]{4})$'),
+        ('format', '^(?:json|xml)$'),
+    ]


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
Named groups of `re_path()` routes now carry their own regex into the schema, so `r'^v(?P<version>\d+)/$'` documents `version` as `{'type': 'string', 'pattern': '^(?:\d+)$'}` and not just `{'type': 'string'}`. The type stays `str`, a regex does not tell us anything better than that.

Getting the sub-pattern out needs the group boundaries and `re` does not expose them, so `dmr/internal/regex.py` scans the source with one tokenizer regex that matches escapes and character classes too, because `\(` and `[(]` must not count as group starts. `_add_group_patterns` then writes the pattern onto the parameters that were just built from the same route.

Two decisions worth a look:

- The sub-pattern is wrapped before it is anchored: `^(?:json|xml)$`, not the `^\d+$` from the issue. A JSON Schema `pattern` is an unanchored search, and a top-level alternation anchored as `^json|xml$` says something else entirely. Four characters per parameter buys that.
- Sub-patterns are copied verbatim, so a nested named group reaches the spec as `(?P<year>\d{4})`, which is Python syntax and not the ECMA-262 that JSON Schema asks for. Translating regex dialects is a much bigger job than this issue, so the caveat is in the docs instead.

Only `re_path()` is touched here. Custom `path()` converters have a `.regex` too and could get the same treatment, but that is its own change.

`parse_named_groups` is tested against `re.compile(...).groupindex` on every case: whatever group `re` finds, the parser has to find as well. The snapshot in `test_raw_path_schema` picked up the two new patterns.

If you would rather have the plain `^\d+$` from the issue, I can wrap only when the sub-pattern has a top-level `|`.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1439
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
