### PR TITLE
Raise `EndpointMetadataError` on `as_view` of abstract controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 ## 0.16.0 WIP
 
+### Breaking changes
+
+- `Controller.as_view` now raises `EndpointMetadataError`
+  when it is called on an abstract controller: one without
+  an exact serializer type or without any endpoints.
+  Previously such controllers could be added to `Router`
+  and to `urlpatterns` silently, but they could not serve
+  any requests, #1445
+
 ### Features
 
 - Added `tags` controller attribute to apply OpenAPI tags

--- a/dmr/controller.py
+++ b/dmr/controller.py
@@ -14,7 +14,7 @@ from dmr import throttling as dmr_throttling
 from dmr.cookies import NewCookie
 from dmr.endpoint import Endpoint
 from dmr.errors import ErrorModel, ErrorType, format_error
-from dmr.exceptions import UnsolvableAnnotationsError
+from dmr.exceptions import EndpointMetadataError, UnsolvableAnnotationsError
 from dmr.internal.io import identity
 from dmr.metadata import ResponseSpec
 from dmr.negotiation import request_renderer
@@ -118,6 +118,8 @@ class Controller(View, Generic[_SerializerT_co]):  # noqa: WPS214
         is_abstract: Whether or not this controller is abstract.
             We consider controller "abstract" when it does not have
             exact serializer type or exact ``api_endpoints`` instances.
+            Abstract controllers cannot be routed, ``as_view`` raises
+            :class:`~dmr.exceptions.EndpointMetadataError` for them.
         is_async: Whether or not this controller is async.
         streaming: Does this controller work with streaming responses like SSE?
         controller_validator_cls: Runs full controller validation on definition.
@@ -219,7 +221,26 @@ class Controller(View, Generic[_SerializerT_co]):  # noqa: WPS214
         This override applies CSRF exemption to the view. Session-based
         authentication will still be explicitly validated for CSRF,
         while all other authentication methods will be CSRF-exempt.
+
+        Raises:
+            EndpointMetadataError: When called on an abstract controller,
+                because it has nothing to serve.
+
+        .. versionchanged:: 0.16.0
+
+            Abstract controllers now raise
+            :class:`~dmr.exceptions.EndpointMetadataError`
+            instead of silently returning a broken view.
+
         """
+        if cls.is_abstract:
+            raise EndpointMetadataError(
+                f'{cls!r} is abstract, it cannot be used as a view. '
+                'Controllers are abstract when they do not have '
+                'an exact serializer type or any endpoints. '
+                'Use a subclass with a real serializer '
+                'and at least one endpoint',
+            )
         return (
             csrf_exempt(super().as_view(**initkwargs))
             if cls.csrf_exempt

--- a/docs/pages/reusable-code.rst
+++ b/docs/pages/reusable-code.rst
@@ -58,6 +58,16 @@ Let's try to create two exact controllers with exact serializers:
 Basically - we just specify what kind of serializer to use. And that's it.
 But, this is just the first step. We can do much more!
 
+.. note::
+
+  Only controllers with an exact serializer and at least one endpoint
+  can be routed. Reusable ones have ``is_abstract`` set to ``True``
+  and raise :exc:`~dmr.exceptions.EndpointMetadataError`
+  when you call ``.as_view()`` on them.
+  Route their subclasses instead.
+
+  .. versionadded:: 0.16.0
+
 .. tip::
 
   Annotate class-level options like ``responses``, ``auth``, ``parsers``,

--- a/tests/test_unit/test_controllers/test_abstract_as_view.py
+++ b/tests/test_unit/test_controllers/test_abstract_as_view.py
@@ -5,7 +5,6 @@ import pytest
 from dmr import Controller
 from dmr.exceptions import EndpointMetadataError
 from dmr.plugins.pydantic import PydanticSerializer
-from dmr.routing import Router, path
 from dmr.serializer import BaseSerializer
 
 _SerializerT = TypeVar('_SerializerT', bound=BaseSerializer)
@@ -51,13 +50,3 @@ def test_concrete_controller_as_view() -> None:
 
     assert not _Custom.is_abstract
     assert callable(_Custom.as_view())
-
-
-def test_abstract_controller_in_router() -> None:
-    """Ensure that abstract controllers cannot be added to a `Router`."""
-
-    class _Custom(Controller[PydanticSerializer]):
-        """Empty."""
-
-    with pytest.raises(EndpointMetadataError, match='_Custom'):
-        Router(urls=[path('custom/', _Custom.as_view())])

--- a/tests/test_unit/test_controllers/test_abstract_as_view.py
+++ b/tests/test_unit/test_controllers/test_abstract_as_view.py
@@ -1,0 +1,63 @@
+from typing import TypeVar
+
+import pytest
+
+from dmr import Controller
+from dmr.exceptions import EndpointMetadataError
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.routing import Router, path
+from dmr.serializer import BaseSerializer
+
+_SerializerT = TypeVar('_SerializerT', bound=BaseSerializer)
+
+
+def test_base_controller_as_view() -> None:
+    """Ensure that `Controller` itself cannot be used as a view."""
+    with pytest.raises(EndpointMetadataError, match='is abstract'):
+        Controller.as_view()
+
+
+def test_generic_controller_as_view() -> None:
+    """Ensure that controllers without an exact serializer are not views."""
+
+    class _Custom(Controller[_SerializerT]):
+        """Has a type var instead of a real serializer."""
+
+        def get(self) -> str:
+            raise NotImplementedError
+
+    assert _Custom.is_abstract
+    with pytest.raises(EndpointMetadataError, match='_Custom'):
+        _Custom.as_view()
+
+
+def test_controller_without_endpoints_as_view() -> None:
+    """Ensure that controllers without any endpoints are not views."""
+
+    class _Custom(Controller[PydanticSerializer]):
+        """Has a real serializer, but nothing to serve."""
+
+    assert _Custom.is_abstract
+    with pytest.raises(EndpointMetadataError, match='_Custom'):
+        _Custom.as_view()
+
+
+def test_concrete_controller_as_view() -> None:
+    """Ensure that regular controllers are still valid views."""
+
+    class _Custom(Controller[PydanticSerializer]):
+        def get(self) -> str:
+            raise NotImplementedError
+
+    assert not _Custom.is_abstract
+    assert callable(_Custom.as_view())
+
+
+def test_abstract_controller_in_router() -> None:
+    """Ensure that abstract controllers cannot be added to a `Router`."""
+
+    class _Custom(Controller[PydanticSerializer]):
+        """Empty."""
+
+    with pytest.raises(EndpointMetadataError, match='_Custom'):
+        Router(urls=[path('custom/', _Custom.as_view())])

--- a/tests/test_unit/test_openapi/test_collector.py
+++ b/tests/test_unit/test_openapi/test_collector.py
@@ -59,15 +59,6 @@ class _PostController(Controller[PydanticSerializer]):
         raise NotImplementedError
 
 
-@final
-class _EmptyController(Controller[PydanticSerializer]):
-    """Test controller with no API endpoints."""
-
-    def incorrect_method(self) -> str:
-        """Non-API method that should be ignored."""
-        raise NotImplementedError
-
-
 @pytest.mark.parametrize(
     ('input_path', 'expected_output'),
     [
@@ -159,7 +150,7 @@ def test_join_paths(
     [
         ('full/', _FullController),
         ('sla/shed/', _GetController),
-        ('', _EmptyController),
+        ('', _PostController),
     ],
 )
 def test_process_pattern_with_different_views(


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->
`Controller.as_view` now raises `EndpointMetadataError` when the controller is abstract, before it builds the view. The check is the first thing in `as_view`, where the issue asked for it. `Router` needed no changes, because everything reaches it through `as_view()` already.

Both kinds of abstract controller are covered, and they used to fail in different ways. One with a real serializer and no endpoints answered every request with a `405` and an empty `Allow` header, since `api_endpoints` is `{}` and `dispatch` falls through to `handle_method_not_allowed`. A generic one never gets `api_endpoints` at all, so `dispatch` raised `AttributeError: 'GenericController' object has no attribute 'api_endpoints'` and the request came back as a `500`. Neither of them said anything when the url patterns were built.

One thing in the diff that is not the change itself: `tests/test_unit/test_openapi/test_collector.py` routed an `_EmptyController` through `_process_pattern` to cover the empty path string. That controller cannot be routed anymore, so I dropped it and gave the empty-path case to `_PostController`. `_process_pattern` does not look at endpoints, so it loses no coverage. The new tests are in `tests/test_unit/test_controllers/test_abstract_as_view.py`.

I put the changelog entry under "Breaking changes" and not under features, because code that registers an abstract controller today stops importing after this. It is one line to move if you read it as a fix instead.

The docs get a note in the "Reusable controllers" section of `docs/pages/reusable-code.rst`. That is where reusable controllers are introduced, so it is where someone is most likely to try routing one.

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
Closes #1445
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
