### PR TITLE
Support customizable schema generation parameters for pydantic and msgspec plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 - Added `tags` controller attribute to apply OpenAPI tags
   to all endpoints of this controller. They are merged
   with router-level and endpoint-level tags, #1434
+- Allows customizing JSON schema generation for `pydantic` (via
+  `PydanticSchemaGenerator.schema_generator` and `.union_format`) and
+  `msgspec` (via `MsgspecSchemaGenerator.schema_hook`), #1462
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
 
 

--- a/dmr/plugins/msgspec/schema.py
+++ b/dmr/plugins/msgspec/schema.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 from msgspec.json import schema
@@ -10,6 +11,10 @@ class MsgspecSchemaGenerator(BaseSchemaGenerator):
     """Generates JSON schema for msgspec objects."""
 
     __slots__ = ()
+
+    #: Subclass and override to hook into msgspec's schema generation
+    #: for types it does not know how to handle natively.
+    schema_hook: Callable[[type], dict[str, Any]] | None = None
 
     @override
     @classmethod
@@ -24,6 +29,7 @@ class MsgspecSchemaGenerator(BaseSchemaGenerator):
         out = schema(
             model,
             ref_template=ref_template + '{name}',  # noqa: WPS336
+            schema_hook=cls.schema_hook,
         )
         components = out.pop('$defs', {})
         return out, components

--- a/dmr/plugins/pydantic/schema.py
+++ b/dmr/plugins/pydantic/schema.py
@@ -1,5 +1,6 @@
-from typing import Any
+from typing import Any, Literal
 
+from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import override
 
 from dmr.serializer import BaseSchemaGenerator, SchemaDef
@@ -9,6 +10,13 @@ class PydanticSchemaGenerator(BaseSchemaGenerator):
     """Generates JSON schema for pydantic objects."""
 
     __slots__ = ()
+
+    #: Subclass and override to customize the ``GenerateJsonSchema``
+    #: class pydantic uses to build the schema.
+    schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema
+
+    #: Subclass and override to customize how pydantic renders unions.
+    union_format: Literal['any_of', 'primitive_type_array'] = 'any_of'
 
     @override
     @classmethod
@@ -27,6 +35,8 @@ class PydanticSchemaGenerator(BaseSchemaGenerator):
         schema = _get_cached_type_adapter(model).json_schema(
             ref_template=ref_template + '{model}',  # noqa: WPS336, RUF027
             mode='serialization' if used_for_response else 'validation',
+            schema_generator=cls.schema_generator,
+            union_format=cls.union_format,
         )
         components = schema.pop('$defs', {})
         return schema, components

--- a/docs/examples/openapi/msgspec_schema_hook_customization.py
+++ b/docs/examples/openapi/msgspec_schema_hook_customization.py
@@ -1,0 +1,29 @@
+from decimal import Decimal
+from typing import Any
+
+from typing_extensions import override
+
+from dmr.plugins.msgspec import MsgspecSerializer
+from dmr.plugins.msgspec.schema import MsgspecSchemaGenerator
+
+
+class MyMsgspecSchemaGenerator(MsgspecSchemaGenerator):
+    """Plugs a custom `schema_hook` into msgspec schema generation."""
+
+    __slots__ = ()
+
+    @override
+    @classmethod
+    def schema_hook(cls, source_type: type) -> dict[str, Any]:
+        """Teach msgspec how to build a schema for extra types."""
+        if source_type is Decimal:
+            return {'type': 'string', 'format': 'decimal'}
+        raise NotImplementedError(f'Unsupported type: {source_type!r}')
+
+
+class MySerializer(MsgspecSerializer):
+    """Serializer using the customized schema generator."""
+
+    __slots__ = ()
+
+    schema_generator = MyMsgspecSchemaGenerator

--- a/docs/examples/openapi/pydantic_schema_generator_customization.py
+++ b/docs/examples/openapi/pydantic_schema_generator_customization.py
@@ -1,0 +1,36 @@
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from typing_extensions import override
+
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.plugins.pydantic.schema import PydanticSchemaGenerator
+
+
+class MyGenerateJsonSchema(GenerateJsonSchema):
+    """Any customization pydantic's `GenerateJsonSchema` supports."""
+
+    @override
+    def generate(
+        self,
+        schema: object,
+        mode: str = 'validation',
+    ) -> JsonSchemaValue:
+        json_schema = super().generate(schema, mode=mode)  # type: ignore[arg-type]
+        json_schema['x-generated-by'] = 'my-generator'
+        return json_schema
+
+
+class MyPydanticSchemaGenerator(PydanticSchemaGenerator):
+    """Plugs `MyGenerateJsonSchema` into pydantic schema generation."""
+
+    __slots__ = ()
+
+    schema_generator = MyGenerateJsonSchema
+    union_format = 'primitive_type_array'
+
+
+class MySerializer(PydanticSerializer):
+    """Serializer using the customized schema generator."""
+
+    __slots__ = ()
+
+    schema_generator = MyPydanticSchemaGenerator

--- a/docs/pages/openapi/openapi.rst
+++ b/docs/pages/openapi/openapi.rst
@@ -275,6 +275,46 @@ To customize a schema, use the native methods.
 
   By default docstring or ``__doc__`` from the model is used as a description.
 
+Customizing schema generation parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both ``msgspec`` and ``pydantic`` accept extra parameters
+that control *how* the whole schema is generated,
+not just a single model.
+To customize them, create your own serializer:
+subclass :class:`~dmr.serializer.BaseSchemaGenerator`
+(:class:`~dmr.plugins.msgspec.schema.MsgspecSchemaGenerator`
+or :class:`~dmr.plugins.pydantic.schema.PydanticSchemaGenerator`),
+override the relevant attribute, and point your serializer's
+``schema_generator`` to it.
+
+.. tabs::
+
+  .. tab:: msgspec
+
+    Docs: https://msgspec.dev/jsonschema (``schema_hook``)
+
+    .. literalinclude:: /examples/openapi/msgspec_schema_hook_customization.py
+      :caption: serializers.py
+      :language: python
+      :linenos:
+      :no-imports-spoiler:
+
+  .. tab:: pydantic
+
+    Docs: https://docs.pydantic.dev/latest/concepts/json_schema
+    (``schema_generator``, ``union_format``)
+
+    .. literalinclude:: /examples/openapi/pydantic_schema_generator_customization.py
+      :caption: serializers.py
+      :language: python
+      :linenos:
+      :no-imports-spoiler:
+
+Then use ``MySerializer`` the same way you would use
+``MsgspecSerializer`` or ``PydanticSerializer``,
+for example: ``Controller[MySerializer]``.
+
 Customizing path items
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_unit/test_plugins/test_msgspec/test_msgspec_schema_generator_customization.py
+++ b/tests/test_unit/test_plugins/test_msgspec/test_msgspec_schema_generator_customization.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+import pytest
+
+pytest.importorskip('msgspec')
+
+from dmr.plugins.msgspec.schema import MsgspecSchemaGenerator
+
+
+class _Unsupported:
+    """A plain class msgspec cannot generate a schema for natively."""
+
+    attr: int
+
+
+def _unsupported_schema_hook(cls: type) -> dict[str, Any]:
+    """Provide a schema for `_Unsupported`, the only extra type known."""
+    if cls is _Unsupported:
+        return {'type': 'object', 'title': 'Unsupported'}
+    raise NotImplementedError(f'Unsupported type: {cls!r}')  # pragma: no cover
+
+
+def test_default_hook_raises_for_unsupported() -> None:
+    """Without a hook, msgspec cannot handle arbitrary classes."""
+    with pytest.raises(TypeError, match='schema_hook'):
+        MsgspecSchemaGenerator.get_schema(
+            _Unsupported,
+            ref_template='#/components/schemas/',
+        )
+
+
+def test_custom_hook_handles_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subclass can override `schema_hook` to support extra types."""
+    monkeypatch.setattr(
+        MsgspecSchemaGenerator,
+        'schema_hook',
+        _unsupported_schema_hook,
+    )
+
+    schema, _ = MsgspecSchemaGenerator.get_schema(
+        _Unsupported,
+        ref_template='#/components/schemas/',
+    )
+
+    assert schema['title'] == 'Unsupported'

--- a/tests/test_unit/test_plugins/test_pydantic/test_pydantic_schema_generator_customization.py
+++ b/tests/test_unit/test_plugins/test_pydantic/test_pydantic_schema_generator_customization.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import pydantic
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from typing_extensions import override
+
+from dmr.plugins.pydantic.schema import PydanticSchemaGenerator
+
+
+class _Model(pydantic.BaseModel):
+    """Simple model used to exercise schema generation."""
+
+    name: str
+
+
+class _CustomGenerateJsonSchema(GenerateJsonSchema):
+    """Adds a marker key so tests can prove this class was actually used."""
+
+    @override
+    def generate(
+        self,
+        schema: Any,
+        mode: str = 'validation',
+    ) -> JsonSchemaValue:
+        json_schema = super().generate(schema, mode=mode)  # type: ignore[arg-type]
+        json_schema['x-custom'] = True
+        return json_schema
+
+
+class _CustomPydanticSchemaGenerator(PydanticSchemaGenerator):
+    """Subclass plugging in a custom ``GenerateJsonSchema``."""
+
+    __slots__ = ()
+
+    schema_generator = _CustomGenerateJsonSchema
+
+
+def test_default_schema_generator_is_unaffected() -> None:
+    """The default `PydanticSchemaGenerator` behavior is unchanged."""
+    schema, _ = PydanticSchemaGenerator.get_schema(
+        _Model,
+        ref_template='#/components/schemas/',
+    )
+
+    assert 'x-custom' not in schema
+
+
+def test_custom_schema_generator_is_used() -> None:
+    """A subclass can override `schema_generator` to customize output."""
+    schema, _ = _CustomPydanticSchemaGenerator.get_schema(
+        _Model,
+        ref_template='#/components/schemas/',
+    )
+
+    assert schema['x-custom'] is True


### PR DESCRIPTION
## Summary

Both `pydantic` and `msgspec` accept extra parameters that control the whole schema generation process (not just a single model), but `django-modern-rest` never passed them through. This adds a way to customize those, matching each library's own idiomatic API:

- **pydantic**: `PydanticSchemaGenerator` gains overridable `schema_generator` (a `type[GenerateJsonSchema]`) and `union_format` class attributes, passed through to `TypeAdapter.json_schema(...)`.
- **msgspec**: `MsgspecSchemaGenerator` gains an overridable `schema_hook` class attribute (`Callable[[type], dict[str, Any]] | None`), passed through to `msgspec.json.schema(...)`.

Both default to today's exact behavior — no change for anyone not opting in. To customize, subclass the relevant `*SchemaGenerator`, override the attribute, and point your `Serializer` subclass's `schema_generator` at it (documented in `docs/pages/openapi/openapi.rst` under a new "Customizing schema generation parameters" section, with runnable examples for both plugins).

## Test plan

- [x] `just lint` (ruff, flake8/wemake, slotscheck, import-linter)
- [x] `uv run python -m mypy .` on changed/added files
- [x] `just unit` — full suite green, 100% coverage maintained
- [x] `just docs` (`-W`, warnings as errors) — new rst section builds clean
- [x] Added tests: custom `schema_generator` for pydantic (marker key injected via `GenerateJsonSchema` subclass), custom `schema_hook` for msgspec (handles an otherwise-unsupported type), plus default-behavior-unchanged tests for both

Fixes #1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)