### PR TITLE
Fixed schemathesis tests

### DIFF
--- a/django_test_app/server/apps/controllers/views.py
+++ b/django_test_app/server/apps/controllers/views.py
@@ -41,7 +41,7 @@ class _CustomHeaders(pydantic.BaseModel):
 
 class _SimpleUserInput(pydantic.BaseModel):
     email: str
-    age: int = pydantic.Field(gt=0, strict=True)
+    age: int = pydantic.Field(gt=0)
 
 
 @final
@@ -166,8 +166,8 @@ class _ConstrainedUserSchema(pydantic.BaseModel):
         max_length=20,  # noqa: WPS432
         pattern=r'^[a-z0-9_]+$',
     )
-    age: int = pydantic.Field(ge=18, le=100, strict=True)  # noqa: WPS432
-    score: int = pydantic.Field(gt=0, le=10, strict=True)  # noqa: WPS432
+    age: int = pydantic.Field(ge=18, le=100)  # noqa: WPS432
+    score: int = pydantic.Field(gt=0, le=10)  # noqa: WPS432
     phone: PhoneNumber
 
 


### PR DESCRIPTION
# I have made things!

After updating schemathesis some tests started to fail. 

https://github.com/schemathesis/schemathesis/releases/tag/v4.27.0

It happened, because according to OpenAPI3.1 `1` and `1.0` should be equviualent values. 

> Since there is no distinct JSON integer type, JSON Schema defines integers mathematically. This means that both 1 and 1.0 are [equivalent](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.2), and are both considered to be integers. 

source: https://swagger.io/specification/v3.1/

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## AI Policy

- [x] I have read and agree to the [AI Policy](https://github.com/wemake-services/django-modern-rest/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
