### PR TITLE
Pre-compute @modify headers and cookies at endpoint build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 ### Features
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
+- Pre-compute `@modify` actionable headers and cookies once when the
+  endpoint is built instead of on every request, #1456
 
 
 ## 0.15.0 (2026-09-11)

--- a/dmr/metadata.py
+++ b/dmr/metadata.py
@@ -224,6 +224,35 @@ class ResponseModification:
     description: '_StrOrPromise | None'
     links: dict[str, 'Link | Reference'] | None
 
+    # Precomputed at build time (see `__post_init__`), reused on every request:
+    _cached_actionable_cookies: 'Mapping[str, NewCookie] | None' = (
+        dataclasses.field(init=False, repr=False, compare=False, default=None)
+    )
+    _cached_static_headers: 'Mapping[str, str]' = dataclasses.field(
+        init=False,
+        repr=False,
+        compare=False,
+        default_factory=dict,
+    )
+
+    def __post_init__(self) -> None:
+        """Precompute request-independent header/cookie data once."""
+        cookies = (  # pyright: ignore[reportGeneralTypeIssues]
+            None  # pyrefly: ignore[bad-assignment]
+            if self.cookies is None
+            else {
+                cookie_key: cookie
+                for cookie_key, cookie in self.cookies.items()
+                if cookie.is_actionable
+            }
+        )
+        object.__setattr__(self, '_cached_actionable_cookies', cookies)
+        object.__setattr__(
+            self,
+            '_cached_static_headers',
+            self._compute_static_headers(),
+        )
+
     def to_spec(self) -> ResponseSpec:
         """Convert response modification to response description."""
         return self.response_spec_cls(
@@ -282,30 +311,27 @@ class ResponseModification:
 
     def actionable_cookies(self) -> Mapping[str, 'NewCookie'] | None:
         """Returns an optional mapping of cookies that should be added."""
-        return (  # pyright: ignore[reportReturnType]
-            None  # pyrefly: ignore[bad-return]
-            if self.cookies is None
-            else {
-                cookie_key: cookie
-                for cookie_key, cookie in self.cookies.items()
-                if cookie.is_actionable
-            }
-        )
+        return self._cached_actionable_cookies  # pyright: ignore[reportReturnType]
 
     def build_headers(
         self,
         renderer: 'Renderer',
     ) -> dict[str, str]:
         """Returns headers with values for raw data endpoints."""
-        result_headers: dict[str, Any] = {'Content-Type': renderer.content_type}
+        return {
+            'Content-Type': renderer.content_type,
+            **self._cached_static_headers,
+        }
+
+    def _compute_static_headers(self) -> Mapping[str, str]:
+        """Computed once at build time, cached in `_cached_static_headers`."""
         headers = self.actionable_headers()
         if not headers:
-            return result_headers
-        result_headers.update({
+            return {}
+        return {
             header_name: response_header.value
             for header_name, response_header in headers.items()
-        })
-        return result_headers
+        }
 
 
 class ResponseSpecProvider:

--- a/dmr/streaming/metadata.py
+++ b/dmr/streaming/metadata.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 from types import MappingProxyType
 from typing import Any, Final, final
 
+from typing_extensions import override
+
 from dmr.cookies import CookieSpec
 from dmr.headers import HeaderSpec, NewHeader
 from dmr.metadata import ResponseModification, ResponseSpec
@@ -29,10 +31,18 @@ class StreamResponseModification(ResponseModification):
 
     headers: Mapping[str, 'NewHeader | HeaderSpec'] | None
 
+    @override
     def __post_init__(self) -> None:
         """Set header specs if it is missing."""
         if self.headers is None:
             object.__setattr__(self, 'headers', STREAMING_HEADERS_SPEC)
+        # Base class caches actionable headers/cookies; must run after
+        # the default `headers` value above is finalized. Uses explicit
+        # `super()` args: zero-arg `super()` breaks here because
+        # `@dataclass(slots=True)` recreates this class after the method
+        # body is compiled, so the `__class__` closure cell it relies on
+        # points to the pre-slots class object.
+        super(StreamResponseModification, self).__post_init__()  # noqa: WPS608
 
 
 def streaming_response_spec(  # noqa: WPS211

--- a/tests/test_unit/test_endpoint/test_modify_decorator.py
+++ b/tests/test_unit/test_endpoint/test_modify_decorator.py
@@ -1,6 +1,7 @@
 import json
 from http import HTTPStatus
 from typing import final
+from unittest import mock
 
 import pytest
 from dirty_equals import IsStr
@@ -20,6 +21,7 @@ from dmr import (
 from dmr.endpoint import Endpoint
 from dmr.errors import wrap_handler
 from dmr.exceptions import EndpointMetadataError
+from dmr.metadata import ResponseModification
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.response import APIError
 from dmr.test import DMRRequestFactory
@@ -390,3 +392,56 @@ def test_modify_with_set_cookie(header_name: str) -> None:
             )
             def post(self) -> dict[str, str]:
                 return {'result': 'done'}  # pragma: no cover
+
+
+def test_modify_headers_cookies_precomputed_once(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Actionable headers/cookies are computed once, not per request."""
+    calls: list[ResponseModification] = []
+    original_post_init = ResponseModification.__post_init__
+
+    def _spy_post_init(self: ResponseModification) -> None:
+        calls.append(self)
+        original_post_init(self)
+
+    with mock.patch.object(
+        ResponseModification,
+        '__post_init__',
+        _spy_post_init,
+    ):
+
+        @final
+        class _PrecomputedController(Controller[PydanticSerializer]):
+            @modify(
+                headers={'X-Test': NewHeader(value='true')},
+                cookies={'session': NewCookie(value='abc123')},
+            )
+            def get(self) -> int:
+                return 1
+
+    # Computed exactly once, at class-definition (endpoint build) time:
+    assert len(calls) == 1
+
+    responses = [
+        _PrecomputedController.as_view()(dmr_rf.get('/whatever/'))
+        for _ in range(2)
+    ]
+
+    # Handling requests must not trigger any extra computation:
+    assert len(calls) == 1
+    for response in responses:
+        assert isinstance(response, HttpResponse)
+        assert response.headers['X-Test'] == 'true'
+
+    modification = _PrecomputedController.api_endpoints[
+        'GET'
+    ].metadata.modification
+    assert modification is not None
+    # The exact same cached mapping is reused across calls, never rebuilt:
+    assert (
+        modification.actionable_cookies() is modification.actionable_cookies()
+    )
+    assert modification._cached_static_headers is (
+        modification._cached_static_headers
+    )


### PR DESCRIPTION
## Summary

Fixes #1456.

`ResponseModification.build_headers()` and `.actionable_cookies()` were
recomputing the same filtering/mapping work on every single request, even
though the result only depends on the endpoint's static `@modify(...)`
configuration (the only per-request-dependent part is the `Content-Type`,
which comes from content negotiation).

- Actionable cookies and the header-name → value mapping (everything except
  `Content-Type`) are now computed once in `ResponseModification.__post_init__`
  (i.e. at class/endpoint-definition/import time) and cached on the frozen
  dataclass instance.
- `build_headers()` now just merges the per-request `Content-Type` with the
  precomputed static header dict — no more per-request filtering loop.
- `actionable_cookies()` returns the cached mapping directly.
- `StreamResponseModification.__post_init__` now calls
  `super(StreamResponseModification, self).__post_init__()` (explicit args
  are required here — with `@dataclass(slots=True)`, zero-arg `super()`
  breaks because the class object is recreated after the method body is
  compiled) so streaming responses get the same caching.
- Added a regression test that spies on `__post_init__` to prove the
  computation happens exactly once per endpoint, regardless of how many
  requests are handled, plus identity checks that the cached mappings are
  reused rather than rebuilt.

No public API changes; purely an internal hot-path optimization.

## Test plan

- [x] `just lint` (ruff, flake8/wemake-python-styleguide, slotscheck,
      import-linter) — all green
- [x] `uv run python -m mypy .` — no issues
- [x] Targeted suites (`test_modify_decorator`, `test_response_validation*`,
      `test_streaming/`, `test_metadata/`, openapi response generator,
      `test_controllers/`, `test_response/`) — 518 passed
- [x] Full `just unit` — 3366 passed, 11 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)