### PR TITLE
Remove OpenAPI 3.0.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ are stored as descriptions in version releases on GitHub, example:
 https://github.com/wemake-services/django-modern-rest/releases/tag/0.13.0
 
 
+## 0.16.0 WIP
+
+### Breaking changes
+
+- `OpenAPIConfig` now rejects `openapi_version` values before `3.1.0`.
+  We only ever supported a subset of `3.0.x`, since `3.1` was the first
+  version to adopt JSON Schema for models, #1435
+
+
 ## 0.15.0 (2026-09-11)
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - [x] Fully typed and checked with `mypy`, `pyright`, `ty`, and `pyrefly` in strict modes
 - [x] Supports content negotiation, has default implementations for `json`, `msgpack`, SSE, Json Lines, and more
 - [x] Strict schema validation of both requests and responses, including errors
-- [x] Supports OpenAPI 3.0 / 3.1 / 3.2 semantic schema generation out of the box
+- [x] Supports OpenAPI 3.1 / 3.2 semantic schema generation out of the box
 - [x] Supports all your existing `django` primitives and packages, no custom runtimes
 - [x] Great testing tools with [schemathesis](https://github.com/schemathesis/schemathesis), [polyfactory](https://github.com/litestar-org/polyfactory), [tracecov](https://django-modern-rest.readthedocs.io/en/latest/pages/testing/tracecov.html), bundled `pytest` plugin, and default Django's testing primitives
 - [x] 100% test coverage with 3000+ of carefully designed unit, integration, typing, and property-based tests

--- a/dmr/openapi/config.py
+++ b/dmr/openapi/config.py
@@ -30,7 +30,7 @@ class OpenAPIConfig:
         version: Version of your API
             (your application's own version, not the OpenAPI spec version).
         openapi_version: Version of the OpenAPI specification to target.
-            Defaults to ``'3.1.0'``.
+            Must be ``'3.1.0'`` or newer. Defaults to ``'3.1.0'``.
         summary: Short, one-line summary of the API.
         description: Longer description of the API. May use CommonMark syntax.
         terms_of_service: URL to the terms of service for the API.
@@ -63,6 +63,14 @@ class OpenAPIConfig:
     servers: list[Server] | None = None
     tags: list[Tag] | None = None
     webhooks: dict[str, PathItem | Reference] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the config."""
+        if self.openapi_version_info[:2] < (3, 1):
+            raise ValueError(
+                'OpenAPI versions before `3.1.0` are not supported, '
+                f'got {self.openapi_version!r}',
+            )
 
     @property
     def openapi_version_info(self) -> tuple[int, int, int]:

--- a/docs/examples/external_views/openapi.yml
+++ b/docs/examples/external_views/openapi.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: Number API
   version: 1.0.0

--- a/docs/pages/openapi/openapi.rst
+++ b/docs/pages/openapi/openapi.rst
@@ -1,7 +1,7 @@
 OpenAPI
 =======
 
-We support OpenAPI versions from ``3.0.0`` through ``3.2.0``.
+We support OpenAPI versions from ``3.1.0`` through ``3.2.0``.
 
 .. note::
 

--- a/tests/test_unit/test_openapi/test_spec.py
+++ b/tests/test_unit/test_openapi/test_spec.py
@@ -70,6 +70,22 @@ def test_schema_collections_can_be_mutated(
     assert schema.tags == [tag]
 
 
+def test_config_rejects_old_openapi_version() -> None:
+    """Ensure OpenAPI ``3.0.x`` is no longer accepted."""
+    with pytest.raises(ValueError, match=r'3\.1\.0'):
+        OpenAPIConfig(
+            title='my title',
+            version='1.0.0',
+            openapi_version='3.0.3',
+        )
+
+
+def test_config_accepts_supported_versions() -> None:
+    """Ensure OpenAPI ``3.1.x`` and ``3.2.x`` are still accepted."""
+    OpenAPIConfig(title='my title', version='1.0.0', openapi_version='3.1.0')
+    OpenAPIConfig(title='my title', version='1.0.0', openapi_version='3.2.0')
+
+
 def test_pass_both_context_and_config() -> None:
     """Ensures that you can't pass both ``config`` and ``context``."""
     router = Router()


### PR DESCRIPTION
We claimed support for OpenAPI 3.0.x, but only ever supported a subset of it, since 3.1 was the first version to adopt JSON Schema for models.

`OpenAPIConfig.__post_init__` now raises `ValueError` when `openapi_version` is below `3.1.0`. Updated the README, `docs/pages/openapi/openapi.rst`, and the `openapi.yml` external-views example to stop claiming 3.0.x support, and added a CHANGELOG entry.

Tested with two new unit tests in `tests/test_unit/test_openapi/test_spec.py`: one confirming `openapi_version='3.0.3'` raises, one confirming `3.1.0`/`3.2.0` are still accepted. Ran `just lint`, `just type-check`, and the full unit suite locally, all green.

Fixes #1435