### PR TITLE
Allow bool fields in dmr.openapi.objects to accept None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 ### Features
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
+- `bool` fields in `dmr.openapi.objects` (`Parameter.deprecated`,
+  `Parameter.required`, `Operation.deprecated`, `XML.attribute`,
+  `XML.wrapped`) now default to `None` instead of `False`,
+  so the default value is no longer dumped into the OpenAPI schema, #1437
 
 
 ## 0.15.0 (2026-09-11)

--- a/dmr/endpoint.py
+++ b/dmr/endpoint.py
@@ -303,7 +303,8 @@ class Endpoint:  # noqa: WPS214
                 if self.metadata.description is None
                 else str(self.metadata.description)
             ),
-            deprecated=self.metadata.deprecated or router_metadata.deprecated,
+            deprecated=(self.metadata.deprecated or router_metadata.deprecated)
+            or None,
             security=context.generators.security_scheme(
                 self.metadata.auth,
                 serializer,

--- a/dmr/openapi/generators/parameter.py
+++ b/dmr/openapi/generators/parameter.py
@@ -45,7 +45,7 @@ class ParameterGenerator:
                 name=property_name,
                 param_in=param_in,
                 schema=property_schema,
-                required=property_name in schema.required,
+                required=(property_name in schema.required) or None,
                 **self._compute_metadata(
                     metadata,
                     property_name,
@@ -89,6 +89,5 @@ class ParameterGenerator:
                 property_schema.deprecated
                 or metadata_params.get('deprecated')
                 or schema.deprecated
-                or False
             ),
         }

--- a/dmr/openapi/mappers/schema_loader.py
+++ b/dmr/openapi/mappers/schema_loader.py
@@ -226,8 +226,8 @@ def _try_xml(raw_value: Any) -> XML | None:
             name=raw_value.get('name'),
             namespace=raw_value.get('namespace'),
             prefix=raw_value.get('prefix'),
-            attribute=raw_value.get('attribute', False),
-            wrapped=raw_value.get('wrapped', False),
+            attribute=raw_value.get('attribute') or None,
+            wrapped=raw_value.get('wrapped') or None,
         )
     )
 

--- a/dmr/openapi/objects/operation.py
+++ b/dmr/openapi/objects/operation.py
@@ -25,6 +25,6 @@ class Operation:
     request_body: 'RequestBody | Reference | None' = None
     responses: 'Responses | None' = None
     callbacks: dict[str, 'Callback | Reference'] | None = None
-    deprecated: bool = False
+    deprecated: bool | None = None
     security: list['SecurityRequirement'] | None = None
     servers: list['Server'] | None = None

--- a/dmr/openapi/objects/parameter.py
+++ b/dmr/openapi/objects/parameter.py
@@ -15,7 +15,7 @@ class ParameterMetadata:
     """Describes metadata for a single operation parameter."""
 
     description: str | None = None
-    deprecated: bool = False
+    deprecated: bool | None = None
     allow_empty_value: bool | None = None
     style: str | None = None
     explode: bool | None = None
@@ -32,4 +32,4 @@ class Parameter(ParameterMetadata):
     param_in: Annotated[str, Field(alias='in')]
     schema: 'Reference | Schema | None' = None
     content: dict[str, 'MediaType'] | None = None
-    required: bool = False
+    required: bool | None = None

--- a/dmr/openapi/objects/xml.py
+++ b/dmr/openapi/objects/xml.py
@@ -14,5 +14,5 @@ class XML:
     name: str | None = None
     namespace: str | None = None
     prefix: str | None = None
-    attribute: bool = False
-    wrapped: bool = False
+    attribute: bool | None = None
+    wrapped: bool | None = None

--- a/tests/test_unit/test_metadata/__snapshots__/test_response_spec_meta.ambr
+++ b/tests/test_unit/test_metadata/__snapshots__/test_response_spec_meta.ambr
@@ -128,8 +128,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "patch": {
           "operationId": "patchHeaderandcookiecontrollerApiV1HeaderAndCookie",
@@ -250,8 +249,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_custom_methods_schema.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_custom_methods_schema.ambr
@@ -43,8 +43,7 @@
                   }
                 }
               }
-            },
-            "deprecated": false
+            }
           }
         }
       }
@@ -155,8 +154,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postStandardcontrollerApiV1Standard",
@@ -194,8 +192,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/meta/": {
@@ -238,8 +235,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "options": {
           "summary": "Default sync implementation for ``OPTIONS`` http method.",
@@ -283,8 +279,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_example_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_example_snapshots.ambr
@@ -73,8 +73,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -234,8 +233,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -413,8 +411,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_files_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_files_snapshots.ambr
@@ -57,8 +57,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -217,8 +216,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -385,8 +383,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -726,8 +723,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -883,8 +879,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -1019,8 +1014,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postSeveralparserscontrollerSeveralParsers",
@@ -1098,8 +1092,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_hidden_endpoints.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_hidden_endpoints.ambr
@@ -59,8 +59,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "patch": {
           "description": "Patch",
@@ -96,8 +95,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -204,8 +202,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postPartiallyhiddenendpointsApiHiddenEndpoints",
@@ -263,8 +260,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_overrides_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_overrides_snapshots.ambr
@@ -46,8 +46,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -152,8 +151,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -257,8 +255,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_schema_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_schema_snapshots.ambr
@@ -14,7 +14,6 @@
           "parameters": [
             {
               "description": "Cookies metadata",
-              "deprecated": false,
               "examples": {},
               "name": "session_id",
               "in": "cookie",
@@ -26,7 +25,6 @@
             },
             {
               "description": "Override",
-              "deprecated": false,
               "examples": {},
               "name": "CSRF",
               "in": "cookie",
@@ -39,7 +37,6 @@
             },
             {
               "description": "Short summary.\n\nAnd some other description text.",
-              "deprecated": false,
               "style": "deepObject",
               "explode": true,
               "examples": {
@@ -68,7 +65,6 @@
             },
             {
               "description": "Short summary.\n\nAnd some other description text.",
-              "deprecated": false,
               "style": "deepObject",
               "explode": true,
               "examples": {
@@ -101,7 +97,6 @@
             },
             {
               "description": "Short summary.\n\nAnd some other description text.",
-              "deprecated": false,
               "style": "deepObject",
               "explode": true,
               "examples": {
@@ -190,7 +185,6 @@
               }
             }
           },
-          "deprecated": false,
           "security": [
             {
               "jwt": []
@@ -361,8 +355,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -600,8 +593,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -754,7 +746,6 @@
           "operationId": "getGetpostcontrollerApiV1UserUserIdPostPostId",
           "parameters": [
             {
-              "deprecated": false,
               "name": "user_id",
               "in": "path",
               "schema": {
@@ -764,7 +755,6 @@
               "required": true
             },
             {
-              "deprecated": false,
               "name": "post_id",
               "in": "path",
               "schema": {
@@ -816,8 +806,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/articles/{year}/{slug}/": {
@@ -825,7 +814,6 @@
           "operationId": "getGetpostcontrollerApiV1ArticlesYearSlug",
           "parameters": [
             {
-              "deprecated": false,
               "name": "year",
               "in": "path",
               "schema": {
@@ -835,7 +823,6 @@
               "required": true
             },
             {
-              "deprecated": false,
               "name": "slug",
               "in": "path",
               "schema": {
@@ -886,8 +873,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -994,8 +980,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postUsercontrollerApiV1User",
@@ -1053,8 +1038,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/user/{id}/": {
@@ -1062,7 +1046,6 @@
           "operationId": "getGetusercontrollerApiV1UserId",
           "parameters": [
             {
-              "deprecated": false,
               "name": "id",
               "in": "path",
               "schema": {
@@ -1123,8 +1106,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_semantic_snapshots.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_semantic_snapshots.ambr
@@ -23,7 +23,6 @@
               }
             }
           },
-          "deprecated": false,
           "security": [
             {
               "jwt": []
@@ -44,7 +43,6 @@
               }
             }
           },
-          "deprecated": false,
           "security": [
             {
               "jwt": []
@@ -124,8 +122,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postPerendpointPerEndpoint",
@@ -140,8 +137,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/__snapshots__/test_translated_schema.ambr
+++ b/tests/test_unit/test_openapi/__snapshots__/test_translated_schema.ambr
@@ -61,8 +61,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_exclude_semantic_responses.ambr
+++ b/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_exclude_semantic_responses.ambr
@@ -35,8 +35,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_semantic_responses.ambr
+++ b/tests/test_unit/test_openapi/test_generators/__snapshots__/test_schema_semantic_responses.ambr
@@ -25,8 +25,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_openapi/test_mappers/test_schema_normalization/__snapshots__/test_schema_load.ambr
+++ b/tests/test_unit/test_openapi/test_mappers/test_schema_normalization/__snapshots__/test_schema_load.ambr
@@ -34,8 +34,7 @@
             "200": {
               "$ref": "#/components/responses/Configuration"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/login": {
@@ -103,8 +102,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/signup": {
@@ -176,8 +174,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/email/verify": {
@@ -224,8 +221,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -276,8 +272,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/email/verify/resend": {
@@ -312,8 +307,7 @@
             "429": {
               "$ref": "#/components/responses/TooManyRequests"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/phone/verify": {
@@ -361,8 +355,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/phone/verify/resend": {
@@ -397,8 +390,7 @@
             "429": {
               "$ref": "#/components/responses/TooManyRequests"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/reauthenticate": {
@@ -438,8 +430,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/password/request": {
@@ -479,8 +470,7 @@
             "401": {
               "$ref": "#/components/responses/Authentication"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/password/reset": {
@@ -527,8 +517,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -576,8 +565,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/browser/v1/auth/provider/redirect": {
@@ -602,8 +590,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/provider/token": {
@@ -671,8 +658,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/provider/signup": {
@@ -701,8 +687,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -772,8 +757,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/2fa/authenticate": {
@@ -816,8 +800,7 @@
             "401": {
               "$ref": "#/components/responses/Authentication"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/2fa/reauthenticate": {
@@ -857,8 +840,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/browser/v1/auth/2fa/trust": {
@@ -890,8 +872,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/webauthn/authenticate": {
@@ -913,8 +894,7 @@
             "200": {
               "$ref": "#/components/responses/WebAuthnRequestOptionsResponse"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -947,8 +927,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/webauthn/reauthenticate": {
@@ -970,8 +949,7 @@
             "200": {
               "$ref": "#/components/responses/WebAuthnRequestOptionsResponse"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1004,8 +982,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/webauthn/login": {
@@ -1027,8 +1004,7 @@
             "200": {
               "$ref": "#/components/responses/WebAuthnRequestOptionsResponse"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1076,8 +1052,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/webauthn/signup": {
@@ -1109,8 +1084,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "put": {
           "tags": [
@@ -1168,8 +1142,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1239,8 +1212,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/code/request": {
@@ -1289,8 +1261,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/code/confirm": {
@@ -1352,8 +1323,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/code/resend": {
@@ -1388,8 +1358,7 @@
             "429": {
               "$ref": "#/components/responses/TooManyRequests"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/providers": {
@@ -1410,8 +1379,7 @@
             "200": {
               "$ref": "#/components/responses/ProviderAccounts"
             }
-          },
-          "deprecated": false
+          }
         },
         "delete": {
           "tags": [
@@ -1452,8 +1420,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/email": {
@@ -1478,8 +1445,7 @@
             "401": {
               "$ref": "#/components/responses/Authentication"
             }
-          },
-          "deprecated": false
+          }
         },
         "put": {
           "tags": [
@@ -1527,8 +1493,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1579,8 +1544,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "delete": {
           "tags": [
@@ -1618,8 +1582,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "patch": {
           "tags": [
@@ -1657,8 +1620,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/phone": {
@@ -1683,8 +1645,7 @@
             "401": {
               "$ref": "#/components/responses/Authentication"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1737,8 +1698,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/authenticators": {
@@ -1765,8 +1725,7 @@
             "410": {
               "$ref": "#/components/responses/SessionGone"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/authenticators/totp": {
@@ -1794,8 +1753,7 @@
             "409": {
               "$ref": "#/components/responses/AddAuthenticatorConflict"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1839,8 +1797,7 @@
             "409": {
               "$ref": "#/components/responses/AddAuthenticatorConflict"
             }
-          },
-          "deprecated": false
+          }
         },
         "delete": {
           "tags": [
@@ -1863,8 +1820,7 @@
             "401": {
               "$ref": "#/components/responses/ReauthenticationRequired"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/authenticators/recovery-codes": {
@@ -1892,8 +1848,7 @@
             "404": {
               "$ref": "#/components/responses/NotFound"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -1927,8 +1882,7 @@
             "401": {
               "$ref": "#/components/responses/ReauthenticationRequired"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/authenticators/webauthn": {
@@ -1959,8 +1913,7 @@
             "409": {
               "$ref": "#/components/responses/AddAuthenticatorConflict"
             }
-          },
-          "deprecated": false
+          }
         },
         "put": {
           "tags": [
@@ -1986,8 +1939,7 @@
             "401": {
               "$ref": "#/components/responses/ReauthenticationRequired"
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "tags": [
@@ -2015,8 +1967,7 @@
             "409": {
               "$ref": "#/components/responses/AddAuthenticatorConflict"
             }
-          },
-          "deprecated": false
+          }
         },
         "delete": {
           "tags": [
@@ -2041,8 +1992,7 @@
             "401": {
               "$ref": "#/components/responses/ReauthenticationRequired"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/session": {
@@ -2070,8 +2020,7 @@
             "410": {
               "$ref": "#/components/responses/SessionGone"
             }
-          },
-          "deprecated": false
+          }
         },
         "delete": {
           "tags": [
@@ -2091,8 +2040,7 @@
             "401": {
               "$ref": "#/components/responses/Unauthenticated"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/app/v1/tokens/refresh": {
@@ -2119,8 +2067,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/account/password/change": {
@@ -2148,8 +2095,7 @@
             "401": {
               "$ref": "#/components/responses/Authentication"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/_allauth/{client}/v1/auth/sessions": {
@@ -2170,8 +2116,7 @@
             "200": {
               "$ref": "#/components/responses/Sessions"
             }
-          },
-          "deprecated": false
+          }
         },
         "delete": {
           "tags": [
@@ -2196,8 +2141,7 @@
             "401": {
               "$ref": "#/components/responses/Authentication"
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -4383,7 +4327,6 @@
       "parameters": {
         "Client": {
           "description": "The type of client accessing the API.",
-          "deprecated": false,
           "name": "client",
           "in": "path",
           "schema": {
@@ -4397,7 +4340,6 @@
         },
         "EmailVerificationKey": {
           "description": "The email verification key",
-          "deprecated": false,
           "name": "X-Email-Verification-Key",
           "in": "header",
           "schema": {
@@ -4407,7 +4349,6 @@
         },
         "PasswordResetKey": {
           "description": "The password reset key",
-          "deprecated": false,
           "name": "X-Password-Reset-Key",
           "in": "header",
           "schema": {
@@ -4417,7 +4358,6 @@
         },
         "SessionToken": {
           "description": "Session token. Only needed when `client` is equal to `app`.\n",
-          "deprecated": false,
           "name": "X-Session-Token",
           "in": "header",
           "schema": {
@@ -4426,7 +4366,6 @@
         },
         "PasswordLess": {
           "description": "When present (regardless of its value), enables passwordless sign-in via a WebAuthn credential (Passkey),\nbut may enforce additional multi-factor authentication (MFA) requirements. Omit the parameter to disable.\n",
-          "deprecated": false,
           "allowEmptyValue": true,
           "name": "passwordless",
           "in": "query",

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_attrs.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_attrs.ambr
@@ -62,8 +62,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgpack.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgpack.ambr
@@ -62,8 +62,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgspec_snapshots.ambr
+++ b/tests/test_unit/test_plugins/test_msgspec/__snapshots__/test_msgspec_snapshots.ambr
@@ -13,7 +13,6 @@
           "operationId": "getAuthedandcookiescontrollerApiCookies",
           "parameters": [
             {
-              "deprecated": false,
               "name": "session_id",
               "in": "cookie",
               "schema": {
@@ -22,7 +21,6 @@
               "required": true
             },
             {
-              "deprecated": false,
               "name": "CSRF",
               "in": "cookie",
               "schema": {
@@ -95,7 +93,6 @@
               }
             }
           },
-          "deprecated": false,
           "security": [
             {
               "jwt": []
@@ -227,8 +224,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -355,8 +351,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -576,8 +571,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -697,8 +691,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -864,8 +857,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_plugins/test_pydantic/__snapshots__/test_pydantic_snapshots.ambr
+++ b/tests/test_unit/test_plugins/test_pydantic/__snapshots__/test_pydantic_snapshots.ambr
@@ -62,8 +62,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -264,8 +263,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -433,8 +431,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/user-fast": {
@@ -491,8 +488,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_problem_details/__snapshots__/test_problem_details_view.ambr
+++ b/tests/test_unit/test_problem_details/__snapshots__/test_problem_details_view.ambr
@@ -13,7 +13,6 @@
           "operationId": "getProblemdetailscontrollerApiV1WithNegotiation",
           "parameters": [
             {
-              "deprecated": false,
               "name": "number",
               "in": "query",
               "schema": {
@@ -130,7 +129,6 @@
               }
             }
           },
-          "deprecated": false,
           "security": [
             {
               "django_session": [],
@@ -144,7 +142,6 @@
           "operationId": "getProblemdetailsdefaultcontrollerApiV1Default",
           "parameters": [
             {
-              "deprecated": false,
               "name": "number",
               "in": "query",
               "schema": {
@@ -205,8 +202,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/regular": {
@@ -214,7 +210,6 @@
           "operationId": "getProblemdetailsvalidationcontrollerApiV1Regular",
           "parameters": [
             {
-              "deprecated": false,
               "name": "number",
               "in": "query",
               "schema": {
@@ -275,8 +270,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_routing/__snapshots__/test_external_paths.ambr
+++ b/tests/test_unit/test_routing/__snapshots__/test_external_paths.ambr
@@ -24,8 +24,7 @@
             "200": {
               "$ref": "#/components/responses/Configuration"
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/async": {
@@ -68,8 +67,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/allauth/{client}/auth/login": {
@@ -137,8 +135,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -2373,7 +2370,6 @@
       "parameters": {
         "Client": {
           "description": "The type of client accessing the API.",
-          "deprecated": false,
           "name": "client",
           "in": "path",
           "schema": {
@@ -2387,7 +2383,6 @@
         },
         "EmailVerificationKey": {
           "description": "The email verification key",
-          "deprecated": false,
           "name": "X-Email-Verification-Key",
           "in": "header",
           "schema": {
@@ -2397,7 +2392,6 @@
         },
         "PasswordResetKey": {
           "description": "The password reset key",
-          "deprecated": false,
           "name": "X-Password-Reset-Key",
           "in": "header",
           "schema": {
@@ -2407,7 +2401,6 @@
         },
         "SessionToken": {
           "description": "Session token. Only needed when `client` is equal to `app`.\n",
-          "deprecated": false,
           "name": "X-Session-Token",
           "in": "header",
           "schema": {
@@ -2416,7 +2409,6 @@
         },
         "PasswordLess": {
           "description": "When present (regardless of its value), enables passwordless sign-in via a WebAuthn credential (Passkey),\nbut may enforce additional multi-factor authentication (MFA) requirements. Omit the parameter to disable.\n",
-          "deprecated": false,
           "allowEmptyValue": true,
           "name": "passwordless",
           "in": "query",

--- a/tests/test_unit/test_routing/__snapshots__/test_urls_include.ambr
+++ b/tests/test_unit/test_routing/__snapshots__/test_urls_include.ambr
@@ -45,8 +45,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/users/user/": {
@@ -86,8 +85,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/users/old/user/": {

--- a/tests/test_unit/test_streaming/test_jsonl/__snapshots__/test_jsonl_snapshots.ambr
+++ b/tests/test_unit/test_streaming/test_jsonl/__snapshots__/test_jsonl_snapshots.ambr
@@ -13,7 +13,6 @@
           "operationId": "getComplexjsonlApiV1Complex",
           "parameters": [
             {
-              "deprecated": false,
               "name": "X-Header",
               "in": "header",
               "schema": {
@@ -91,8 +90,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -193,7 +191,6 @@
           "operationId": "getComplexjsonlApiV1Complex",
           "parameters": [
             {
-              "deprecated": false,
               "name": "X-Header",
               "in": "header",
               "schema": {
@@ -271,8 +268,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -420,8 +416,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postClassbasedjsonlApiV1Jsonl",
@@ -474,8 +469,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_streaming/test_sse/__snapshots__/test_sse_snapshots.ambr
+++ b/tests/test_unit/test_streaming/test_sse/__snapshots__/test_sse_snapshots.ambr
@@ -13,7 +13,6 @@
           "operationId": "getComplexsseApiV1Complex",
           "parameters": [
             {
-              "deprecated": false,
               "name": "X-Header",
               "in": "header",
               "schema": {
@@ -91,8 +90,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -281,8 +279,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -419,8 +416,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         },
         "post": {
           "operationId": "postClassbasedsseApiV1Sse",
@@ -475,8 +471,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },

--- a/tests/test_unit/test_throttling/__snapshots__/test_throttling_snapshots.ambr
+++ b/tests/test_unit/test_throttling/__snapshots__/test_throttling_snapshots.ambr
@@ -82,8 +82,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/all": {
@@ -174,8 +173,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       },
       "/api/v1/no": {
@@ -222,8 +220,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -401,8 +398,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },
@@ -506,8 +502,7 @@
                 }
               }
             }
-          },
-          "deprecated": false
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- Change `bool = False` fields that are dumped into the OpenAPI schema (`Parameter.deprecated`, `Parameter.required`, `Operation.deprecated`, `XML.attribute`, `XML.wrapped`) to `bool | None = None`
- `None` values are already ignored by the schema dump, so this stops emitting the redundant default `false` (e.g. `"deprecated": false`) into every generated OpenAPI document
- Regenerated all affected snapshots; diffs only remove the now-implicit `false` keys, nothing else changed

Fixes #1437

## Test plan
- [x] `just lint`
- [x] `just unit` (full suite green; only pre-existing, environment-only failures remain: Redis-backend tests requiring local Docker)
- [x] Manually reviewed every snapshot diff to confirm only default-`false` keys were removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)