### PR TITLE
Cache negotiation header_value -> parser/renderer class resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 - Increased default `DMR_MAX_CACHE_SIZE` from `256` to `1024`, #1448
 
+### Misc
+
+- Caches `Content-Type` / `Accept` header negotiation results per endpoint,
+  so repeated requests with the same header value skip re-running
+  the negotiation algorithm, #1455
+
 
 ## 0.15.0 (2026-09-11)
 

--- a/dmr/negotiation.py
+++ b/dmr/negotiation.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, final, overload
 from django.http.request import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
+from dmr.envs import MAX_CACHE_SIZE
 from dmr.exceptions import (
     EndpointMetadataError,
     NotAcceptableError,
@@ -40,6 +41,7 @@ class RequestNegotiator:
         '_media_by_precedence',
         '_parsers',
         '_serializer',
+        '_wildcard_cache',
     )
 
     def __init__(
@@ -59,6 +61,9 @@ class RequestNegotiator:
         self._media_by_precedence = media_by_precedence(self._parsers.keys())
         # The last configured parser is the most specific one:
         self._default = next(iter(self._parsers.values()))
+        # Caches `content_type -> parser` for the non-exact (wildcard)
+        # matches only, since exact matches are already O(1) dict lookups:
+        self._wildcard_cache: dict[str, Parser] = {}
 
     def __call__(self, request: HttpRequest) -> Parser:
         """
@@ -90,25 +95,39 @@ class RequestNegotiator:
 
     def _decide(self, request: HttpRequest) -> Parser:
         # TODO: compile this code
-        if request.content_type is None:
+        content_type = request.content_type
+        if content_type is None:
             return self._default
         # Try the exact match first, since it is faster, O(1):
-        parser_type = self._exact_parsers.get(request.content_type)
+        parser_type = self._exact_parsers.get(content_type)
         if parser_type is not None:
             # Do not allow invalid content types to be matched exactly.
             return parser_type
 
-        # Now, try to find parser types based on `*/*` patterns, O(n):
+        # Was this exact (non-registered) content type already resolved
+        # via the `*/*` patterns below? Most repeated requests will hit
+        # this cache instead of re-running the O(n) loop every time.
+        cached_parser_type = self._wildcard_cache.get(content_type)
+        if cached_parser_type is not None:
+            return cached_parser_type
+
+        return self._decide_wildcard(content_type)
+
+    def _decide_wildcard(self, content_type: str) -> Parser:
+        # Try to find parser types based on `*/*` patterns, O(n):
         for media in self._media_by_precedence:
             # TODO: replace this with a compiled implementation:
-            if media_match(media, request.content_type):
-                return self._parsers[str(media)]
+            if media_match(media, content_type):
+                parser_type = self._parsers[str(media)]
+                if len(self._wildcard_cache) < MAX_CACHE_SIZE:
+                    self._wildcard_cache[content_type] = parser_type
+                return parser_type
 
         # No parsers found, raise an error:
         expected = list(self._parsers.keys())
         raise RequestSerializationError(
             _CANNOT_PARSE_MSG.format(
-                content_type=repr(request.content_type),
+                content_type=repr(content_type),
                 expected=repr(expected),
             ),
         )
@@ -127,8 +146,10 @@ class ResponseNegotiator:
 
     __slots__ = (
         '_default',
+        '_non_streaming_cache',
         '_non_streaming_default',
         '_non_streaming_renderers',
+        '_renderer_cache',
         '_renderer_keys',
         '_renderers',
         '_serializer',
@@ -165,6 +186,12 @@ class ResponseNegotiator:
         self._non_streaming_default = next(
             iter(self._non_streaming_renderers.values()),
         )
+        # Caches `Accept header value -> renderer`. Most clients send the
+        # exact same `Accept` header on every request (e.g. always
+        # `application/json`), so there is no need to re-run the full
+        # negotiation algorithm for a value we already resolved:
+        self._renderer_cache: dict[str, Renderer] = {}
+        self._non_streaming_cache: dict[str, Renderer] = {}
 
     def __call__(self, request: HttpRequest) -> Renderer:
         """
@@ -190,17 +217,19 @@ class ResponseNegotiator:
             NotAcceptableError: when ``Accept`` request header is not supported.
 
         """
-        renderer = _negotiate_renderer(
+        renderer = self._negotiate_cached(
             request,
             self._renderers,
+            self._renderer_cache,
             default=self._default,
         )
         request.__dmr_renderer__ = renderer  # type: ignore[attr-defined]
         if self._streaming:
             try:
-                non_streaming = _negotiate_renderer(
+                non_streaming = self._negotiate_cached(
                     request,
                     self._non_streaming_renderers,
+                    self._non_streaming_cache,
                     default=self._non_streaming_default,
                 )
             except NotAcceptableError:
@@ -212,6 +241,27 @@ class ResponseNegotiator:
                 # type (e.g. browser ``EventSource``).
                 non_streaming = self._non_streaming_default
             request.__dmr_nonstreaming_renderer__ = non_streaming  # type: ignore[attr-defined]
+        return renderer
+
+    def _negotiate_cached(
+        self,
+        request: HttpRequest,
+        renderers: Mapping[str, Renderer],
+        cache: dict[str, Renderer],
+        *,
+        default: Renderer,
+    ) -> Renderer:
+        accept = request.headers.get('Accept')
+        if accept is None:
+            return default
+
+        cached_renderer = cache.get(accept)
+        if cached_renderer is not None:
+            return cached_renderer
+
+        renderer = _negotiate_renderer(request, renderers, default=default)
+        if len(cache) < MAX_CACHE_SIZE:
+            cache[accept] = renderer
         return renderer
 
 

--- a/tests/test_unit/test_negotiation/test_negotiation_caching.py
+++ b/tests/test_unit/test_negotiation/test_negotiation_caching.py
@@ -1,0 +1,217 @@
+import json
+from http import HTTPStatus
+from typing import Any, final
+
+import dmr.negotiation as negotiation
+import pytest
+from django.http import HttpRequest, HttpResponse
+from typing_extensions import override
+
+from dmr import Body, Controller
+from dmr.parsers import DeserializeFunc, Parser, Raw
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.renderers import JsonRenderer, Renderer
+from dmr.test import DMRRequestFactory
+
+
+class _EchoParser(Parser):
+    __slots__ = ()
+
+    content_type = 'application/*'
+
+    @override
+    def parse(
+        self,
+        to_deserialize: Raw,
+        deserializer_hook: DeserializeFunc | None = None,
+        *,
+        request: HttpRequest,
+        model: Any,
+    ) -> Any:
+        return {'echo': True}
+
+
+@final
+class _WildcardParserController(Controller[PydanticSerializer]):
+    parsers = [_EchoParser()]
+
+    def post(self, parsed_body: Body[dict[str, bool]]) -> dict[str, bool]:
+        return parsed_body
+
+
+def test_wildcard_parser_cache_is_stable(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Repeated non-exact content types must keep resolving correctly."""
+    for _ in range(3):
+        request = dmr_rf.post(
+            '/whatever/',
+            headers={'Content-Type': 'application/vnd.custom+json'},
+            data={},
+        )
+
+        response = _WildcardParserController.as_view()(request)
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == HTTPStatus.CREATED
+        assert json.loads(response.content) == {'echo': True}
+
+
+def test_bad_content_type_is_not_cached(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """An unsupported ``Content-Type`` must keep failing on every call."""
+    for _ in range(3):
+        request = dmr_rf.post(
+            '/whatever/',
+            headers={'Content-Type': 'text/plain'},
+            data={},
+        )
+
+        response = _WildcardParserController.as_view()(request)
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+class _FakeXmlRenderer(Renderer):
+    content_type = 'application/xml'
+
+    @override
+    def render(
+        self,
+        to_serialize: Any,
+        serializer_hook: Any,
+    ) -> bytes:
+        return b'<xml/>'
+
+    @property
+    @override
+    def validation_parser(self) -> Parser:
+        return _EchoParser()
+
+
+@final
+class _JsonOnlyController(Controller[PydanticSerializer]):
+    renderers = (JsonRenderer(),)
+
+    def get(self) -> str:
+        return 'json-only'
+
+
+@final
+class _JsonAndXmlController(Controller[PydanticSerializer]):
+    renderers = (JsonRenderer(), _FakeXmlRenderer())
+
+    def get(self) -> str:
+        return 'json-or-xml'
+
+
+def _negotiated_content_type(
+    dmr_rf: DMRRequestFactory,
+    controller: type[Controller[PydanticSerializer]],
+    accept: str,
+) -> str:
+    request = dmr_rf.get('/whatever/', headers={'Accept': accept})
+    response = controller.as_view()(request)
+    assert isinstance(response, HttpResponse)
+    return response.headers['Content-Type']
+
+
+def test_fake_xml_renderer_validation_parser() -> None:
+    """The XML test double must expose a working ``validation_parser``."""
+    assert isinstance(_FakeXmlRenderer().validation_parser, _EchoParser)
+
+
+def test_renderer_cache_not_shared(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """Two endpoints with different renderers must not contaminate caches."""
+    accept = 'application/xml,application/json;q=0.9'
+
+    assert (
+        _negotiated_content_type(dmr_rf, _JsonAndXmlController, accept)
+        == 'application/xml'
+    )
+    assert (
+        _negotiated_content_type(dmr_rf, _JsonOnlyController, accept)
+        == 'application/json'
+    )
+    # Calling both again must still return the same, endpoint-specific
+    # result instead of leaking a cached value from the other endpoint:
+    assert (
+        _negotiated_content_type(dmr_rf, _JsonAndXmlController, accept)
+        == 'application/xml'
+    )
+
+
+def test_not_acceptable_is_not_falsely_cached(
+    dmr_rf: DMRRequestFactory,
+) -> None:
+    """An unsupported ``Accept`` header must keep failing on every call."""
+    for _ in range(3):
+        request = dmr_rf.get(
+            '/whatever/',
+            headers={'Accept': 'application/xml'},
+        )
+
+        response = _JsonOnlyController.as_view()(request)
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
+
+
+def test_wildcard_parser_cache_stops_growing_past_max_size(
+    dmr_rf: DMRRequestFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the wildcard cache is full, new content types are not stored."""
+    monkeypatch.setattr(negotiation, 'MAX_CACHE_SIZE', 1)
+
+    first = dmr_rf.post(
+        '/whatever/',
+        headers={'Content-Type': 'application/vnd.first+json'},
+        data={},
+    )
+    response = _WildcardParserController.as_view()(first)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.CREATED
+
+    # Cache is now full (maxsize=1). A second, distinct content type must
+    # still resolve correctly even though it cannot be cached anymore:
+    second = dmr_rf.post(
+        '/whatever/',
+        headers={'Content-Type': 'application/vnd.second+json'},
+        data={},
+    )
+    response = _WildcardParserController.as_view()(second)
+    assert isinstance(response, HttpResponse)
+    assert response.status_code == HTTPStatus.CREATED
+    assert json.loads(response.content) == {'echo': True}
+
+
+def test_renderer_cache_stops_growing_past_max_size(
+    dmr_rf: DMRRequestFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the renderer cache is full, new ``Accept`` values still work."""
+    monkeypatch.setattr(negotiation, 'MAX_CACHE_SIZE', 1)
+
+    assert (
+        _negotiated_content_type(
+            dmr_rf,
+            _JsonAndXmlController,
+            'application/xml',
+        )
+        == 'application/xml'
+    )
+    # Cache is now full (maxsize=1). A second, distinct Accept value must
+    # still resolve correctly even though it cannot be cached anymore:
+    assert (
+        _negotiated_content_type(
+            dmr_rf,
+            _JsonAndXmlController,
+            'application/xml,application/json;q=0.9',
+        )
+        == 'application/xml'
+    )

--- a/tests/test_unit/test_negotiation/test_negotiation_caching.py
+++ b/tests/test_unit/test_negotiation/test_negotiation_caching.py
@@ -2,12 +2,11 @@ import json
 from http import HTTPStatus
 from typing import Any, final
 
-import dmr.negotiation as negotiation
 import pytest
 from django.http import HttpRequest, HttpResponse
 from typing_extensions import override
 
-from dmr import Body, Controller
+from dmr import Body, Controller, negotiation
 from dmr.parsers import DeserializeFunc, Parser, Raw
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.renderers import JsonRenderer, Renderer


### PR DESCRIPTION
## Summary
- Adds a bounded per-endpoint cache (respecting `DMR_MAX_CACHE_SIZE`) for `RequestNegotiator`'s wildcard `Content-Type` resolution and for `ResponseNegotiator`'s `Accept` header resolution.
- Most clients send the same `Content-Type`/`Accept` value on every request (e.g. `application/json`), so repeated requests now skip re-running the O(n) wildcard-matching / renderer-negotiation algorithm and hit an O(1) cache lookup instead.
- No public API changes, as requested in the issue.
- Cache is keyed per-endpoint instance (not globally), so two endpoints with different configured parsers/renderers never share or contaminate each other's cached results.
- Once the cache reaches `DMR_MAX_CACHE_SIZE`, new values are simply not cached (still resolved correctly via the full algorithm), preventing unbounded memory growth.

Fixes #1455

## Test plan
- Added `tests/test_unit/test_negotiation/test_negotiation_caching.py` covering: repeated stable resolution, unsupported values are never falsely cached, cross-endpoint cache isolation, and correct behavior once the cache is full (bounded growth).
- `just lint` and `just unit` pass locally (100% coverage maintained).
- `mypy .` passes with no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)