### PR TITLE
Improve performance of _run_checks and _run_async_checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
 
+### Misc
+
+- Improves the performance of `Endpoint._run_checks`
+  and `Endpoint._run_async_checks` by skipping throttle and auth calls
+  entirely when they are not configured for an endpoint,
+  instead of calling into them and checking internally, #1454
+
 
 ## 0.15.0 (2026-09-11)
 

--- a/dmr/endpoint.py
+++ b/dmr/endpoint.py
@@ -415,29 +415,38 @@ class Endpoint:  # noqa: WPS214
     # Sync checks:
 
     def _run_checks(self, controller: 'Controller[BaseSerializer]') -> None:
-        # First round of throttling:
-        self._run_throttle_before(controller)
+        # Only call the parts that are actually configured for this
+        # endpoint: checking `is None` here avoids the (non-free) call
+        # into a method that would otherwise just check and return.
+        throttling_before_auth = self.metadata.throttling_before_auth
+        if throttling_before_auth is not None:
+            self._run_throttle_before(controller, throttling_before_auth)
         # Negotiate response:
         self.response_negotiator(controller.request)
         # Auth:
-        self._run_auth(controller)
+        auth = self.metadata.auth
+        if auth is not None:
+            self._run_auth(controller, auth)
         # Second round of throttling:
-        self._run_throttle_after(controller)
+        throttling_after_auth = self.metadata.throttling_after_auth
+        if throttling_after_auth is not None:
+            self._run_throttle_after(controller, throttling_after_auth)
 
     def _run_throttle_before(
         self,
         controller: 'Controller[BaseSerializer]',
+        throttles: 'tuple[SyncThrottle | AsyncThrottle, ...]',
     ) -> None:
-        if self.metadata.throttling_before_auth is None:
-            return
-        for throttle in self.metadata.throttling_before_auth:
+        for throttle in throttles:
             assert isinstance(throttle, SyncThrottle)  # noqa: S101
             throttle(self, controller, self._sync_lock)
 
-    def _run_auth(self, controller: 'Controller[BaseSerializer]') -> None:
-        if self.metadata.auth is None:
-            return
-        for auth in self.metadata.auth:
+    def _run_auth(
+        self,
+        controller: 'Controller[BaseSerializer]',
+        auths: 'list[SyncAuth | AsyncAuth]',
+    ) -> None:
+        for auth in auths:
             assert isinstance(auth, SyncAuth)  # noqa: S101
             authed_by = auth(self, controller)
             if authed_by is not None:
@@ -448,10 +457,9 @@ class Endpoint:  # noqa: WPS214
     def _run_throttle_after(
         self,
         controller: 'Controller[BaseSerializer]',
+        throttles: 'tuple[SyncThrottle | AsyncThrottle, ...]',
     ) -> None:
-        if self.metadata.throttling_after_auth is None:
-            return
-        for throttle in self.metadata.throttling_after_auth:
+        for throttle in throttles:
             assert isinstance(throttle, SyncThrottle)  # noqa: S101
             throttle(self, controller, self._sync_lock)
 
@@ -461,22 +469,35 @@ class Endpoint:  # noqa: WPS214
         self,
         controller: 'Controller[BaseSerializer]',
     ) -> None:
-        # First round of throttling:
-        await self._run_async_throttle_before(controller)
+        # Only await the parts that are actually configured for this
+        # endpoint, instead of always awaiting all 4 coroutines and
+        # letting each check internally no-op.
+        throttling_before_auth = self.metadata.throttling_before_auth
+        if throttling_before_auth is not None:
+            await self._run_async_throttle_before(
+                controller,
+                throttling_before_auth,
+            )
         # Negotiate response:
         self.response_negotiator(controller.request)
         # Auth:
-        await self._run_async_auth(controller)
+        auth = self.metadata.auth
+        if auth is not None:
+            await self._run_async_auth(controller, auth)
         # Second round of throttling:
-        await self._run_async_throttle_after(controller)
+        throttling_after_auth = self.metadata.throttling_after_auth
+        if throttling_after_auth is not None:
+            await self._run_async_throttle_after(
+                controller,
+                throttling_after_auth,
+            )
 
     async def _run_async_throttle_before(
         self,
         controller: 'Controller[BaseSerializer]',
+        throttles: 'tuple[SyncThrottle | AsyncThrottle, ...]',
     ) -> None:
-        if self.metadata.throttling_before_auth is None:
-            return
-        for throttle in self.metadata.throttling_before_auth:
+        for throttle in throttles:
             assert isinstance(throttle, AsyncThrottle)  # noqa: S101
             # We have to check them in sync one by one :(
             await throttle(self, controller, self._async_lock)  # noqa: WPS476
@@ -484,10 +505,9 @@ class Endpoint:  # noqa: WPS214
     async def _run_async_auth(
         self,
         controller: 'Controller[BaseSerializer]',
+        auths: 'list[SyncAuth | AsyncAuth]',
     ) -> None:
-        if self.metadata.auth is None:
-            return
-        for auth in self.metadata.auth:
+        for auth in auths:
             assert isinstance(auth, AsyncAuth)  # noqa: S101
             authed_by = await auth(self, controller)  # noqa: WPS476
             if authed_by is not None:
@@ -498,10 +518,9 @@ class Endpoint:  # noqa: WPS214
     async def _run_async_throttle_after(
         self,
         controller: 'Controller[BaseSerializer]',
+        throttles: 'tuple[SyncThrottle | AsyncThrottle, ...]',
     ) -> None:
-        if self.metadata.throttling_after_auth is None:
-            return
-        for throttle in self.metadata.throttling_after_auth:
+        for throttle in throttles:
             assert isinstance(throttle, AsyncThrottle)  # noqa: S101
             # We have to check them in sync one by one :(
             await throttle(self, controller, self._async_lock)  # noqa: WPS476

--- a/tests/test_unit/test_endpoint/test_run_checks_skips_unneeded.py
+++ b/tests/test_unit/test_endpoint/test_run_checks_skips_unneeded.py
@@ -1,0 +1,148 @@
+from http import HTTPMethod
+from unittest import mock
+
+import pytest
+
+from dmr import Controller, modify
+from dmr.plugins.pydantic import PydanticFastSerializer
+from dmr.security.django_session import (
+    DjangoSessionAsyncAuth,
+    DjangoSessionSyncAuth,
+)
+from dmr.test import DMRAsyncRequestFactory, DMRRequestFactory
+from dmr.throttling import AsyncThrottle, Rate, SyncThrottle
+
+
+class _NoChecksSyncController(Controller[PydanticFastSerializer]):
+    def get(self) -> str:
+        return 'ok'
+
+
+class _NoChecksAsyncController(Controller[PydanticFastSerializer]):
+    async def get(self) -> str:
+        return 'ok'
+
+
+class _WithChecksSyncController(Controller[PydanticFastSerializer]):
+    @modify(
+        throttling=[SyncThrottle(100, Rate.second)],
+        auth=[DjangoSessionSyncAuth()],
+    )
+    def get(self) -> str:
+        return 'ok'
+
+
+class _WithChecksAsyncController(Controller[PydanticFastSerializer]):
+    @modify(
+        throttling=[AsyncThrottle(100, Rate.second)],
+        auth=[DjangoSessionAsyncAuth()],
+    )
+    async def get(self) -> str:
+        return 'ok'
+
+
+def test_sync_checks_skipped_when_not_configured(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """`_run_checks` must not call parts that are not configured."""
+    endpoint = _NoChecksSyncController.api_endpoints[str(HTTPMethod.GET)]
+    with (
+        mock.patch.object(type(endpoint), '_run_throttle_before') as before,
+        mock.patch.object(type(endpoint), '_run_auth') as auth,
+        mock.patch.object(type(endpoint), '_run_throttle_after') as after,
+    ):
+        response = _NoChecksSyncController.as_view()(
+            dmr_rf.get('/whatever/'),
+        )
+        assert response.status_code == 200  # noqa: WPS432
+        before.assert_not_called()
+        auth.assert_not_called()
+        after.assert_not_called()
+
+
+async def test_async_checks_skipped_when_not_configured(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """`_run_async_checks` must not await parts that are not configured."""
+    endpoint = _NoChecksAsyncController.api_endpoints[str(HTTPMethod.GET)]
+    with (
+        mock.patch.object(
+            type(endpoint),
+            '_run_async_throttle_before',
+        ) as before,
+        mock.patch.object(type(endpoint), '_run_async_auth') as auth,
+        mock.patch.object(
+            type(endpoint),
+            '_run_async_throttle_after',
+        ) as after,
+    ):
+        response = await dmr_async_rf.wrap(
+            _NoChecksAsyncController.as_view()(dmr_async_rf.get('/whatever/')),
+        )
+        assert response.status_code == 200  # noqa: WPS432
+        before.assert_not_called()
+        auth.assert_not_called()
+        after.assert_not_called()
+
+
+def test_sync_checks_run_when_configured(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """`_run_checks` must call every configured part exactly once."""
+    endpoint = _WithChecksSyncController.api_endpoints[str(HTTPMethod.GET)]
+    with (
+        mock.patch.object(
+            type(endpoint),
+            '_run_throttle_before',
+            wraps=endpoint._run_throttle_before,
+        ) as before,
+        mock.patch.object(
+            type(endpoint),
+            '_run_auth',
+            wraps=endpoint._run_auth,
+        ) as auth,
+        mock.patch.object(
+            type(endpoint),
+            '_run_throttle_after',
+            wraps=endpoint._run_throttle_after,
+        ) as after,
+    ):
+        # Auth is expected to fail (no session), we only care that every
+        # configured check was actually invoked, not about the outcome.
+        _WithChecksSyncController.as_view()(dmr_rf.get('/whatever/'))
+        before.assert_called_once()
+        auth.assert_called_once()
+        after.assert_not_called()  # auth raised: throttle-after never runs
+
+
+@pytest.mark.django_db
+async def test_async_checks_run_when_configured(
+    dmr_async_rf: DMRAsyncRequestFactory,
+) -> None:
+    """`_run_async_checks` must await every configured part exactly once."""
+    endpoint = _WithChecksAsyncController.api_endpoints[str(HTTPMethod.GET)]
+    with (
+        mock.patch.object(
+            type(endpoint),
+            '_run_async_throttle_before',
+            wraps=endpoint._run_async_throttle_before,
+        ) as before,
+        mock.patch.object(
+            type(endpoint),
+            '_run_async_auth',
+            wraps=endpoint._run_async_auth,
+        ) as auth,
+        mock.patch.object(
+            type(endpoint),
+            '_run_async_throttle_after',
+            wraps=endpoint._run_async_throttle_after,
+        ) as after,
+    ):
+        await dmr_async_rf.wrap(
+            _WithChecksAsyncController.as_view()(
+                dmr_async_rf.get('/whatever/'),
+            ),
+        )
+        before.assert_called_once()
+        auth.assert_called_once()
+        after.assert_not_called()


### PR DESCRIPTION
## Summary

`Endpoint._run_checks` and `Endpoint._run_async_checks` always called
into `_run_throttle_before`, `_run_auth`, and `_run_throttle_after`
(and their async counterparts), each of which then internally checked
`if self.metadata.X is None: return`. A function call (and, in the
async case, an `await`) is not free in Python, so this meant paying
for 3-4 calls/awaits on every single request even when throttling
and/or auth were not configured for that endpoint at all.

This moves the "is this check needed" condition to the caller, so a
check that isn't configured is skipped entirely instead of being
called and immediately returning. The now-narrowed values are passed
in as arguments rather than re-read from `self.metadata` inside each
helper.

Behavior is unchanged — this is a pure hot-path performance refactor.

## Test plan

- Added `tests/test_unit/test_endpoint/test_run_checks_skips_unneeded.py`
  covering both the sync and async paths: verifies the throttle/auth
  helpers are **not called** when not configured, and **are called
  exactly once each** when configured.
- `just lint` — green
- `uv run python -m mypy .` — green
- `just unit` — 3369 passed, 11 skipped, 0 failures/errors (identical
  to a clean `master` baseline run modulo the pre-existing
  Docker-only Redis backend tests, which aren't runnable in this
  environment)

Fixes #1454