### PR TITLE
Support default values for TypeVar in controller type var inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 ### Features
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
+- `TypeVar` `default=` values (PEP 696) are now honored during controller
+  type var inference when a type var is left unbound, #1452
 
 
 ## 0.15.0 (2026-09-11)

--- a/dmr/types.py
+++ b/dmr/types.py
@@ -317,10 +317,6 @@ class TypeVarInference:
 
             is_needed = type_map.get(type_param.__name__)
             if is_needed:
-                # TODO: most likely this will require
-                # some extra work to support
-                # type var defaults. Right now defaults
-                # are ignored in the resolution.
                 type_map.update({type_param.__name__: type_arg})
                 if isinstance(type_arg, TypeVar):
                     type_map.update({type_arg.__name__: type_arg})
@@ -333,16 +329,26 @@ class TypeVarInference:
         inferenced: dict[TypeVar, Any] = {}
         type_param: Any
         for type_param in type_parameters:
-            orig_type_param = type_param
-            iterations = 0
-            while isinstance(type_param, TypeVar):
-                iterations += 1
-                type_param = type_map[type_param.__name__]
-                if iterations >= self._max_depth:
-                    raise UnsolvableAnnotationsError(
-                        f'Cannot solve type annotations for {type_param!r}. '
-                        f'Is definition for {self._to_infer!r} generic? '
-                        'It must be concrete',
-                    )
-            inferenced.update({orig_type_param: type_param})
+            inferenced[type_param] = self._resolve(type_param, type_map)
         return inferenced
+
+    def _resolve(
+        self,
+        type_param: Any,
+        type_map: dict[str, Any],
+    ) -> Any:
+        iterations = 0
+        while isinstance(type_param, TypeVar):
+            mapped = type_map[type_param.__name__]
+            has_default = getattr(type_param, 'has_default', None)
+            if mapped is type_param and callable(has_default) and has_default():
+                return type_param.__default__
+            iterations += 1
+            type_param = mapped
+            if iterations >= self._max_depth:
+                raise UnsolvableAnnotationsError(
+                    f'Cannot solve type annotations for {type_param!r}. '
+                    f'Is definition for {self._to_infer!r} generic? '
+                    'It must be concrete',
+                )
+        return type_param

--- a/tests/test_unit/test_controllers/test_reusable_generics.py
+++ b/tests/test_unit/test_controllers/test_reusable_generics.py
@@ -6,12 +6,13 @@ from typing import Generic, TypeVar
 import pydantic
 import pytest
 from django.http import HttpResponse
+from typing_extensions import TypeVar as ExtTypeVar
 
 from dmr import Body, Controller, ResponseSpec, validate
 from dmr.exceptions import UnsolvableAnnotationsError
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.serializer import BaseSerializer
-from dmr.types import safe_typevar
+from dmr.types import infer_annotation, safe_typevar
 
 _SerializerT = TypeVar('_SerializerT', bound=BaseSerializer)
 _ModelT = TypeVar('_ModelT')
@@ -125,6 +126,41 @@ def test_generics_in_validate() -> None:
     response = metadata.responses[HTTPStatus.OK]
     assert response.return_type == list[str]
     assert response.status_code == HTTPStatus.OK
+
+
+def test_typevar_default_used_when_unbound() -> None:
+    """A ``TypeVar`` with ``default=`` (PEP 696) resolves when not given."""
+    DefaultModelT = ExtTypeVar('DefaultModelT', default=_BodyModel)
+
+    class _BaseController(
+        Controller[_SerializerT],
+        Generic[_SerializerT, DefaultModelT],
+    ):
+        def post(self, parsed_body: Body[DefaultModelT]) -> str:
+            raise NotImplementedError
+
+    class ConcreteController(_BaseController[PydanticSerializer]):
+        """Leaves ``DefaultModelT`` unbound, so its default is used."""
+
+    assert not ConcreteController.is_abstract
+    metadata = ConcreteController.api_endpoints['POST'].metadata
+    assert metadata.component_parsers[0][1] is _BodyModel
+
+    class OverriddenController(_BaseController[PydanticSerializer, str]):
+        """Explicitly overrides the default."""
+
+    metadata = OverriddenController.api_endpoints['POST'].metadata
+    assert metadata.component_parsers[0][1] is str
+
+
+def test_infer_annotation_uses_default() -> None:
+    """``infer_annotation`` uses ``default=`` for a fully unbound base."""
+    DefaultT = ExtTypeVar('DefaultT', default=int)
+
+    class _Base(Generic[DefaultT]):
+        """Never subscribed, so ``DefaultT`` stays unbound."""
+
+    assert infer_annotation(DefaultT, _Base) is int
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #1452

## Summary

`TypeVarInference` (used to resolve generic type vars declared on `Controller` subclasses) ignored `TypeVar(..., default=...)` (PEP 696) values: if a type var was never bound to a concrete type anywhere in the inheritance chain, resolution would eventually raise `UnsolvableAnnotationsError` instead of falling back to the declared default.

In the common case (a type var re-declared and eventually concretely subscribed through the inheritance chain), Python's own runtime substitution already fills in defaults transparently, so this was already working. The gap was the edge case where a generic base is inherited without ever being subscripted at all (e.g. `class Concrete(Base):` where `Base` is `Generic[T]` with `T` having a default) — `__orig_bases__` doesn't even list `Base` in that case, so dmr's own walk never saw a concrete value and the type var stayed unresolved.

## Changes

- `dmr/types.py`: `TypeVarInference._infer`/`_resolve` now check `type_param.has_default()` when a type var can't be resolved further, and use `type_param.__default__` instead of raising.
- Removed the now-resolved `TODO` about type var defaults.
- Added tests in `tests/test_unit/test_controllers/test_reusable_generics.py`:
  - `test_typevar_default_used_when_unbound`: full `Controller` chain with a `default=`-carrying `TypeVar`, proving both "left unbound → uses default" and "explicitly overridden → uses override".
  - `test_infer_annotation_uses_default`: exercises the specific fallback branch directly (fully unparametrized base).
- `CHANGELOG.md` entry.

## Testing

- `just lint` — passes (ruff, flake8/wemake-python-styleguide, slotscheck, import-linter)
- `uv run python -m mypy .` — passes
- `just unit` — 3367 passed, 11 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)