### PR TITLE
Support customizing operation_id generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 ### Features
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
+- Added `OpenAPIConfig.operation_id_generator` to allow customizing
+  `operationId` generation via a callback, #1461
 
 
 ## 0.15.0 (2026-09-11)

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dmr.openapi.objects import (  # noqa: WPS235
     Components,
@@ -12,6 +13,15 @@ from dmr.openapi.objects import (  # noqa: WPS235
     Server,
     Tag,
 )
+
+if TYPE_CHECKING:
+    from dmr.metadata import EndpointMetadata
+    from dmr.serializer import BaseSerializer
+
+    OperationIdGeneratorCallback = Callable[
+        [str, str, EndpointMetadata, type[BaseSerializer]],
+        str,
+    ]
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -45,6 +55,15 @@ class OpenAPIConfig:
         tags: Metadata tags used to group operations in the documentation.
         webhooks: Webhook definitions that may be initiated by the API,
             keyed by name.
+        operation_id_generator: Optional callback used to generate the
+            ``operationId`` for operations that don't have an explicit one
+            set via endpoint metadata. Receives ``(path, suffix, metadata,
+            serializer)`` and must return the final operation id string.
+            When not set, the default ``method + tokenized path`` algorithm
+            is used.
+
+            .. versionadded:: 0.16.0
+
     """
 
     title: str
@@ -63,6 +82,7 @@ class OpenAPIConfig:
     servers: list[Server] | None = None
     tags: list[Tag] | None = None
     webhooks: dict[str, PathItem | Reference] | None = None
+    operation_id_generator: 'OperationIdGeneratorCallback | None' = None
 
     @property
     def openapi_version_info(self) -> tuple[int, int, int]:

--- a/dmr/openapi/generators/operation.py
+++ b/dmr/openapi/generators/operation.py
@@ -44,6 +44,12 @@ class OperationIdGenerator:
             self._context.registries.operation_id.register(operation_id)
             return operation_id
 
+        custom_generator = self._context.config.operation_id_generator
+        if custom_generator is not None:
+            operation_id = custom_generator(path, suffix, metadata, serializer)
+            self._context.registries.operation_id.register(operation_id)
+            return operation_id
+
         # Generate operation_id from path and method
         operation_id = metadata.method.lower() + ''.join(
             self._tokenize_path(suffix + path),

--- a/tests/test_unit/test_openapi/test_generators/test_operation.py
+++ b/tests/test_unit/test_openapi/test_generators/test_operation.py
@@ -144,3 +144,92 @@ def test_explicit_operation_id(generator: OperationIdGenerator) -> None:
 
     assert operation_id == 'customGetUser'
     assert 'customGetUser' in registry._operation_ids
+
+
+class _PlainController(Controller[PydanticSerializer]):
+    def get(self) -> list[int]:
+        raise NotImplementedError
+
+
+def test_default_operation_id_generator_unchanged(
+    generator: OperationIdGenerator,
+) -> None:
+    """Ensure the default algorithm is used when no callback is configured."""
+    assert generator._context.config.operation_id_generator is None
+
+    controller = _PlainController()
+    operation_id = generator(
+        '/users',
+        '',
+        metadata=controller.api_endpoints['GET'].metadata,
+        serializer=PydanticSerializer,
+    )
+
+    assert operation_id == 'getUsers'
+
+
+def test_custom_operation_id_generator() -> None:
+    """Ensure a configured ``operation_id_generator`` callback is used."""
+
+    def custom_generator(
+        path: str,
+        suffix: str,
+        metadata: object,
+        serializer: object,
+    ) -> str:
+        return f'custom_{suffix}_{path}'.replace('/', '_')
+
+    context = OpenAPIContext(
+        OpenAPIConfig(
+            title='Test API',
+            version='1.0.0',
+            operation_id_generator=custom_generator,
+        ),
+    )
+    generator = context.generators.operation_id
+    controller = _PlainController()
+
+    operation_id = generator(
+        '/users',
+        'ctrl',
+        metadata=controller.api_endpoints['GET'].metadata,
+        serializer=PydanticSerializer,
+    )
+
+    registry = generator._context.registries.operation_id
+    assert operation_id == 'custom_ctrl__users'
+    assert operation_id in registry._operation_ids
+
+
+def test_generator_ignored_when_explicit_id() -> None:
+    """Explicit per-endpoint ``operation_id`` still wins over the callback."""
+    calls: list[str] = []
+
+    def custom_generator(
+        path: str,
+        suffix: str,
+        metadata: object,
+        serializer: object,
+    ) -> str:
+        calls.append(path)
+        return 'shouldNotBeUsed'
+
+    context = OpenAPIContext(
+        OpenAPIConfig(
+            title='Test API',
+            version='1.0.0',
+            operation_id_generator=custom_generator,
+        ),
+    )
+    generator = context.generators.operation_id
+    controller = _ControllerWithOperationId()
+
+    operation_id = generator(
+        'whatever',
+        'controller',
+        metadata=controller.api_endpoints['GET'].metadata,
+        serializer=PydanticSerializer,
+    )
+
+    assert operation_id == 'customGetUser'
+    assert not calls


### PR DESCRIPTION
Fixes #1461

Adds `OpenAPIConfig.operation_id_generator`, an optional callback
`(path, suffix, metadata, serializer) -> str` used by
`OperationIdGenerator` to build the `operationId` for operations that
don't have an explicit `operation_id` set via endpoint metadata (which
still always wins, unchanged).

When not set (the default), the existing method + tokenized-path
algorithm is used exactly as before — no behavior change and no
snapshot changes for existing users.

Tests cover: default behavior is unchanged, a custom callback is
invoked and its result registered/returned, and the callback is not
called when an explicit endpoint `operation_id` is present.

`just lint`, `mypy`, and the full `just unit` suite pass locally
(same pre-existing, unrelated flakiness as on `master`: Redis backend
tests requiring local Docker, and the negotiation coverage report
showing 93.02%, both reproduced identically on a clean `master`
checkout before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)